### PR TITLE
Add notification HTML migration and schema checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+/tmp/
+*.sqlite
+.env
+.DS_Store
+npm-debug.log*

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,0 +1,8 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('config', 'config.js'),
+  'models-path': path.resolve('database', 'models'),
+  'migrations-path': path.resolve('database', 'migrations'),
+  'seeders-path': path.resolve('database', 'seeders'),
+};

--- a/database/migrations/20240907-add-message-html-to-notifications.js
+++ b/database/migrations/20240907-add-message-html-to-notifications.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Notifications', 'messageHtml', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Notifications', 'messageHtml');
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node scripts/health-check.js"
+    "test": "node scripts/health-check.js && node tests/schema.test.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = process.env.DB_DIALECT || 'sqlite';
+process.env.DB_STORAGE = process.env.DB_STORAGE || ':memory:';
+
+const Sequelize = require('sequelize');
+const { sequelize } = require('../database/models');
+
+const { DataTypes } = Sequelize;
+const queryInterface = sequelize.getQueryInterface();
+
+const migrations = [
+  require('../database/migrations/20240906-add-credit-balance-to-users'),
+  require('../database/migrations/20240907-add-message-html-to-notifications'),
+];
+
+(async () => {
+  try {
+    await queryInterface.createTable('Users', {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    });
+
+    await queryInterface.createTable('Notifications', {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+      message: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    });
+
+    for (const migration of migrations) {
+      if (typeof migration.up === 'function') {
+        await migration.up(queryInterface, Sequelize);
+      }
+    }
+
+    const usersTable = await queryInterface.describeTable('Users');
+    const notificationsTable = await queryInterface.describeTable('Notifications');
+
+    if (!usersTable.creditBalance) {
+      throw new Error('Coluna "creditBalance" não encontrada na tabela Users.');
+    }
+
+    if (usersTable.creditBalance.allowNull) {
+      throw new Error('Coluna "creditBalance" deveria ser NOT NULL.');
+    }
+
+    if (!notificationsTable.messageHtml) {
+      throw new Error('Coluna "messageHtml" não encontrada na tabela Notifications.');
+    }
+
+    console.log('Verificação das colunas creditBalance e messageHtml concluída com sucesso.');
+  } catch (error) {
+    console.error('Teste de schema falhou:', error);
+    process.exitCode = 1;
+  } finally {
+    await queryInterface.dropTable('Users').catch(() => {});
+    await queryInterface.dropTable('Notifications').catch(() => {});
+    await sequelize.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- add migration that introduces the optional `messageHtml` field to notifications and wire up sequelize-cli paths
- add a schema regression test to assert the presence of `creditBalance` on users and `messageHtml` on notifications
- ignore transient artifacts such as `node_modules` to keep the repository clean

## Testing
- npm test
- NODE_ENV=test DB_DIALECT=sqlite DB_STORAGE=/tmp/sistema_gestao.sqlite npx sequelize-cli db:migrate --env test
- NODE_ENV=test DB_DIALECT=sqlite DB_STORAGE=/tmp/sistema_gestao.sqlite npx sequelize-cli db:migrate:status --env test
- NODE_ENV=development DB_DIALECT=postgres DB_HOST=127.0.0.1 DB_PORT=5432 DB_USER=postgres DB_PASS=postgres DB_NAME=sistema_gestao npx sequelize-cli db:migrate --env development
- NODE_ENV=development DB_DIALECT=postgres DB_HOST=127.0.0.1 DB_PORT=5432 DB_USER=postgres DB_PASS=postgres DB_NAME=sistema_gestao npx sequelize-cli db:migrate:status --env development

------
https://chatgpt.com/codex/tasks/task_e_68c991d75d70832fbe18861ce28acaca