### PR TITLE
Add audit logging infrastructure and admin view

### DIFF
--- a/database/models/auditLog.js
+++ b/database/models/auditLog.js
@@ -1,0 +1,75 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const AuditLog = sequelize.define('AuditLog', {
+        userId: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'Users',
+                key: 'id'
+            },
+            onUpdate: 'CASCADE',
+            onDelete: 'SET NULL'
+        },
+        action: {
+            type: DataTypes.STRING(120),
+            allowNull: false,
+            validate: {
+                notEmpty: {
+                    msg: 'Ação de auditoria é obrigatória.'
+                }
+            }
+        },
+        resource: {
+            type: DataTypes.STRING(200),
+            allowNull: false,
+            validate: {
+                notEmpty: {
+                    msg: 'Recurso monitorado é obrigatório.'
+                }
+            }
+        },
+        ip: {
+            type: DataTypes.STRING(45),
+            allowNull: true,
+            validate: {
+                len: {
+                    args: [0, 45],
+                    msg: 'Endereço IP inválido.'
+                }
+            }
+        },
+        createdAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW
+        }
+    }, {
+        tableName: 'AuditLogs',
+        timestamps: false,
+        indexes: [
+            {
+                name: 'audit_logs_created_at_idx',
+                fields: ['createdAt']
+            },
+            {
+                name: 'audit_logs_action_idx',
+                fields: ['action']
+            },
+            {
+                name: 'audit_logs_user_idx',
+                fields: ['userId']
+            }
+        ]
+    });
+
+    AuditLog.associate = (models) => {
+        AuditLog.belongsTo(models.User, {
+            as: 'user',
+            foreignKey: 'userId'
+        });
+    };
+
+    return AuditLog;
+};

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const roomRoutes = require('./src/routes/roomRoutes');
 const appointmentRoutes = require('./src/routes/appointmentRoutes');
 const financeRoutes = require('./src/routes/financeRoutes');
 const notificationRoutes = require('./src/routes/notificationRoutes');
