### PR TITLE
feat: add campaign management pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+*.log

--- a/database/models/notification.js
+++ b/database/models/notification.js
@@ -31,6 +31,11 @@ module.exports = (sequelize, DataTypes) => {
             allowNull: true,
             defaultValue: {}
         },
+        segmentFilters: {
+            type: DataTypes.JSON,
+            allowNull: true,
+            defaultValue: {}
+        },
         repeatFrequency: {
             type: DataTypes.STRING,
             allowNull: false,
@@ -39,6 +44,26 @@ module.exports = (sequelize, DataTypes) => {
                 isIn: {
                     args: [['none', 'daily', 'weekly', 'monthly']],
                     msg: 'Frequência de repetição inválida.'
+                }
+            }
+        },
+        scheduledAt: {
+            type: DataTypes.DATE,
+            allowNull: true,
+            validate: {
+                isDate: {
+                    msg: 'Data de agendamento inválida.'
+                }
+            }
+        },
+        status: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            defaultValue: 'draft',
+            validate: {
+                isIn: {
+                    args: [['draft', 'scheduled', 'queued', 'sending', 'sent', 'failed', 'cancelled']],
+                    msg: 'Status de campanha inválido.'
                 }
             }
         },

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const appointmentRoutes = require('./src/routes/appointmentRoutes');
 const financeRoutes = require('./src/routes/financeRoutes');
 const notificationRoutes = require('./src/routes/notificationRoutes');
 const auditRoutes = require('./src/routes/auditRoutes');
+const campaignRoutes = require('./src/routes/campaignRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -128,6 +129,7 @@ app.use('/rooms', roomRoutes);
 app.use('/appointments', appointmentRoutes);
 app.use('/finance', financeRoutes);
 app.use('/notifications', notificationRoutes);
+app.use('/campaigns', campaignRoutes);
 app.use('/audit', auditRoutes);
 
 // Conexão DB

--- a/src/controllers/campaignController.js
+++ b/src/controllers/campaignController.js
@@ -1,0 +1,181 @@
+// src/controllers/campaignController.js
+const {
+    CAMPAIGN_STATUS_LABELS,
+    createCampaign,
+    queueCampaignById,
+    dispatchCampaignById,
+    dispatchPendingCampaigns,
+    listCampaigns
+} = require('../services/campaignService');
+const { ROLE_LABELS, ROLE_ORDER } = require('../constants/roles');
+
+const safeParseJson = (value) => {
+    if (!value) return null;
+    if (typeof value === 'object') return value;
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        return null;
+    }
+};
+
+const buildRoleOptions = () => {
+    return ROLE_ORDER.map((role) => ({
+        value: role,
+        label: ROLE_LABELS[role] || role
+    }));
+};
+
+const buildStatusOptions = () => Object.entries(CAMPAIGN_STATUS_LABELS).map(([value, label]) => ({ value, label }));
+
+module.exports = {
+    showCreate: (req, res) => {
+        const formData = safeParseJson(req.flash('campaign_form')[0]) || {};
+        res.render('campaigns/create', {
+            pageTitle: 'Nova campanha',
+            roleOptions: buildRoleOptions(),
+            statusOptions: buildStatusOptions(),
+            formData
+        });
+    },
+
+    createCampaign: async (req, res) => {
+        const {
+            title,
+            message,
+            messageHtml,
+            previewText,
+            accentColor,
+            segmentFilters,
+            scheduledAt,
+            action
+        } = req.body;
+
+        const payload = {
+            title,
+            message,
+            messageHtml,
+            previewText,
+            accentColor,
+            segmentFilters,
+            scheduledAt
+        };
+
+        try {
+            const campaign = await createCampaign(payload, {
+                actorId: req.user?.id,
+                ip: req.ip
+            });
+
+            if (action === 'queue' || action === 'dispatch') {
+                await queueCampaignById(campaign.id, {
+                    scheduledAt,
+                    actorId: req.user?.id,
+                    ip: req.ip
+                });
+            }
+
+            if (action === 'dispatch') {
+                await dispatchCampaignById(campaign.id, {
+                    actorId: req.user?.id,
+                    ip: req.ip
+                });
+                req.flash('success_msg', 'Campanha criada e enviada com sucesso.');
+            } else if (action === 'queue') {
+                req.flash('success_msg', 'Campanha criada e adicionada à fila.');
+            } else {
+                req.flash('success_msg', 'Campanha salva como rascunho.');
+            }
+
+            return res.redirect('/campaigns');
+        } catch (error) {
+            console.error('Erro ao criar campanha:', error);
+            req.flash('error_msg', error.message || 'Erro ao criar campanha.');
+            req.flash('campaign_form', JSON.stringify(payload));
+            return res.redirect('/campaigns/create');
+        }
+    },
+
+    listCampaigns: async (req, res) => {
+        try {
+            const { campaigns, filters } = await listCampaigns(req.query);
+            res.render('campaigns/manage', {
+                pageTitle: 'Campanhas de marketing',
+                campaigns,
+                filters,
+                statusOptions: buildStatusOptions()
+            });
+        } catch (error) {
+            console.error('Erro ao listar campanhas:', error);
+            req.flash('error_msg', 'Erro ao listar campanhas.');
+            return res.redirect('/');
+        }
+    },
+
+    queueCampaign: async (req, res) => {
+        const { id } = req.params;
+        const { scheduledAt, dispatchNow } = req.body;
+        try {
+            await queueCampaignById(id, {
+                scheduledAt,
+                actorId: req.user?.id,
+                ip: req.ip
+            });
+
+            if (dispatchNow === 'true') {
+                await dispatchCampaignById(id, {
+                    actorId: req.user?.id,
+                    ip: req.ip
+                });
+                req.flash('success_msg', 'Campanha enviada com sucesso.');
+            } else {
+                req.flash('success_msg', 'Campanha adicionada à fila.');
+            }
+        } catch (error) {
+            console.error('Erro ao enfileirar campanha:', error);
+            req.flash('error_msg', error.message || 'Erro ao enfileirar campanha.');
+        }
+
+        return res.redirect('/campaigns');
+    },
+
+    dispatchCampaign: async (req, res) => {
+        const { id } = req.params;
+        try {
+            await dispatchCampaignById(id, {
+                actorId: req.user?.id,
+                ip: req.ip
+            });
+            req.flash('success_msg', 'Campanha enviada com sucesso.');
+        } catch (error) {
+            console.error('Erro ao enviar campanha:', error);
+            req.flash('error_msg', error.message || 'Erro ao enviar campanha.');
+        }
+
+        return res.redirect('/campaigns');
+    },
+
+    dispatchPending: async (req, res) => {
+        try {
+            const results = await dispatchPendingCampaigns({
+                actorId: req.user?.id,
+                ip: req.ip
+            });
+
+            const sentCount = results.filter((item) => item.status === 'sent').length;
+            const failedCount = results.filter((item) => item.status === 'failed').length;
+
+            if (sentCount) {
+                req.flash('success_msg', `${sentCount} campanha(s) despachada(s) com sucesso.`);
+            }
+            if (failedCount) {
+                req.flash('error_msg', `${failedCount} campanha(s) falharam ao despachar.`);
+            }
+        } catch (error) {
+            console.error('Erro ao processar campanhas pendentes:', error);
+            req.flash('error_msg', 'Erro ao processar campanhas pendentes.');
+        }
+
+        return res.redirect('/campaigns');
+    }
+};

--- a/src/routes/campaignRoutes.js
+++ b/src/routes/campaignRoutes.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const campaignController = require('../controllers/campaignController');
+const authMiddleware = require('../middlewares/authMiddleware');
+const permissionMiddleware = require('../middlewares/permissionMiddleware');
+const { createFilterValidation } = require('../middlewares/queryValidationMiddleware');
+
+const campaignFiltersValidation = createFilterValidation({
+    allowedStatuses: ['draft', 'scheduled', 'queued', 'sending', 'sent', 'failed', 'cancelled'],
+    redirectTo: '/campaigns'
+});
+
+router.get(
+    '/',
+    authMiddleware,
+    permissionMiddleware(4),
+    ...campaignFiltersValidation,
+    campaignController.listCampaigns
+);
+
+router.get('/create', authMiddleware, permissionMiddleware(4), campaignController.showCreate);
+router.post('/', authMiddleware, permissionMiddleware(4), campaignController.createCampaign);
+router.post('/:id/queue', authMiddleware, permissionMiddleware(4), campaignController.queueCampaign);
+router.post('/:id/dispatch', authMiddleware, permissionMiddleware(4), campaignController.dispatchCampaign);
+router.post('/dispatch/pending', authMiddleware, permissionMiddleware(4), campaignController.dispatchPending);
+
+module.exports = router;

