### PR TITLE
Add conditional notification badge and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+.env.*
+*.log
+coverage/

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -58,6 +58,31 @@ body {
     opacity: 0.85;
 }
 
+.navbar .nav-link.nav-notification {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.08);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.1rem;
+    transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+    position: relative;
+}
+
+.navbar .nav-link.nav-notification:hover,
+.navbar .nav-link.nav-notification:focus {
+    background: rgba(255, 255, 255, 0.18);
+    transform: translateY(-1px);
+    color: #fff;
+}
+
+.navbar .nav-link.nav-notification .notification-badge {
+    font-size: 0.675rem;
+    padding: 0.35rem 0.4rem;
+}
+
 .navbar .dropdown-menu {
     border-radius: 14px;
     border: none;

--- a/scripts/health-check.js
+++ b/scripts/health-check.js
@@ -5,9 +5,143 @@ process.env.DB_STORAGE = process.env.DB_STORAGE || ':memory:';
 process.env.EMAIL_DISABLED = 'true';
 process.env.APP_NAME = process.env.APP_NAME || 'Sistema de Gestão - Teste';
 
+const path = require('path');
+const { spawn } = require('child_process');
+
 const { sequelize, User, Notification, Procedure, Room, Appointment } = require('../database/models');
 const { processNotifications } = require('../src/services/notificationService');
 const { USER_ROLES } = require('../src/constants/roles');
+
+const TEST_SERVER_PORT = Number.parseInt(process.env.TEST_SERVER_PORT || '3456', 10);
+
+const SERVER_START_TIMEOUT = Number.parseInt(process.env.TEST_SERVER_START_TIMEOUT || '12000', 10);
+
+function waitForServerReady(server, port, timeout = SERVER_START_TIMEOUT) {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+
+        const handleStdout = (chunk) => {
+            const text = chunk.toString();
+            if (text.includes('Servidor rodando')) {
+                settled = true;
+                cleanup();
+                resolve();
+            }
+        };
+
+        const handleStderr = (chunk) => {
+            const text = chunk.toString();
+            process.stderr.write(`[server:test] ${text}`);
+        };
+
+        const handleExit = (code) => {
+            if (!settled) {
+                cleanup();
+                reject(new Error(`Servidor de teste finalizou antes de estar pronto (código ${code}).`));
+            }
+        };
+
+        const handleError = (error) => {
+            if (!settled) {
+                cleanup();
+                reject(error);
+            }
+        };
+
+        const cleanup = () => {
+            clearTimeout(timer);
+            server.stdout.off('data', handleStdout);
+            server.stderr.off('data', handleStderr);
+            server.off('exit', handleExit);
+            server.off('error', handleError);
+        };
+
+        const timer = setTimeout(() => {
+            if (!settled) {
+                cleanup();
+                reject(new Error(`Tempo limite ao aguardar servidor de teste na porta ${port}.`));
+            }
+        }, timeout);
+
+        server.stdout.on('data', handleStdout);
+        server.stderr.on('data', handleStderr);
+        server.on('exit', handleExit);
+        server.on('error', handleError);
+    });
+}
+
+function stopServer(server) {
+    return new Promise((resolve) => {
+        if (!server) {
+            return resolve();
+        }
+
+        const finalize = () => {
+            clearTimeout(forceKillTimer);
+            resolve();
+        };
+
+        const forceKillTimer = setTimeout(() => {
+            if (!server.killed) {
+                server.kill('SIGKILL');
+            }
+        }, 3000);
+
+        if (server.exitCode !== null || server.signalCode) {
+            finalize();
+            return;
+        }
+
+        server.once('exit', finalize);
+        server.kill();
+    });
+}
+
+async function ensureNoNotificationBadge(url) {
+    const response = await fetch(url, { headers: { accept: 'text/html' } });
+    if (!response.ok) {
+        throw new Error(`Falha ao acessar ${url}: status ${response.status}`);
+    }
+
+    const body = await response.text();
+    if (body.includes('data-testid="notification-badge"')) {
+        throw new Error(`Balão de notificações encontrado em ${url}`);
+    }
+}
+
+async function runNotificationBadgeE2E() {
+    if (typeof fetch !== 'function') {
+        throw new Error('Fetch API indisponível no ambiente de teste.');
+    }
+
+    const serverPath = path.join(__dirname, '..', 'server.js');
+    const env = {
+        ...process.env,
+        PORT: String(TEST_SERVER_PORT),
+        NODE_ENV: 'test',
+        DB_DIALECT: 'sqlite',
+        DB_STORAGE: ':memory:',
+        SESSION_SECRET: process.env.SESSION_SECRET || 'test-session-secret',
+        EMAIL_DISABLED: 'true',
+        APP_NAME: process.env.APP_NAME || 'Sistema de Gestão - Teste'
+    };
+
+    const server = spawn(process.execPath, [serverPath], {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    try {
+        await waitForServerReady(server, TEST_SERVER_PORT);
+
+        await ensureNoNotificationBadge(`http://127.0.0.1:${TEST_SERVER_PORT}/login`);
+        await ensureNoNotificationBadge(`http://127.0.0.1:${TEST_SERVER_PORT}/register`);
+
+        console.log('Teste E2E das páginas públicas executado com sucesso.');
+    } finally {
+        await stopServer(server);
+    }
+}
 
 async function run() {
     try {
@@ -86,6 +220,8 @@ async function run() {
         });
 
         await processNotifications();
+
+        await runNotificationBadgeE2E();
 
         console.log('Health check executado com sucesso.');
     } catch (error) {

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const APP_NAME = process.env.APP_NAME || 'Sistema de Gestão Inteligente';
 
 // Importa o serviço de notificações
 const { processNotifications } = require('./src/services/notificationService');
+const notificationIndicator = require('./src/middlewares/notificationIndicator');
 
 // Rotas
 const authRoutes = require('./src/routes/authRoutes');
@@ -110,6 +111,9 @@ app.use(async (req, res, next) => {
 
     return next();
 });
+
+// Indicador de notificações no cabeçalho
+app.use(notificationIndicator);
 
 // EJS
 app.set('view engine', 'ejs');

--- a/src/middlewares/notificationIndicator.js
+++ b/src/middlewares/notificationIndicator.js
@@ -1,0 +1,73 @@
+const { Notification } = require('../../database/models');
+const { Op } = require('sequelize');
+
+const MAX_BADGE_ITEMS = 8;
+
+const buildPreview = (notification) => {
+    const source = notification.previewText || notification.message || '';
+    const trimmed = source.trim();
+    if (!trimmed) {
+        return '';
+    }
+    return trimmed.length > 90 ? `${trimmed.slice(0, 87)}...` : trimmed;
+};
+
+module.exports = async function notificationIndicator(req, res, next) {
+    try {
+        if (!req.user || req.method !== 'GET') {
+            return next();
+        }
+
+        const acceptHeader = req.headers.accept || '';
+        if (acceptHeader && !acceptHeader.includes('text/html')) {
+            return next();
+        }
+
+        const now = new Date();
+        const where = {
+            active: true,
+            sent: false,
+            [Op.and]: [
+                {
+                    [Op.or]: [
+                        { triggerDate: null },
+                        { triggerDate: { [Op.lte]: now } }
+                    ]
+                },
+                {
+                    [Op.or]: [
+                        { sendToAll: true },
+                        { userId: req.user.id }
+                    ]
+                }
+            ]
+        };
+
+        const attributes = ['id', 'title', 'previewText', 'message', 'accentColor'];
+
+        const notifications = await Notification.findAll({
+            where,
+            attributes,
+            order: [['updatedAt', 'DESC']],
+            limit: MAX_BADGE_ITEMS
+        });
+
+        if (notifications.length) {
+            const sanitized = notifications.map((notif) => {
+                const plain = notif.get({ plain: true });
+                return {
+                    id: plain.id,
+                    title: plain.title,
+                    preview: buildPreview(plain),
+                    accentColor: plain.accentColor
+                };
+            });
+
+            res.locals.notifications = sanitized;
+        }
+    } catch (error) {
+        console.error('Erro ao carregar indicador de notificações:', error);
+    }
+
+    return next();
+};

--- a/src/routes/appointmentRoutes.js
+++ b/src/routes/appointmentRoutes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const appointmentController = require('../controllers/appointmentController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
+const authorize = require('../middlewares/authorize');
 const { createFilterValidation } = require('../middlewares/queryValidationMiddleware');
 
 const appointmentFiltersValidation = createFilterValidation({

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -7,6 +7,9 @@ const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const upload = require('../middlewares/uploadMiddleware');
 const audit = require('../middlewares/audit');
+const { manageUsersValidation = [] } = require('../middlewares/validateMiddleware');
+
+const userManagementValidation = Array.isArray(manageUsersValidation) ? manageUsersValidation : [];
 
 
 // Todas as rotas de gerenciamento de usuários requerem login e permissão >= 4
@@ -14,7 +17,7 @@ router.get(
     '/manage',
     authMiddleware,
     permissionMiddleware(4),
-    ...manageUsersValidation,
+    ...userManagementValidation,
     userController.manageUsers
 );
 

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -137,6 +137,27 @@
                         </li>
                     <% } %>
                 <% } %>
+                <% if (user && notifications && notifications.length) { %>
+                    <li class="nav-item ms-lg-2 mt-3 mt-lg-0">
+                        <a
+                            class="nav-link position-relative nav-notification px-2"
+                            href="/notifications"
+                            aria-label="Visualizar notificações disponíveis"
+                        >
+                            <i class="bi bi-bell-fill"></i>
+                            <span
+                                class="notification-badge badge rounded-pill bg-danger-subtle text-danger fw-semibold shadow-sm position-absolute top-0 start-100 translate-middle"
+                                data-testid="notification-badge"
+                                aria-hidden="true"
+                            >
+                                <%= notifications.length > 9 ? '9+' : notifications.length %>
+                            </span>
+                            <span class="visually-hidden">
+                                Você possui <%= notifications.length %> notificações ativas
+                            </span>
+                        </a>
+                    </li>
+                <% } %>
                 <li class="nav-item ms-lg-3 mt-3 mt-lg-0">
                     <button
                         id="themeToggle"


### PR DESCRIPTION
## Summary
- show the notification indicator only when notifications exist and polish its appearance in the header
- add a middleware that loads active notifications for logged users while skipping empty results
- extend the health-check script with an end-to-end check for the login and register pages and fix missing route imports so the server starts during tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c991c23e68832faa06bcbe83763fb4