+const auditRoutes = require('./src/routes/auditRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -99,6 +100,7 @@ app.use('/rooms', roomRoutes);
 app.use('/appointments', appointmentRoutes);
 app.use('/finance', financeRoutes);
 app.use('/notifications', notificationRoutes);
+app.use('/audit', auditRoutes);
 
 // Conexão DB
 sequelize

--- a/src/controllers/auditController.js
+++ b/src/controllers/auditController.js
@@ -1,0 +1,161 @@
+const { Op } = require('sequelize');
+const { AuditLog, User, Sequelize } = require('../../database/models');
+
+const parseDate = (value, endOfDay = false) => {
+    if (!value) {
+        return null;
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    if (endOfDay) {
+        date.setHours(23, 59, 59, 999);
+    } else {
+        date.setHours(0, 0, 0, 0);
+    }
+    return date;
+};
+
+const buildQueryBuilder = (filters, pageSize) => {
+    const baseParams = new URLSearchParams();
+
+    if (filters.startDate) baseParams.set('startDate', filters.startDate);
+    if (filters.endDate) baseParams.set('endDate', filters.endDate);
+    if (filters.userId) baseParams.set('userId', filters.userId);
+    if (filters.action) baseParams.set('action', filters.action);
+    if (pageSize) baseParams.set('pageSize', String(pageSize));
+
+    return (page) => {
+        const params = new URLSearchParams(baseParams.toString());
+        params.set('page', String(page));
+        return params.toString();
+    };
+};
+
+module.exports = {
+    listLogs: async (req, res) => {
+        try {
+            const pageFromQuery = Number.parseInt(req.query.page, 10);
+            const pageSizeFromQuery = Number.parseInt(req.query.pageSize, 10);
+
+            const filters = {
+                startDate: typeof req.query.startDate === 'string' ? req.query.startDate.trim() : '',
+                endDate: typeof req.query.endDate === 'string' ? req.query.endDate.trim() : '',
+                userId: typeof req.query.userId === 'string' ? req.query.userId.trim() : '',
+                action: typeof req.query.action === 'string' ? req.query.action.trim() : ''
+            };
+
+            const pageSize = Number.isInteger(pageSizeFromQuery)
+                ? Math.min(Math.max(pageSizeFromQuery, 5), 100)
+                : 20;
+            const requestedPage = Number.isInteger(pageFromQuery) && pageFromQuery > 0 ? pageFromQuery : 1;
+
+            const where = {};
+
+            if (filters.userId) {
+                const parsedUserId = Number.parseInt(filters.userId, 10);
+                if (Number.isInteger(parsedUserId)) {
+                    where.userId = parsedUserId;
+                } else {
+                    filters.userId = '';
+                }
+            }
+
+            if (filters.action) {
+                where.action = { [Op.like]: `%${filters.action}%` };
+            }
+
+            const startDate = parseDate(filters.startDate);
+            const endDate = parseDate(filters.endDate, true);
+
+            if (startDate || endDate) {
+                where.createdAt = {};
+                if (startDate) {
+                    where.createdAt[Op.gte] = startDate;
+                }
+                if (endDate) {
+                    where.createdAt[Op.lte] = endDate;
+                }
+            }
+
+            const include = [
+                {
+                    model: User,
+                    as: 'user',
+                    attributes: ['id', 'name', 'email']
+                }
+            ];
+
+            const offset = (requestedPage - 1) * pageSize;
+
+            const { count, rows } = await AuditLog.findAndCountAll({
+                where,
+                include,
+                order: [['createdAt', 'DESC']],
+                limit: pageSize,
+                offset
+            });
+
+            const totalItems = count;
+            const totalPages = totalItems === 0 ? 1 : Math.ceil(totalItems / pageSize);
+            const currentPage = Math.min(requestedPage, totalPages);
+
+            let logs = rows;
+
+            if (requestedPage !== currentPage) {
+                const adjustedOffset = (currentPage - 1) * pageSize;
+                logs = await AuditLog.findAll({
+                    where,
+                    include,
+                    order: [['createdAt', 'DESC']],
+                    limit: pageSize,
+                    offset: adjustedOffset
+                });
+            }
+
+            const windowSize = 2;
+            const startPage = Math.max(1, currentPage - windowSize);
+            const endPage = Math.min(totalPages, currentPage + windowSize);
+            const pages = [];
+            for (let page = startPage; page <= endPage; page += 1) {
+                pages.push(page);
+            }
+
+            const users = await User.findAll({
+                attributes: ['id', 'name', 'email'],
+                order: [['name', 'ASC']]
+            });
+
+            const actionRecords = await AuditLog.findAll({
+                attributes: [[Sequelize.fn('DISTINCT', Sequelize.col('action')), 'action']],
+                order: [[Sequelize.col('action'), 'ASC']]
+            });
+            const actions = actionRecords
+                .map(record => record.get('action'))
+                .filter(Boolean);
+
+            const buildQuery = buildQueryBuilder(filters, pageSize);
+
+            return res.render('audit/logs', {
+                pageTitle: 'Logs de auditoria',
+                logs,
+                users,
+                actions,
+                filters,
+                pagination: {
+                    currentPage,
+                    totalPages,
+                    totalItems,
+                    pageSize,
+                    pages,
+                    buildQuery
+                }
+            });
+        } catch (error) {
+            console.error('Erro ao carregar logs de auditoria:', error);
+            req.flash('error_msg', 'Não foi possível carregar os logs de auditoria.');
+            return res.redirect('/');
+        }
+    }
+};

--- a/src/middlewares/audit.js
+++ b/src/middlewares/audit.js
@@ -1,0 +1,69 @@
+const { AuditLog } = require('../../database/models');
+
+const resolveClientIp = (req) => {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (forwarded) {
+        const [firstIp] = String(forwarded).split(',');
+        if (firstIp) {
+            return firstIp.trim();
+        }
+    }
+    return (
+        req.ip ||
+        req.socket?.remoteAddress ||
+        req.connection?.remoteAddress ||
+        ''
+    ).toString();
+};
+
+module.exports = (action, resource) => {
+    if (!action) {
+        throw new Error('Audit middleware requires an action identifier.');
+    }
+
+    return (req, res, next) => {
+        const originalFlash = typeof req.flash === 'function' ? req.flash.bind(req) : null;
+        let shouldLog = false;
+
+        if (originalFlash) {
+            req.flash = (...args) => {
+                if (args.length > 1 && args[0] === 'success_msg' && args[1]) {
+                    shouldLog = true;
+                }
+                return originalFlash(...args);
+            };
+        }
+
+        res.on('finish', async () => {
+            if (!shouldLog) {
+                return;
+            }
+
+            if (res.statusCode >= 400) {
+                return;
+            }
+
+            const resolvedResource = typeof resource === 'function'
+                ? resource(req, res)
+                : resource;
+
+            try {
+                if (!AuditLog) {
+                    console.warn('AuditLog model is not available. Skipping audit log.');
+                    return;
+                }
+
+                await AuditLog.create({
+                    userId: req.session?.user?.id ?? null,
+                    action,
+                    resource: resolvedResource || req.originalUrl,
+                    ip: resolveClientIp(req)
+                });
+            } catch (error) {
+                console.error('Erro ao registrar log de auditoria:', error);
+            }
+        });
+
+        return next();
+    };
+};

--- a/src/routes/auditRoutes.js
+++ b/src/routes/auditRoutes.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+
+const auditController = require('../controllers/auditController');
+const authMiddleware = require('../middlewares/authMiddleware');
+const permissionMiddleware = require('../middlewares/permissionMiddleware');
+
+router.get(
+    '/logs',
+    authMiddleware,
+    permissionMiddleware(4),
+    auditController.listLogs
+);
+
+module.exports = router;

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -3,11 +3,30 @@ const router = express.Router();
 const financeController = require('../controllers/financeController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
+const audit = require('../middlewares/audit');
 
 // Geralmente admin ou financeiro teria role >= 3 ou 4
 router.get('/', authMiddleware, permissionMiddleware(4), financeController.listFinanceEntries);
-router.post('/create', authMiddleware, permissionMiddleware(4), financeController.createFinanceEntry);
-router.put('/update/:id', authMiddleware, permissionMiddleware(4), financeController.updateFinanceEntry);
-router.delete('/delete/:id', authMiddleware, permissionMiddleware(4), financeController.deleteFinanceEntry);
+router.post(
+    '/create',
+    authMiddleware,
+    permissionMiddleware(4),
+    audit('financeEntry.create', (req) => `FinanceEntry:${req.body?.description || 'novo'}`),
+    financeController.createFinanceEntry
+);
+router.put(
+    '/update/:id',
+    authMiddleware,
+    permissionMiddleware(4),
+    audit('financeEntry.update', (req) => `FinanceEntry:${req.params.id}`),
+    financeController.updateFinanceEntry
+);
+router.delete(
+    '/delete/:id',
+    authMiddleware,
+    permissionMiddleware(4),
+    audit('financeEntry.delete', (req) => `FinanceEntry:${req.params.id}`),
+    financeController.deleteFinanceEntry
+);
 
 module.exports = router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -6,6 +6,7 @@ const userController = require('../controllers/userController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const upload = require('../middlewares/uploadMiddleware');
+const audit = require('../middlewares/audit');
 
 // Todas as rotas de gerenciamento de usuários requerem login e permissão >= 4
 router.get('/manage', authMiddleware, permissionMiddleware(4), userController.manageUsers);
@@ -16,6 +17,7 @@ router.post(
     authMiddleware,
     permissionMiddleware(4),
     upload.single('profileImage'),
+    audit('user.create', (req) => `User:${req.body?.email || 'novo'}`),
     userController.createUser
 );
 
@@ -24,6 +26,7 @@ router.put(
     authMiddleware,
     permissionMiddleware(4),
     upload.single('profileImage'),
+    audit('user.update', (req) => `User:${req.params.id}`),
     userController.updateUser
 );
 
@@ -31,6 +34,7 @@ router.delete(
     '/delete/:id',
     authMiddleware,
     permissionMiddleware(4),
+    audit('user.delete', (req) => `User:${req.params.id}`),
     userController.deleteUser
 );
 

--- a/src/views/audit/logs.ejs
+++ b/src/views/audit/logs.ejs
@@ -1,0 +1,191 @@
+<%- include('../partials/header') %>
+
+<div class="row justify-content-center g-4">
+    <div class="col-12">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+            <div>
+                <h1 class="h3 fw-semibold mb-0 text-primary">Monitoramento de auditoria</h1>
+                <p class="text-muted mb-0">Acompanhe ações críticas realizadas por usuários privilegiados.</p>
+            </div>
+            <div class="text-md-end">
+                <span class="badge rounded-pill text-bg-dark px-3 py-2 shadow-sm">
+                    <i class="bi bi-shield-check me-2"></i>
+                    <span>Total de registros: <%= pagination.totalItems %></span>
+                </span>
+            </div>
+        </div>
+
+        <% if (error_msg && error_msg.length) { %>
+            <div class="alert alert-danger shadow-sm"><%= error_msg %></div>
+        <% } %>
+        <% if (success_msg && success_msg.length) { %>
+            <div class="alert alert-success shadow-sm"><%= success_msg %></div>
+        <% } %>
+    </div>
+
+    <div class="col-12">
+        <form method="GET" class="card border-0 shadow-sm">
+            <div class="card-header bg-white border-0 pb-0">
+                <h2 class="h5 fw-semibold mb-0"><i class="bi bi-filter-circle me-2 text-primary"></i>Filtros inteligentes</h2>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    <div class="col-md-3">
+                        <label class="form-label text-muted">Data inicial</label>
+                        <input
+                            type="date"
+                            name="startDate"
+                            value="<%= filters.startDate %>"
+                            class="form-control"
+                            max="<%= filters.endDate || '' %>"
+                        />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label text-muted">Data final</label>
+                        <input
+                            type="date"
+                            name="endDate"
+                            value="<%= filters.endDate %>"
+                            class="form-control"
+                            min="<%= filters.startDate || '' %>"
+                        />
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label text-muted">Usuário responsável</label>
+                        <select class="form-select" name="userId">
+                            <option value="">Todos</option>
+                            <% users.forEach((userItem) => { %>
+                                <option
+                                    value="<%= userItem.id %>"
+                                    <%= filters.userId == userItem.id ? 'selected' : '' %>
+                                >
+                                    <%= userItem.name %>
+                                </option>
+                            <% }) %>
+                        </select>
+                    </div>
+                    <div class="col-md-2">
+                        <label class="form-label text-muted">Ação</label>
+                        <select class="form-select" name="action">
+                            <option value="">Todas</option>
+                            <% actions.forEach((actionItem) => { %>
+                                <option
+                                    value="<%= actionItem %>"
+                                    <%= filters.action === actionItem ? 'selected' : '' %>
+                                >
+                                    <%= actionItem %>
+                                </option>
+                            <% }) %>
+                        </select>
+                    </div>
+                    <div class="col-md-1">
+                        <label class="form-label text-muted">Por página</label>
+                        <select class="form-select" name="pageSize">
+                            <% [10, 20, 50, 100].forEach((size) => { %>
+                                <option value="<%= size %>" <%= pagination.pageSize === size ? 'selected' : '' %>>
+                                    <%= size %>
+                                </option>
+                            <% }) %>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="card-footer bg-white border-0 d-flex justify-content-between flex-column flex-md-row gap-2">
+                <div class="text-muted small d-flex align-items-center gap-2">
+                    <i class="bi bi-info-circle"></i>
+                    Ajuste os filtros para identificar padrões e auditorias específicas.
+                </div>
+                <div class="d-flex gap-2">
+                    <a href="/audit/logs" class="btn btn-light border">Limpar</a>
+                    <button type="submit" class="btn btn-primary shadow-sm">
+                        <i class="bi bi-search me-1"></i>Aplicar filtros
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="col-12">
+        <div class="card border-0 shadow-sm">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover table-nowrap mb-0 align-middle">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Data e hora</th>
+                                <th>Usuário</th>
+                                <th>Ação</th>
+                                <th>Recurso</th>
+                                <th>Origem (IP)</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <% if (!logs.length) { %>
+                                <tr>
+                                    <td colspan="5" class="text-center py-4 text-muted">
+                                        <i class="bi bi-inboxes me-2"></i>Nenhum log encontrado para os filtros selecionados.
+                                    </td>
+                                </tr>
+                            <% } else { %>
+                                <% logs.forEach((log) => { %>
+                                    <tr>
+                                        <td class="text-nowrap">
+                                            <i class="bi bi-clock-history text-primary me-1"></i>
+                                            <%= new Date(log.createdAt).toLocaleString('pt-BR') %>
+                                        </td>
+                                        <td>
+                                            <% if (log.user) { %>
+                                                <div class="fw-semibold"><%= log.user.name %></div>
+                                                <div class="text-muted small"><%= log.user.email %></div>
+                                            <% } else { %>
+                                                <span class="badge text-bg-secondary">Sistema</span>
+                                            <% } %>
+                                        </td>
+                                        <td>
+                                            <span class="badge text-bg-info text-uppercase fw-semibold">
+                                                <i class="bi bi-activity me-1"></i><%= log.action %>
+                                            </span>
+                                        </td>
+                                        <td class="text-break">
+                                            <code class="small"><%= log.resource %></code>
+                                        </td>
+                                        <td class="text-nowrap"><%= log.ip || '—' %></td>
+                                    </tr>
+                                <% }) %>
+                            <% } %>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="card-footer bg-white border-0 d-flex flex-column flex-md-row align-items-center justify-content-between gap-3">
+                <div class="small text-muted">
+                    Exibindo <strong><%= logs.length %></strong> de <strong><%= pagination.totalItems %></strong> registros
+                    monitorados.
+                </div>
+                <nav aria-label="Paginação de auditoria">
+                    <ul class="pagination mb-0">
+                        <li class="page-item <%= pagination.currentPage === 1 ? 'disabled' : '' %>">
+                            <a class="page-link" href="?<%= pagination.buildQuery(pagination.currentPage - 1) %>">
+                                <i class="bi bi-chevron-left"></i>
+                            </a>
+                        </li>
+                        <% pagination.pages.forEach((pageNumber) => { %>
+                            <li class="page-item <%= pageNumber === pagination.currentPage ? 'active' : '' %>">
+                                <a class="page-link" href="?<%= pagination.buildQuery(pageNumber) %>">
+                                    <%= pageNumber %>
+                                </a>
+                            </li>
+                        <% }) %>
+                        <li class="page-item <%= pagination.currentPage >= pagination.totalPages ? 'disabled' : '' %>">
+                            <a class="page-link" href="?<%= pagination.buildQuery(pagination.currentPage + 1) %>">
+                                <i class="bi bi-chevron-right"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </div>
+</div>
+
+<%- include('../partials/footer') %>


### PR DESCRIPTION
## Summary
- add an AuditLog Sequelize model and expose a secured /audit route namespace
- introduce an audit middleware that records successful privileged actions and wraps user/finance routes
- provide an administrative audit log screen with filtering and pagination controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9848a04d0832fa369571ba2825e26