--- a/src/services/campaignService.js
+++ b/src/services/campaignService.js
@@ -1,0 +1,762 @@
+// src/services/campaignService.js
+const sanitizeHtml = require('sanitize-html');
+const { Op } = require('sequelize');
+
+const {
+    Notification,
+    User,
+    AuditLog,
+    sequelize
+} = require('../../database/models');
+const { buildQueryFilters } = require('../utils/queryBuilder');
+const { sendBulkEmail } = require('../utils/email');
+const { buildEmailContent } = require('../utils/placeholderUtils');
+const { ROLE_LABELS, parseRole, sortRolesByHierarchy } = require('../constants/roles');
+
+const DEFAULT_APP_NAME = process.env.APP_NAME || 'Sistema de Gestão';
+const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}){1,2}$/;
+const MAX_RULES = 20;
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_RATE_LIMIT = Object.freeze({
+    max: 90,
+    intervalMs: 60_000,
+    concurrency: 3
+});
+
+const CAMPAIGN_STATUS = Object.freeze({
+    DRAFT: 'draft',
+    SCHEDULED: 'scheduled',
+    QUEUED: 'queued',
+    SENDING: 'sending',
+    SENT: 'sent',
+    FAILED: 'failed',
+    CANCELLED: 'cancelled'
+});
+
+const CAMPAIGN_STATUS_LABELS = Object.freeze({
+    [CAMPAIGN_STATUS.DRAFT]: 'Rascunho',
+    [CAMPAIGN_STATUS.SCHEDULED]: 'Agendada',
+    [CAMPAIGN_STATUS.QUEUED]: 'Na fila',
+    [CAMPAIGN_STATUS.SENDING]: 'Enviando',
+    [CAMPAIGN_STATUS.SENT]: 'Enviada',
+    [CAMPAIGN_STATUS.FAILED]: 'Com falha',
+    [CAMPAIGN_STATUS.CANCELLED]: 'Cancelada'
+});
+
+const SUPPORTED_FIELDS = Object.freeze({
+    role: {
+        operators: new Set(['in', 'notIn'])
+    },
+    active: {
+        operators: new Set(['eq'])
+    },
+    creditBalance: {
+        operators: new Set(['gte', 'lte', 'between'])
+    },
+    createdAt: {
+        operators: new Set(['between', 'gte', 'lte'])
+    },
+    emailDomain: {
+        operators: new Set(['contains', 'notContains'])
+    }
+});
+
+const SEGMENT_FIELD_LABELS = Object.freeze({
+    role: 'Perfil',
+    active: 'Status',
+    creditBalance: 'Crédito',
+    createdAt: 'Criado em',
+    emailDomain: 'Domínio do e-mail'
+});
+
+const SEGMENT_OPERATOR_LABELS = Object.freeze({
+    in: 'em',
+    notIn: 'fora de',
+    eq: 'igual a',
+    gte: '≥',
+    lte: '≤',
+    between: 'entre',
+    contains: 'contém',
+    notContains: 'não contém'
+});
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const sanitizeHtmlContent = (value) => {
+    if (!value) return null;
+    return sanitizeHtml(value, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+            'h1', 'h2', 'h3', 'h4', 'img', 'table', 'tbody', 'thead', 'tr', 'td', 'th', 'span'
+        ]),
+        allowedAttributes: {
+            '*': ['style', 'class'],
+            a: ['href', 'name', 'target', 'rel'],
+            img: ['src', 'alt', 'width', 'height']
+        },
+        allowedSchemes: ['http', 'https', 'mailto']
+    });
+};
+
+const sanitizeColor = (value) => {
+    if (typeof value !== 'string') {
+        return '#0d6efd';
+    }
+    const trimmed = value.trim();
+    return HEX_COLOR_REGEX.test(trimmed) ? trimmed : '#0d6efd';
+};
+
+const normalizeBoolean = (value) => {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['true', '1', 'yes', 'on', 'ativo', 'active'].includes(normalized)) {
+            return true;
+        }
+        if (['false', '0', 'no', 'off', 'inativo', 'inactive'].includes(normalized)) {
+            return false;
+        }
+    }
+    return null;
+};
+
+const parseNumber = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value === 'string') {
+        const normalized = value.replace(',', '.').trim();
+        if (!normalized) return null;
+        const parsed = Number.parseFloat(normalized);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+};
+
+const parseDateInput = (value) => {
+    if (!value) return null;
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    return date;
+};
+
+const normalizeBetweenValue = (value, parser) => {
+    if (!value) return null;
+    let start;
+    let end;
+
+    if (Array.isArray(value)) {
+        [start, end] = value;
+    } else if (typeof value === 'object') {
+        start = value.start ?? value.min ?? value.from;
+        end = value.end ?? value.max ?? value.to;
+    } else if (typeof value === 'string') {
+        const parts = value.split(',').map((part) => part.trim());
+        if (parts.length >= 2) {
+            [start, end] = parts;
+        }
+    }
+
+    const parsedStart = parser(start);
+    const parsedEnd = parser(end);
+    if (parsedStart === null || parsedEnd === null) {
+        return null;
+    }
+
+    if (parsedStart > parsedEnd) {
+        return [parsedEnd, parsedStart];
+    }
+
+    return [parsedStart, parsedEnd];
+};
+
+const parseRoleArray = (value) => {
+    if (!value) return [];
+    const source = Array.isArray(value) ? value : [value];
+    const normalized = sortRolesByHierarchy(
+        source
+            .map((item) => parseRole(item, null))
+            .filter(Boolean)
+    );
+    return normalized;
+};
+
+const normalizeSegmentFilters = (rawValue) => {
+    if (!rawValue) {
+        return { logic: 'AND', rules: [] };
+    }
+
+    let payload = rawValue;
+    if (typeof rawValue === 'string') {
+        try {
+            payload = JSON.parse(rawValue);
+        } catch (error) {
+            return { logic: 'AND', rules: [] };
+        }
+    }
+
+    if (!payload || typeof payload !== 'object') {
+        return { logic: 'AND', rules: [] };
+    }
+
+    const logic = typeof payload.logic === 'string' && payload.logic.trim().toUpperCase() === 'OR'
+        ? 'OR'
+        : 'AND';
+
+    const rulesSource = Array.isArray(payload.rules) ? payload.rules.slice(0, MAX_RULES) : [];
+    const rules = [];
+
+    for (const entry of rulesSource) {
+        if (!entry || typeof entry !== 'object') {
+            continue;
+        }
+        const field = typeof entry.field === 'string' ? entry.field.trim() : '';
+        if (!field || !Object.prototype.hasOwnProperty.call(SUPPORTED_FIELDS, field)) {
+            continue;
+        }
+        const operator = typeof entry.operator === 'string' ? entry.operator.trim() : '';
+        const allowedOperators = SUPPORTED_FIELDS[field]?.operators;
+        if (!operator || !allowedOperators?.has(operator)) {
+            continue;
+        }
+
+        let normalizedRule = null;
+
+        switch (field) {
+            case 'role': {
+                const roles = parseRoleArray(entry.value);
+                if (!roles.length) break;
+                normalizedRule = { field, operator, value: roles };
+                break;
+            }
+            case 'active': {
+                const booleanValue = normalizeBoolean(entry.value);
+                if (booleanValue === null) break;
+                normalizedRule = { field, operator, value: booleanValue };
+                break;
+            }
+            case 'creditBalance': {
+                if (operator === 'between') {
+                    const range = normalizeBetweenValue(entry.value, parseNumber);
+                    if (!range) break;
+                    normalizedRule = { field, operator, value: range };
+                    break;
+                }
+                const amount = parseNumber(entry.value);
+                if (amount === null) break;
+                normalizedRule = { field, operator, value: amount };
+                break;
+            }
+            case 'createdAt': {
+                const range = operator === 'between'
+                    ? normalizeBetweenValue(entry.value, parseDateInput)
+                    : null;
+
+                if (operator === 'between') {
+                    if (!range) break;
+                    normalizedRule = { field, operator, value: range.map((date) => date.toISOString()) };
+                    break;
+                }
+
+                const dateValue = parseDateInput(entry.value);
+                if (!dateValue) break;
+                normalizedRule = { field, operator, value: dateValue.toISOString() };
+                break;
+            }
+            case 'emailDomain': {
+                if (typeof entry.value !== 'string') break;
+                const domain = entry.value.trim().replace(/^@/, '').toLowerCase();
+                if (!domain) break;
+                normalizedRule = { field, operator, value: domain };
+                break;
+            }
+            default:
+                break;
+        }
+
+        if (normalizedRule) {
+            rules.push(normalizedRule);
+        }
+    }
+
+    return { logic, rules };
+};
+
+const buildSegmentSummary = (filters) => {
+    const normalized = normalizeSegmentFilters(filters);
+    const summaries = [];
+
+    const hasActiveRule = normalized.rules.some((rule) => rule.field === 'active');
+    if (!hasActiveRule) {
+        summaries.push('Somente usuários ativos');
+    }
+
+    normalized.rules.forEach((rule) => {
+        const label = SEGMENT_FIELD_LABELS[rule.field] || rule.field;
+        const operatorLabel = SEGMENT_OPERATOR_LABELS[rule.operator] || rule.operator;
+
+        switch (rule.field) {
+            case 'role': {
+                const roleLabels = rule.value.map((role) => ROLE_LABELS[role] || role);
+                const joiner = rule.operator === 'notIn' ? ' exceto ' : ' ';
+                summaries.push(`${label}${joiner}${roleLabels.join(', ')}`);
+                break;
+            }
+            case 'active': {
+                summaries.push(rule.value ? 'Usuários ativos' : 'Usuários inativos');
+                break;
+            }
+            case 'creditBalance': {
+                if (rule.operator === 'between') {
+                    summaries.push(`${label} entre ${Number(rule.value[0]).toFixed(2)} e ${Number(rule.value[1]).toFixed(2)}`);
+                } else {
+                    summaries.push(`${label} ${operatorLabel} ${Number(rule.value).toFixed(2)}`);
+                }
+                break;
+            }
+            case 'createdAt': {
+                if (rule.operator === 'between') {
+                    const [start, end] = rule.value;
+                    summaries.push(`${label} entre ${new Date(start).toLocaleDateString('pt-BR')} e ${new Date(end).toLocaleDateString('pt-BR')}`);
+                } else {
+                    summaries.push(`${label} ${operatorLabel} ${new Date(rule.value).toLocaleDateString('pt-BR')}`);
+                }
+                break;
+            }
+            case 'emailDomain': {
+                const prefix = rule.operator === 'notContains' ? 'Sem e-mails que ' : 'E-mails que ';
+                summaries.push(`${prefix}${operatorLabel} @${rule.value}`);
+                break;
+            }
+            default:
+                break;
+        }
+    });
+
+    if (!summaries.length) {
+        summaries.push('Base ativa completa');
+    }
+
+    return { normalized, summaries };
+};
+
+const buildRecipientWhere = (segmentFilters) => {
+    const { normalized } = buildSegmentSummary(segmentFilters);
+    const where = {};
+    const andConditions = [
+        { email: { [Op.ne]: null } },
+        { email: { [Op.ne]: '' } }
+    ];
+
+    const ruleConditions = normalized.rules.map((rule) => {
+        switch (rule.field) {
+            case 'role':
+                if (rule.operator === 'in') {
+                    return { role: { [Op.in]: rule.value } };
+                }
+                return { role: { [Op.notIn]: rule.value } };
+            case 'active':
+                return { active: rule.value };
+            case 'creditBalance':
+                if (rule.operator === 'between') {
+                    return {
+                        creditBalance: {
+                            [Op.between]: [rule.value[0], rule.value[1]]
+                        }
+                    };
+                }
+                return {
+                    creditBalance: {
+                        [rule.operator === 'gte' ? Op.gte : Op.lte]: rule.value
+                    }
+                };
+            case 'createdAt':
+                if (rule.operator === 'between') {
+                    return {
+                        createdAt: {
+                            [Op.between]: [new Date(rule.value[0]), new Date(rule.value[1])]
+                        }
+                    };
+                }
+                return {
+                    createdAt: {
+                        [rule.operator === 'gte' ? Op.gte : Op.lte]: new Date(rule.value)
+                    }
+                };
+            case 'emailDomain': {
+                const column = sequelize.col('email');
+                const domainPattern = `%@${rule.value}`;
+                const comparator = rule.operator === 'notContains' ? Op.notLike : Op.like;
+                return sequelize.where(
+                    sequelize.fn('lower', column),
+                    { [comparator]: domainPattern }
+                );
+            }
+            default:
+                return null;
+        }
+    }).filter(Boolean);
+
+    const useOrLogic = normalized.logic === 'OR';
+
+    if (!normalized.rules.some((rule) => rule.field === 'active')) {
+        andConditions.push({ active: true });
+    }
+
+    if (useOrLogic && ruleConditions.length) {
+        andConditions.push({ [Op.or]: ruleConditions });
+    } else {
+        andConditions.push(...ruleConditions);
+    }
+
+    if (andConditions.length) {
+        where[Op.and] = andConditions;
+    }
+
+    return {
+        where,
+        normalized
+    };
+};
+
+const estimateRecipients = async (segmentFilters) => {
+    const { where } = buildRecipientWhere(segmentFilters);
+    return User.count({ where });
+};
+
+async function* iterateRecipients(segmentFilters, { batchSize = DEFAULT_BATCH_SIZE } = {}) {
+    const { where } = buildRecipientWhere(segmentFilters);
+    let offset = 0;
+    const safeBatch = Math.max(10, Math.min(batchSize, 500));
+
+    while (true) {
+        const users = await User.findAll({
+            where,
+            attributes: ['id', 'name', 'email', 'role', 'creditBalance', 'active'],
+            order: [['id', 'ASC']],
+            limit: safeBatch,
+            offset,
+            raw: true
+        });
+
+        if (!users.length) {
+            break;
+        }
+
+        yield users;
+        offset += users.length;
+
+        await delay(5);
+    }
+}
+
+const parseScheduledAt = (value) => {
+    const parsed = parseDateInput(value);
+    return parsed ? parsed : null;
+};
+
+const resolveInitialStatus = (scheduledAt) => {
+    if (!scheduledAt) {
+        return CAMPAIGN_STATUS.DRAFT;
+    }
+    const now = Date.now();
+    return scheduledAt.getTime() > now ? CAMPAIGN_STATUS.SCHEDULED : CAMPAIGN_STATUS.QUEUED;
+};
+
+const createAuditLog = async ({ userId, action, resource, ip }) => {
+    if (!AuditLog || typeof AuditLog.create !== 'function') {
+        return null;
+    }
+    return AuditLog.create({
+        userId: userId ?? null,
+        action,
+        resource,
+        ip: ip ? String(ip).slice(0, 45) : null
+    });
+};
+
+const createCampaign = async (payload, { actorId, ip } = {}) => {
+    const title = typeof payload.title === 'string' ? payload.title.trim() : '';
+    const message = typeof payload.message === 'string' ? payload.message.trim() : '';
+    const previewText = typeof payload.previewText === 'string'
+        ? payload.previewText.trim().slice(0, 120)
+        : null;
+
+    if (!title) {
+        throw new Error('Título da campanha é obrigatório.');
+    }
+    if (!message && !payload.messageHtml) {
+        throw new Error('Defina uma mensagem para o disparo da campanha.');
+    }
+
+    const messageHtml = sanitizeHtmlContent(payload.messageHtml);
+    const accentColor = sanitizeColor(payload.accentColor);
+    const scheduledAt = parseScheduledAt(payload.scheduledAt);
+    const segmentFilters = normalizeSegmentFilters(payload.segmentFilters);
+    const status = resolveInitialStatus(scheduledAt);
+
+    const campaign = await Notification.create({
+        title,
+        message: message || ' ',
+        messageHtml,
+        type: 'campaign',
+        triggerDate: scheduledAt,
+        active: true,
+        sendToAll: false,
+        filters: null,
+        segmentFilters,
+        scheduledAt,
+        status,
+        accentColor,
+        previewText,
+        sent: false
+    });
+
+    await createAuditLog({
+        userId: actorId,
+        action: 'campaign.created',
+        resource: `campaign:${campaign.id}`,
+        ip
+    });
+
+    return campaign;
+};
+
+const queueCampaignById = async (campaignId, { scheduledAt, actorId, ip } = {}) => {
+    const campaign = await Notification.findOne({
+        where: { id: campaignId, type: 'campaign' }
+    });
+
+    if (!campaign) {
+        throw new Error('Campanha não encontrada.');
+    }
+
+    const normalizedFilters = normalizeSegmentFilters(campaign.segmentFilters);
+    const scheduleDate = parseScheduledAt(scheduledAt) || campaign.scheduledAt || new Date();
+    const status = resolveInitialStatus(scheduleDate);
+
+    await campaign.update({
+        scheduledAt: scheduleDate,
+        triggerDate: scheduleDate,
+        status,
+        segmentFilters: normalizedFilters
+    });
+
+    await createAuditLog({
+        userId: actorId,
+        action: 'campaign.queued',
+        resource: `campaign:${campaign.id}`,
+        ip
+    });
+
+    return campaign;
+};
+
+const buildEmailPayloads = (campaign, recipients) => {
+    const payloads = [];
+
+    recipients.forEach((user) => {
+        if (!user.email) return;
+        const content = buildEmailContent(campaign, {
+            user,
+            extras: {
+                organizationName: DEFAULT_APP_NAME
+            }
+        });
+
+        payloads.push({
+            to: user.email,
+            subject: content.subject,
+            payload: {
+                text: content.text,
+                html: content.html,
+                headers: content.previewText
+                    ? { 'X-Entity-Preview': content.previewText }
+                    : undefined
+            }
+        });
+    });
+
+    return payloads;
+};
+
+const dispatchCampaignInstance = async (campaign, { actorId, ip, rateLimit, batchSize } = {}) => {
+    const normalizedFilters = normalizeSegmentFilters(campaign.segmentFilters);
+    const scheduleReference = campaign.scheduledAt || new Date();
+
+    await campaign.update({
+        status: CAMPAIGN_STATUS.SENDING,
+        scheduledAt: scheduleReference,
+        triggerDate: scheduleReference,
+        segmentFilters: normalizedFilters
+    });
+
+    const appliedRateLimit = {
+        max: rateLimit?.max ?? DEFAULT_RATE_LIMIT.max,
+        intervalMs: rateLimit?.intervalMs ?? DEFAULT_RATE_LIMIT.intervalMs,
+        concurrency: rateLimit?.concurrency ?? DEFAULT_RATE_LIMIT.concurrency
+    };
+
+    const safeBatchSize = batchSize ?? DEFAULT_BATCH_SIZE;
+    let totalSent = 0;
+    const errors = [];
+
+    for await (const batch of iterateRecipients(normalizedFilters, { batchSize: safeBatchSize })) {
+        const messages = buildEmailPayloads(campaign, batch);
+        if (!messages.length) {
+            continue;
+        }
+
+        try {
+            const result = await sendBulkEmail(messages, {
+                rateLimit: appliedRateLimit,
+                concurrency: appliedRateLimit.concurrency,
+                stopOnError: false,
+                onError: (error, job) => {
+                    errors.push({ error, job });
+                }
+            });
+            totalSent += result.sent;
+        } catch (error) {
+            errors.push({ error });
+        }
+    }
+
+    const status = errors.length ? CAMPAIGN_STATUS.FAILED : CAMPAIGN_STATUS.SENT;
+
+    await campaign.update({
+        status,
+        sent: status === CAMPAIGN_STATUS.SENT,
+        triggerDate: new Date(),
+        segmentFilters: normalizedFilters
+    });
+
+    await createAuditLog({
+        userId: actorId,
+        action: status === CAMPAIGN_STATUS.SENT ? 'campaign.dispatched' : 'campaign.failed',
+        resource: `campaign:${campaign.id}`,
+        ip
+    });
+
+    if (errors.length) {
+        const aggregateError = new Error(`Falha ao enviar campanha ${campaign.id}.`);
+        aggregateError.details = errors;
+        throw aggregateError;
+    }
+
+    return {
+        totalSent
+    };
+};
+
+const dispatchCampaignById = async (campaignId, options = {}) => {
+    const campaign = await Notification.findOne({
+        where: { id: campaignId, type: 'campaign' }
+    });
+
+    if (!campaign) {
+        throw new Error('Campanha não encontrada.');
+    }
+
+    return dispatchCampaignInstance(campaign, options);
+};
+
+const dispatchPendingCampaigns = async ({ limit = 5, ...options } = {}) => {
+    const now = new Date();
+    const campaigns = await Notification.findAll({
+        where: {
+            type: 'campaign',
+            status: {
+                [Op.in]: [CAMPAIGN_STATUS.QUEUED, CAMPAIGN_STATUS.SCHEDULED]
+            },
+            active: true,
+            scheduledAt: {
+                [Op.not]: null,
+                [Op.lte]: now
+            }
+        },
+        order: [['scheduledAt', 'ASC']],
+        limit: Math.max(1, limit)
+    });
+
+    const results = [];
+
+    for (const campaign of campaigns) {
+        try {
+            const result = await dispatchCampaignInstance(campaign, options);
+            results.push({ id: campaign.id, status: 'sent', ...result });
+        } catch (error) {
+            results.push({ id: campaign.id, status: 'failed', error });
+        }
+    }
+
+    return results;
+};
+
+const listCampaigns = async (query = {}) => {
+    const statusMap = {
+        draft: CAMPAIGN_STATUS.DRAFT,
+        scheduled: CAMPAIGN_STATUS.SCHEDULED,
+        queued: CAMPAIGN_STATUS.QUEUED,
+        sending: CAMPAIGN_STATUS.SENDING,
+        sent: CAMPAIGN_STATUS.SENT,
+        failed: CAMPAIGN_STATUS.FAILED,
+        cancelled: CAMPAIGN_STATUS.CANCELLED
+    };
+
+    const { where, filters, metadata } = buildQueryFilters(query, {
+        statusField: 'status',
+        statusMap,
+        allowedStatuses: Object.values(CAMPAIGN_STATUS),
+        defaultStatus: 'all',
+        dateField: 'scheduledAt',
+        keywordFields: ['title', 'message', 'previewText']
+    });
+
+    where.type = 'campaign';
+
+    const campaigns = await Notification.findAll({
+        where,
+        order: [
+            ['scheduledAt', 'DESC'],
+            ['id', 'DESC']
+        ]
+    });
+
+    const detailed = await Promise.all(campaigns.map(async (campaign) => {
+        const plain = campaign.get({ plain: true });
+        const { normalized, summaries } = buildSegmentSummary(plain.segmentFilters);
+        const recipientEstimate = await estimateRecipients(normalized);
+        return {
+            ...plain,
+            statusLabel: CAMPAIGN_STATUS_LABELS[plain.status] || plain.status,
+            segmentSummary: summaries,
+            segmentLogic: normalized.logic,
+            recipientEstimate
+        };
+    }));
+
+    return {
+        campaigns: detailed,
+        filters,
+        metadata
+    };
+};
+
+module.exports = {
+    CAMPAIGN_STATUS,
+    CAMPAIGN_STATUS_LABELS,
+    createCampaign,
+    queueCampaignById,
+    dispatchCampaignById,
+    dispatchPendingCampaigns,
+    listCampaigns,
+    buildSegmentSummary,
+    estimateRecipients
+};

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -16,6 +16,15 @@ const transporter = nodemailer.createTransport({
 
 const shouldMockEmail = () => process.env.EMAIL_DISABLED === 'true';
 
+const BULK_DEFAULTS = Object.freeze({
+    max: 90,
+    intervalMs: 60_000,
+    concurrency: 2,
+    stopOnError: false
+});
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Envia e-mail com suporte a HTML e personalizações de cabeçalho.
  * Também permite receber um objeto com as opções completas do Nodemailer.
@@ -63,6 +72,107 @@ async function sendEmail(to, subject, payload, html) {
     }
 }
 
+/**
+ * Envia múltiplos e-mails com controle de taxa e concorrência.
+ * Cada item deve possuir as propriedades { to, subject, payload, html }.
+ *
+ * @param {Array} messages
+ * @param {object} options
+ */
+async function sendBulkEmail(messages = [], options = {}) {
+    const jobs = Array.isArray(messages) ? messages.slice() : [];
+    const total = jobs.length;
+
+    if (!total) {
+        return { sent: 0, total: 0, errors: [] };
+    }
+
+    const rateLimit = options.rateLimit || {};
+    const maxPerInterval = Number.isFinite(rateLimit.max) && rateLimit.max > 0
+        ? Math.floor(rateLimit.max)
+        : BULK_DEFAULTS.max;
+    const intervalMs = Number.isFinite(rateLimit.intervalMs) && rateLimit.intervalMs > 0
+        ? Math.floor(rateLimit.intervalMs)
+        : BULK_DEFAULTS.intervalMs;
+    const concurrency = Number.isFinite(options.concurrency)
+        ? Math.max(1, Math.floor(options.concurrency))
+        : Number.isFinite(rateLimit.concurrency)
+            ? Math.max(1, Math.floor(rateLimit.concurrency))
+            : BULK_DEFAULTS.concurrency;
+
+    const stopOnError = options.stopOnError ?? BULK_DEFAULTS.stopOnError;
+    const onProgress = typeof options.onProgress === 'function' ? options.onProgress : null;
+    const onError = typeof options.onError === 'function' ? options.onError : null;
+
+    let sentInWindow = 0;
+    let windowStart = Date.now();
+    let sent = 0;
+    let aborted = false;
+    const errors = [];
+
+    const pullJob = () => {
+        if (!jobs.length) return null;
+        return jobs.shift();
+    };
+
+    const executeJob = async (job) => {
+        const now = Date.now();
+        if (now - windowStart >= intervalMs) {
+            windowStart = now;
+            sentInWindow = 0;
+        }
+
+        if (sentInWindow >= maxPerInterval) {
+            const waitTime = intervalMs - (now - windowStart);
+            if (waitTime > 0) {
+                await delay(waitTime);
+            }
+            windowStart = Date.now();
+            sentInWindow = 0;
+        }
+
+        await sendEmail(job.to, job.subject, job.payload ?? job.text ?? '', job.html);
+        sentInWindow += 1;
+        sent += 1;
+        if (onProgress) {
+            onProgress({ sent, total, last: job });
+        }
+    };
+
+    const worker = async () => {
+        while (!aborted) {
+            const job = pullJob();
+            if (!job) {
+                break;
+            }
+
+            try {
+                await executeJob(job);
+            } catch (error) {
+                errors.push({ error, job });
+                if (onError) {
+                    try {
+                        await onError(error, job);
+                    } catch (hookError) {
+                        errors.push({ error: hookError, job });
+                    }
+                }
+                if (stopOnError) {
+                    aborted = true;
+                    break;
+                }
+            }
+        }
+    };
+
+    const workerCount = Math.min(concurrency, total);
+    const workers = Array.from({ length: workerCount }, () => worker());
+    await Promise.all(workers);
+
+    return { sent, total, errors };
+}
+
 module.exports = {
-    sendEmail
+    sendEmail,
+    sendBulkEmail
 };

--- a/src/views/campaigns/create.ejs
+++ b/src/views/campaigns/create.ejs
@@ -1,0 +1,634 @@
+<%- include('../partials/header') %>
+
+<%
+    const availableRoles = roleOptions || [];
+    const storedForm = formData || {};
+    const roleLabelsMap = roleLabels || {};
+    function formatDatetimeLocal(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        const pad = (num) => String(num).padStart(2, '0');
+        const year = date.getFullYear();
+        const month = pad(date.getMonth() + 1);
+        const day = pad(date.getDate());
+        const hours = pad(date.getHours());
+        const minutes = pad(date.getMinutes());
+        return `${year}-${month}-${day}T${hours}:${minutes}`;
+    }
+    let segmentJson;
+    if (typeof storedForm.segmentFilters === 'string' && storedForm.segmentFilters.trim().length) {
+        segmentJson = storedForm.segmentFilters.trim();
+    } else if (storedForm.segmentFilters && typeof storedForm.segmentFilters === 'object') {
+        segmentJson = JSON.stringify(storedForm.segmentFilters);
+    } else {
+        segmentJson = JSON.stringify({ logic: 'AND', rules: [] });
+    }
+%>
+
+<div class="row justify-content-center fade-in">
+    <div class="col-12 col-xxl-10">
+        <div class="card card-soft p-4">
+            <div class="d-flex flex-wrap justify-content-between align-items-center mb-4">
+                <div>
+                    <h2 class="fw-semibold mb-1">Nova campanha multicanal</h2>
+                    <p class="text-muted mb-0">Crie segmentações inteligentes, defina agendamentos e visualize o impacto antes do disparo.</p>
+                </div>
+                <a href="/campaigns" class="btn btn-outline-secondary rounded-pill"><i class="bi bi-arrow-left"></i> Voltar</a>
+            </div>
+
+            <% if (success_msg) { %>
+                <div class="alert alert-success alert-auto" data-auto-dismiss="5000">
+                    <i class="bi bi-check-circle me-2"></i><%= success_msg %>
+                </div>
+            <% } else if (error_msg) { %>
+                <div class="alert alert-danger alert-auto" data-auto-dismiss="5000">
+                    <i class="bi bi-exclamation-triangle me-2"></i><%= error_msg %>
+                </div>
+            <% } %>
+
+            <form action="/campaigns" method="POST" class="needs-validation" novalidate data-campaign-form>
+                <fieldset class="scheduler-border mb-4">
+                    <legend class="scheduler-border">Conteúdo</legend>
+                    <div class="row g-3">
+                        <div class="col-lg-8">
+                            <label class="form-label">Assunto</label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                name="title"
+                                maxlength="160"
+                                required
+                                placeholder="Informe um título atrativo"
+                                value="<%= storedForm.title || '' %>"
+                            />
+                        </div>
+                        <div class="col-lg-4">
+                            <label class="form-label">Cor de destaque</label>
+                            <input
+                                type="color"
+                                class="form-control form-control-color"
+                                name="accentColor"
+                                value="<%= storedForm.accentColor || '#0d6efd' %>"
+                            />
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Mensagem (texto plano)</label>
+                            <textarea
+                                class="form-control"
+                                name="message"
+                                rows="4"
+                                placeholder="Olá %USUARIO%, temos novidades exclusivas..."
+                            ><%= storedForm.message || '' %></textarea>
+                            <div class="form-text">Use placeholders como %USUARIO%, %USER_EMAIL%, %ORGANIZACAO% para personalizações automáticas.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Mensagem rica (HTML opcional)</label>
+                            <textarea
+                                class="form-control"
+                                name="messageHtml"
+                                rows="5"
+                                placeholder="<p>Olá &lt;strong&gt;%USUARIO%&lt;/strong&gt;, ...</p>"
+                            ><%= storedForm.messageHtml || '' %></textarea>
+                            <div class="form-text">O HTML é sanitizado automaticamente para proteger contra scripts maliciosos.</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Texto de pré-visualização</label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                name="previewText"
+                                maxlength="120"
+                                placeholder="Resumo exibido na caixa de entrada"
+                                value="<%= storedForm.previewText || '' %>"
+                            />
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset class="scheduler-border mb-4">
+                    <legend class="scheduler-border">Agendamento</legend>
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-6">
+                            <label class="form-label">Data e hora de envio</label>
+                            <input
+                                type="datetime-local"
+                                class="form-control"
+                                name="scheduledAt"
+                                value="<%= formatDatetimeLocal(storedForm.scheduledAt) %>"
+                            />
+                            <div class="form-text">Deixe em branco para salvar como rascunho ou enviar imediatamente.</div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="alert alert-info mb-0 small">
+                                <i class="bi bi-info-circle me-2"></i>Campanhas agendadas entram automaticamente na fila quando chegar a hora definida.
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+
+                <fieldset class="scheduler-border mb-4" data-segment-builder>
+                    <legend class="scheduler-border">Segmentação dinâmica</legend>
+                    <div class="row g-3 align-items-end">
+                        <div class="col-lg-3 col-md-6">
+                            <label class="form-label">Campo</label>
+                            <select class="form-select" data-segment-field>
+                                <option value="role">Perfil do usuário</option>
+                                <option value="active">Status</option>
+                                <option value="creditBalance">Crédito em conta</option>
+                                <option value="createdAt">Data de cadastro</option>
+                                <option value="emailDomain">Domínio do e-mail</option>
+                            </select>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <label class="form-label">Operador</label>
+                            <select class="form-select" data-segment-operator></select>
+                        </div>
+                        <div class="col-lg-4 col-md-7" data-segment-value-container>
+                            <label class="form-label">Valor</label>
+                            <div data-segment-value></div>
+                        </div>
+                        <div class="col-lg-2 col-md-5 d-grid">
+                            <button type="button" class="btn btn-gradient" data-add-rule><i class="bi bi-plus-lg me-2"></i>Adicionar filtro</button>
+                        </div>
+                    </div>
+                    <div class="row g-3 mt-3">
+                        <div class="col-md-4">
+                            <label class="form-label">Combinação</label>
+                            <div class="btn-group" role="group">
+                                <input class="btn-check" type="radio" name="segmentLogic" id="logicAnd" value="AND" checked />
+                                <label class="btn btn-outline-primary" for="logicAnd">Todos os filtros (E)</label>
+                                <input class="btn-check" type="radio" name="segmentLogic" id="logicOr" value="OR" />
+                                <label class="btn btn-outline-primary" for="logicOr">Qualquer filtro (OU)</label>
+                            </div>
+                        </div>
+                        <div class="col-md-8">
+                            <div class="card border-0 shadow-sm h-100">
+                                <div class="card-body">
+                                    <div class="d-flex justify-content-between align-items-center mb-2">
+                                        <h6 class="mb-0 text-uppercase text-muted">Resumo da segmentação</h6>
+                                        <span class="badge bg-soft-primary" data-logic-badge>Combinação AND</span>
+                                    </div>
+                                    <ul class="list-unstyled mb-0 small" data-rules-summary>
+                                        <li class="text-muted">Defina filtros e visualize aqui a audiência.</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <input type="hidden" name="segmentFilters" value="<%= segmentJson %>" data-segment-input />
+                </fieldset>
+
+                <div class="row g-4">
+                    <div class="col-lg-6">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <h5 class="fw-semibold">Pré-visualização em tempo real</h5>
+                                <p class="text-muted small">Simulação da mensagem com as personalizações aplicadas.</p>
+                                <div class="campaign-preview" data-preview-container>
+                                    <div class="campaign-preview-header" data-preview-header>
+                                        <h6 class="mb-0" data-preview-subject>Assunto da campanha</h6>
+                                        <small class="text-muted" data-preview-preview>Prévia exibida na caixa de entrada</small>
+                                    </div>
+                                    <div class="campaign-preview-body" data-preview-body>
+                                        <em>Escreva uma mensagem para visualizar como seus usuários receberão.</em>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-6">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body d-flex flex-column">
+                                <h5 class="fw-semibold">Ações rápidas</h5>
+                                <p class="text-muted small">Escolha como deseja salvar esta campanha.</p>
+                                <div class="d-grid gap-2 mt-auto">
+                                    <button type="submit" name="action" value="draft" class="btn btn-outline-secondary rounded-pill">Salvar como rascunho</button>
+                                    <button type="submit" name="action" value="queue" class="btn btn-gradient rounded-pill">Salvar e agendar envio</button>
+                                    <button type="submit" name="action" value="dispatch" class="btn btn-primary rounded-pill">Enviar agora</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script type="application/json" id="campaign-config">
+<%- JSON.stringify({
+    roles: availableRoles,
+    roleLabels: roleLabelsMap,
+    initialSegment: segmentJson,
+    storedPreview: {
+        title: storedForm.title || '',
+        preview: storedForm.previewText || '',
+        accentColor: storedForm.accentColor || '#0d6efd',
+        message: storedForm.message || '',
+        messageHtml: storedForm.messageHtml || ''
+    }
+}) %>
+</script>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const form = document.querySelector('[data-campaign-form]');
+        if (!form) return;
+
+        const configElement = document.getElementById('campaign-config');
+        let config = { roles: [], roleLabels: {}, initialSegment: { logic: 'AND', rules: [] }, storedPreview: {} };
+        try {
+            if (configElement?.textContent) {
+                config = JSON.parse(configElement.textContent);
+            }
+        } catch (error) {
+            console.warn('Não foi possível carregar a configuração da campanha.', error);
+        }
+
+        const fieldSelect = form.querySelector('[data-segment-field]');
+        const operatorSelect = form.querySelector('[data-segment-operator]');
+        const valueContainer = form.querySelector('[data-segment-value]');
+        const addRuleButton = form.querySelector('[data-add-rule]');
+        const logicRadios = form.querySelectorAll('input[name="segmentLogic"]');
+        const summaryList = form.querySelector('[data-rules-summary]');
+        const logicBadge = form.querySelector('[data-logic-badge]');
+        const hiddenInput = form.querySelector('[data-segment-input]');
+
+        const previewSubject = form.querySelector('[data-preview-subject]');
+        const previewPreview = form.querySelector('[data-preview-preview]');
+        const previewBody = form.querySelector('[data-preview-body]');
+        const previewHeader = form.querySelector('[data-preview-header]');
+
+        const fieldConfig = {
+            role: {
+                label: 'Perfil do usuário',
+                operators: {
+                    in: { label: 'Está entre', type: 'multiselect', options: config.roles },
+                    notIn: { label: 'Não está entre', type: 'multiselect', options: config.roles }
+                }
+            },
+            active: {
+                label: 'Status',
+                operators: {
+                    eq: {
+                        label: 'É',
+                        type: 'select',
+                        options: [
+                            { value: true, label: 'Ativo' },
+                            { value: false, label: 'Inativo' }
+                        ]
+                    }
+                }
+            },
+            creditBalance: {
+                label: 'Crédito em conta',
+                operators: {
+                    gte: { label: 'Maior ou igual a', type: 'number' },
+                    lte: { label: 'Menor ou igual a', type: 'number' },
+                    between: { label: 'Entre valores', type: 'number-range' }
+                }
+            },
+            createdAt: {
+                label: 'Data de cadastro',
+                operators: {
+                    gte: { label: 'A partir de', type: 'date' },
+                    lte: { label: 'Até', type: 'date' },
+                    between: { label: 'Entre datas', type: 'date-range' }
+                }
+            },
+            emailDomain: {
+                label: 'Domínio do e-mail',
+                operators: {
+                    contains: { label: 'Termina com', type: 'text' },
+                    notContains: { label: 'Não termina com', type: 'text' }
+                }
+            }
+        };
+
+        let initialSegment = { logic: 'AND', rules: [] };
+        try {
+            if (config.initialSegment) {
+                initialSegment = typeof config.initialSegment === 'string'
+                    ? JSON.parse(config.initialSegment)
+                    : config.initialSegment;
+            }
+        } catch (error) {
+            initialSegment = { logic: 'AND', rules: [] };
+        }
+
+        const state = {
+            logic: initialSegment?.logic === 'OR' ? 'OR' : 'AND',
+            rules: Array.isArray(initialSegment?.rules) ? initialSegment.rules.slice(0, 20) : []
+        };
+
+        const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+            style: 'currency',
+            currency: 'BRL'
+        });
+
+        const renderOperatorOptions = () => {
+            const field = fieldSelect.value;
+            const operators = fieldConfig[field]?.operators || {};
+            operatorSelect.innerHTML = '';
+            Object.entries(operators).forEach(([value, meta], index) => {
+                const option = document.createElement('option');
+                option.value = value;
+                option.textContent = meta.label;
+                if (index === 0) {
+                    option.selected = true;
+                }
+                operatorSelect.appendChild(option);
+            });
+            renderValueInput();
+        };
+
+        const buildSelect = (options = [], multiple = false) => {
+            const select = document.createElement('select');
+            select.className = 'form-select';
+            if (multiple) {
+                select.multiple = true;
+            }
+            options.forEach((option) => {
+                const opt = document.createElement('option');
+                opt.value = option.value;
+                opt.textContent = option.label;
+                select.appendChild(opt);
+            });
+            return select;
+        };
+
+        const buildNumberInput = () => {
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.step = '0.01';
+            input.className = 'form-control';
+            input.placeholder = 'Ex.: 100.00';
+            return input;
+        };
+
+        const buildDateInput = () => {
+            const input = document.createElement('input');
+            input.type = 'date';
+            input.className = 'form-control';
+            return input;
+        };
+
+        const buildTextInput = () => {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'form-control';
+            input.placeholder = 'exemplo.com';
+            return input;
+        };
+
+        const renderValueInput = () => {
+            const field = fieldSelect.value;
+            const operator = operatorSelect.value;
+            const operatorMeta = fieldConfig[field]?.operators?.[operator];
+            valueContainer.innerHTML = '';
+
+            if (!operatorMeta) {
+                valueContainer.appendChild(buildTextInput());
+                return;
+            }
+
+            switch (operatorMeta.type) {
+                case 'multiselect':
+                    valueContainer.appendChild(buildSelect(operatorMeta.options || [], true));
+                    break;
+                case 'select':
+                    valueContainer.appendChild(buildSelect(operatorMeta.options || []));
+                    break;
+                case 'number':
+                    valueContainer.appendChild(buildNumberInput());
+                    break;
+                case 'number-range': {
+                    const row = document.createElement('div');
+                    row.className = 'row g-2';
+                    const startCol = document.createElement('div');
+                    startCol.className = 'col-6';
+                    const endCol = document.createElement('div');
+                    endCol.className = 'col-6';
+                    startCol.appendChild(buildNumberInput());
+                    endCol.appendChild(buildNumberInput());
+                    row.appendChild(startCol);
+                    row.appendChild(endCol);
+                    valueContainer.appendChild(row);
+                    break;
+                }
+                case 'date':
+                    valueContainer.appendChild(buildDateInput());
+                    break;
+                case 'date-range': {
+                    const row = document.createElement('div');
+                    row.className = 'row g-2';
+                    const startCol = document.createElement('div');
+                    startCol.className = 'col-6';
+                    const endCol = document.createElement('div');
+                    endCol.className = 'col-6';
+                    startCol.appendChild(buildDateInput());
+                    endCol.appendChild(buildDateInput());
+                    valueContainer.appendChild(row);
+                    row.appendChild(startCol);
+                    row.appendChild(endCol);
+                    break;
+                }
+                default:
+                    valueContainer.appendChild(buildTextInput());
+            }
+        };
+
+        const collectValue = () => {
+            const field = fieldSelect.value;
+            const operator = operatorSelect.value;
+            const operatorMeta = fieldConfig[field]?.operators?.[operator];
+            if (!operatorMeta) return null;
+
+            const inputElement = valueContainer.querySelector('input, select');
+            if (!inputElement) return null;
+
+            switch (operatorMeta.type) {
+                case 'multiselect': {
+                    const values = Array.from(valueContainer.querySelectorAll('option:checked')).map((opt) => opt.value);
+                    return values;
+                }
+                case 'select':
+                    return inputElement.value;
+                case 'number': {
+                    const value = inputElement.value.trim();
+                    if (!value) return null;
+                    return parseFloat(value);
+                }
+                case 'number-range': {
+                    const inputs = valueContainer.querySelectorAll('input');
+                    const start = inputs[0]?.value.trim();
+                    const end = inputs[1]?.value.trim();
+                    if (!start || !end) return null;
+                    return [parseFloat(start), parseFloat(end)];
+                }
+                case 'date':
+                    return inputElement.value || null;
+                case 'date-range': {
+                    const inputs = valueContainer.querySelectorAll('input');
+                    const start = inputs[0]?.value;
+                    const end = inputs[1]?.value;
+                    if (!start || !end) return null;
+                    return [start, end];
+                }
+                default:
+                    return inputElement.value.trim() || null;
+            }
+        };
+
+        const describeRule = (rule) => {
+            const fieldMeta = fieldConfig[rule.field];
+            if (!fieldMeta) return '';
+            const operatorMeta = fieldMeta.operators?.[rule.operator];
+            const label = fieldMeta.label || rule.field;
+
+            switch (rule.field) {
+                case 'role': {
+                    const values = (Array.isArray(rule.value) ? rule.value : [rule.value])
+                        .map((value) => config.roleLabels?.[value] || value)
+                        .join(', ');
+                    return `${label} ${rule.operator === 'notIn' ? 'não inclui' : 'inclui'} ${values}`;
+                }
+                case 'active':
+                    return rule.value ? 'Somente usuários ativos' : 'Incluir usuários inativos';
+                case 'creditBalance':
+                    if (Array.isArray(rule.value)) {
+                        return `${label} entre ${currencyFormatter.format(rule.value[0] || 0)} e ${currencyFormatter.format(rule.value[1] || 0)}`;
+                    }
+                    return `${label} ${operatorMeta?.label.toLowerCase() || ''} ${currencyFormatter.format(rule.value || 0)}`;
+                case 'createdAt':
+                    if (Array.isArray(rule.value)) {
+                        return `${label} entre ${rule.value[0]} e ${rule.value[1]}`;
+                    }
+                    return `${label} ${operatorMeta?.label.toLowerCase() || ''} ${rule.value}`;
+                case 'emailDomain':
+                    return `${label} ${operatorMeta?.label.toLowerCase() || ''} @${rule.value}`;
+                default:
+                    return `${label}`;
+            }
+        };
+
+        const syncHiddenInput = () => {
+            hiddenInput.value = JSON.stringify(state);
+        };
+
+        const renderSummary = () => {
+            summaryList.innerHTML = '';
+            const activeRule = state.rules.some((rule) => rule.field === 'active');
+            if (!activeRule) {
+                const item = document.createElement('li');
+                item.textContent = 'Somente usuários ativos';
+                summaryList.appendChild(item);
+            }
+
+            if (!state.rules.length) {
+                const item = document.createElement('li');
+                item.className = 'text-muted';
+                item.textContent = 'Nenhum filtro definido. Todos os usuários ativos com e-mail válido serão considerados.';
+                summaryList.appendChild(item);
+            } else {
+                state.rules.forEach((rule, index) => {
+                    const item = document.createElement('li');
+                    item.className = 'd-flex justify-content-between align-items-center gap-2 mb-1';
+                    const description = document.createElement('span');
+                    description.textContent = describeRule(rule);
+                    const removeBtn = document.createElement('button');
+                    removeBtn.type = 'button';
+                    removeBtn.className = 'btn btn-sm btn-outline-danger';
+                    removeBtn.innerHTML = '<i class="bi bi-x-lg"></i>';
+                    removeBtn.addEventListener('click', () => {
+                        state.rules.splice(index, 1);
+                        renderSummary();
+                        syncHiddenInput();
+                    });
+                    item.appendChild(description);
+                    item.appendChild(removeBtn);
+                    summaryList.appendChild(item);
+                });
+            }
+
+            logicBadge.textContent = state.logic === 'OR' ? 'Combinação OR' : 'Combinação AND';
+            logicBadge.className = state.logic === 'OR' ? 'badge bg-soft-warning' : 'badge bg-soft-primary';
+        };
+
+        addRuleButton.addEventListener('click', () => {
+            const field = fieldSelect.value;
+            const operator = operatorSelect.value;
+            const value = collectValue();
+            if (value === null || value === undefined || (Array.isArray(value) && !value.length)) {
+                valueContainer.classList.add('border', 'border-danger');
+                setTimeout(() => valueContainer.classList.remove('border', 'border-danger'), 2000);
+                return;
+            }
+            valueContainer.classList.remove('border', 'border-danger');
+            state.rules.push({ field, operator, value });
+            renderSummary();
+            syncHiddenInput();
+        });
+
+        logicRadios.forEach((radio) => {
+            radio.checked = radio.value === state.logic;
+            radio.addEventListener('change', () => {
+                if (radio.checked) {
+                    state.logic = radio.value;
+                    syncHiddenInput();
+                    renderSummary();
+                }
+            });
+        });
+
+        fieldSelect.addEventListener('change', renderOperatorOptions);
+        operatorSelect.addEventListener('change', renderValueInput);
+
+        renderOperatorOptions();
+        syncHiddenInput();
+        renderSummary();
+
+        const subjectInput = form.querySelector('input[name="title"]');
+        const previewInput = form.querySelector('input[name="previewText"]');
+        const accentInput = form.querySelector('input[name="accentColor"]');
+        const messageInput = form.querySelector('textarea[name="message"]');
+        const messageHtmlInput = form.querySelector('textarea[name="messageHtml"]');
+
+        const updatePreview = () => {
+            const subject = subjectInput.value.trim() || 'Assunto da campanha';
+            const previewText = previewInput.value.trim() || 'Prévia exibida na caixa de entrada';
+            const accent = accentInput.value || '#0d6efd';
+            const htmlContent = messageHtmlInput.value.trim();
+            const textContent = messageInput.value.trim();
+            const body = htmlContent || (textContent ? textContent.replace(/\n/g, '<br />') : '');
+
+            previewSubject.textContent = subject;
+            previewPreview.textContent = previewText;
+            previewHeader.style.borderLeft = `4px solid ${accent}`;
+            if (body) {
+                previewBody.innerHTML = body;
+            } else {
+                previewBody.innerHTML = '<em>Escreva uma mensagem para visualizar como seus usuários receberão.</em>';
+            }
+        };
+
+        subjectInput.addEventListener('input', updatePreview);
+        previewInput.addEventListener('input', updatePreview);
+        accentInput.addEventListener('input', updatePreview);
+        messageInput.addEventListener('input', updatePreview);
+        messageHtmlInput.addEventListener('input', updatePreview);
+
+        if (config.storedPreview) {
+            subjectInput.value = config.storedPreview.title || subjectInput.value;
+            previewInput.value = config.storedPreview.preview || previewInput.value;
+            accentInput.value = config.storedPreview.accentColor || accentInput.value;
+            messageInput.value = config.storedPreview.message || messageInput.value;
+            messageHtmlInput.value = config.storedPreview.messageHtml || messageHtmlInput.value;
+        }
+
+        updatePreview();
+    });
+</script>
+
+<%- include('../partials/footer') %>

--- a/src/views/campaigns/manage.ejs
+++ b/src/views/campaigns/manage.ejs
@@ -1,0 +1,259 @@
+<%- include('../partials/header') %>
+
+<%
+    const currentFilters = filters || {};
+    const statusOptionsList = statusOptions || [];
+    const statusBadge = {
+        draft: 'badge-soft-secondary',
+        scheduled: 'badge-soft-info',
+        queued: 'badge-soft-primary',
+        sending: 'badge-soft-warning',
+        sent: 'badge-soft-success',
+        failed: 'badge-soft-danger',
+        cancelled: 'badge-soft-dark'
+    };
+    function formatDateTime(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        return date.toLocaleString('pt-BR');
+    }
+    function formatDateInput(value) {
+        if (!value) return '';
+        if (/^\d{4}-\d{2}-\d{2}/.test(value)) return value.slice(0, 10);
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        const pad = (num) => String(num).padStart(2, '0');
+        return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+    }
+    function formatDateTimeLocal(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        const pad = (num) => String(num).padStart(2, '0');
+        return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+    }
+%>
+
+<div class="row gy-4 fade-in">
+    <div class="col-12">
+        <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+            <div>
+                <h2 class="fw-semibold mb-1">Campanhas automatizadas</h2>
+                <p class="text-muted mb-0">Acompanhe agendamentos, status e alcance das campanhas enviadas aos usuários.</p>
+            </div>
+            <a href="/campaigns/create" class="btn btn-gradient"><i class="bi bi-plus-lg me-2"></i>Nova campanha</a>
+        </div>
+
+        <% if (success_msg) { %>
+            <div class="alert alert-success alert-auto" data-auto-dismiss="5000">
+                <i class="bi bi-check-circle me-2"></i><%= success_msg %>
+            </div>
+        <% } else if (error_msg) { %>
+            <div class="alert alert-danger alert-auto" data-auto-dismiss="5000">
+                <i class="bi bi-exclamation-triangle me-2"></i><%= error_msg %>
+            </div>
+        <% } %>
+
+        <div class="card card-soft p-4 mb-4">
+            <form action="/campaigns" method="GET" class="row g-3 align-items-end" data-filter-form>
+                <div class="col-lg-4 col-md-6">
+                    <label class="form-label">Palavra-chave</label>
+                    <div class="input-group input-group-flat">
+                        <span class="input-group-text bg-transparent border-end-0 text-muted">
+                            <i class="bi bi-search"></i>
+                        </span>
+                        <input
+                            type="text"
+                            class="form-control border-start-0"
+                            name="keyword"
+                            maxlength="120"
+                            placeholder="Busque por título, mensagem ou ID"
+                            value="<%= currentFilters.keyword || '' %>"
+                        />
+                    </div>
+                </div>
+                <div class="col-lg-3 col-md-6">
+                    <label class="form-label">Status</label>
+                    <select class="form-select" name="status">
+                        <option value="all" <%= (currentFilters.status || 'all') === 'all' ? 'selected' : '' %>>Todos</option>
+                        <% statusOptionsList.forEach(option => { %>
+                            <option value="<%= option.value %>" <%= currentFilters.status === option.value ? 'selected' : '' %>>
+                                <%= option.label %>
+                            </option>
+                        <% }) %>
+                    </select>
+                </div>
+                <div class="col-lg-2 col-md-6">
+                    <label class="form-label">Agendadas a partir de</label>
+                    <input
+                        type="date"
+                        class="form-control"
+                        name="startDate"
+                        value="<%= formatDateInput(currentFilters.startDate) %>"
+                        max="<%= formatDateInput(currentFilters.endDate) %>"
+                    />
+                </div>
+                <div class="col-lg-2 col-md-6">
+                    <label class="form-label">Até</label>
+                    <input
+                        type="date"
+                        class="form-control"
+                        name="endDate"
+                        value="<%= formatDateInput(currentFilters.endDate) %>"
+                        min="<%= formatDateInput(currentFilters.startDate) %>"
+                    />
+                </div>
+                <div class="col-lg-1 col-md-12 d-flex gap-2">
+                    <button type="submit" class="btn btn-gradient flex-grow-1" data-submit-filters>
+                        <i class="bi bi-funnel me-2"></i>Filtrar
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary" data-reset-filters>
+                        <i class="bi bi-x-lg"></i>
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <div class="card card-soft p-4">
+            <div class="table-responsive table-modern">
+                <table class="table align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Campanha</th>
+                            <th>Status</th>
+                            <th>Programação</th>
+                            <th>Estimativa</th>
+                            <th>Segmentação</th>
+                            <th class="text-end">Ações</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <% if (!campaigns || !campaigns.length) { %>
+                            <tr>
+                                <td colspan="7" class="text-center py-5 text-muted">Nenhuma campanha encontrada com os filtros atuais.</td>
+                            </tr>
+                        <% } %>
+                        <% campaigns.forEach((campaign) => { %>
+                            <tr>
+                                <td><strong><%= campaign.id %></strong></td>
+                                <td>
+                                    <div class="fw-semibold"><%= campaign.title %></div>
+                                    <small class="text-muted d-block text-truncate" style="max-width: 360px;">
+                                        <%= campaign.previewText || campaign.message %>
+                                    </small>
+                                    <small class="text-muted">Atualizado em <%= formatDateTime(campaign.updatedAt || campaign.createdAt) %></small>
+                                </td>
+                                <td>
+                                    <span class="badge <%= statusBadge[campaign.status] || 'badge-soft-secondary' %>"><%= campaign.statusLabel %></span>
+                                </td>
+                                <td>
+                                    <% if (campaign.scheduledAt) { %>
+                                        <i class="bi bi-clock-history me-2"></i><%= formatDateTime(campaign.scheduledAt) %>
+                                    <% } else { %>
+                                        <span class="text-muted">Sem agendamento</span>
+                                    <% } %>
+                                </td>
+                                <td>
+                                    <% if (Number.isFinite(campaign.recipientEstimate)) { %>
+                                        <span class="badge bg-soft-primary">~ <%= campaign.recipientEstimate %> destinatários</span>
+                                    <% } else { %>
+                                        <span class="text-muted">Indefinido</span>
+                                    <% } %>
+                                </td>
+                                <td>
+                                    <% if (campaign.segmentSummary && campaign.segmentSummary.length) { %>
+                                        <% campaign.segmentSummary.forEach((summary) => { %>
+                                            <span class="app-filter-tag mb-1"><i class="bi bi-funnel me-2"></i><%= summary %></span>
+                                        <% }); %>
+                                    <% } else { %>
+                                        <span class="app-filter-tag"><i class="bi bi-funnel me-2"></i>Base ativa completa</span>
+                                    <% } %>
+                                </td>
+                                <td class="text-end">
+                                    <form
+                                        action="/campaigns/<%= campaign.id %>/queue"
+                                        method="POST"
+                                        class="d-flex flex-wrap align-items-center justify-content-end gap-2"
+                                    >
+                                        <input
+                                            type="datetime-local"
+                                            name="scheduledAt"
+                                            class="form-control form-control-sm"
+                                            style="max-width: 210px;"
+                                            value="<%= formatDateTimeLocal(campaign.scheduledAt || new Date()) %>"
+                                        />
+                                        <div class="btn-group">
+                                            <button type="submit" class="btn btn-sm btn-outline-primary">Fila</button>
+                                            <button type="submit" class="btn btn-sm btn-primary" name="dispatchNow" value="true">Fila e enviar</button>
+                                        </div>
+                                    </form>
+                                    <form
+                                        action="/campaigns/<%= campaign.id %>/dispatch"
+                                        method="POST"
+                                        class="d-inline"
+                                    >
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary mt-2"><i class="bi bi-send"></i> Enviar agora</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        <% }) %>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const filterForms = document.querySelectorAll('[data-filter-form]');
+
+        const buildQueryFromForm = (form) => {
+            const params = new URLSearchParams();
+            const fields = form.querySelectorAll('input[name], select[name], textarea[name]');
+            fields.forEach((field) => {
+                const value = typeof field.value === 'string' ? field.value.trim() : field.value;
+                if (value) {
+                    params.append(field.name, value);
+                }
+            });
+            return params.toString();
+        };
+
+        filterForms.forEach((form) => {
+            const action = form.getAttribute('action');
+
+            const submitFilters = () => {
+                const queryString = buildQueryFromForm(form);
+                const targetUrl = queryString ? `${action}?${queryString}` : action;
+                window.location.assign(targetUrl);
+            };
+
+            form.addEventListener('submit', (event) => {
+                event.preventDefault();
+                submitFilters();
+            });
+
+            const submitButton = form.querySelector('[data-submit-filters]');
+            if (submitButton) {
+                submitButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    submitFilters();
+                });
+            }
+
+            const resetButton = form.querySelector('[data-reset-filters]');
+            if (resetButton) {
+                resetButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    form.reset();
+                    window.location.assign(action);
+                });
+            }
+        });
+    });
+</script>
+
+<%- include('../partials/footer') %>


### PR DESCRIPTION
## Summary
- extend the notification model with scheduling metadata and segment filters to support campaigns
- add campaign service, controller, routes, and views with live preview and segmentation builder
- enhance email utilities with rate-limited bulk sending and expose campaign management entry points in the server

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c992d15868832fa3068b89b79507f1