### PR TITLE
Add scheduledAt column migration for notifications

### DIFF
--- a/database/migrations/20240908-add-scheduled-at-to-notifications.js
+++ b/database/migrations/20240908-add-scheduled-at-to-notifications.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Notifications', 'scheduledAt', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+
+    const rawDialect = queryInterface.sequelize?.getDialect?.() || queryInterface.sequelize?.dialect?.name;
+    const normalizedDialect = typeof rawDialect === 'string' ? rawDialect.toLowerCase() : '';
+    if (normalizedDialect === 'postgres' || normalizedDialect === 'postgresql') {
+      await queryInterface.sequelize.query(`
+        UPDATE "Notifications"
+        SET "scheduledAt" = "triggerDate"
+        WHERE "triggerDate" IS NOT NULL
+          AND ("scheduledAt" IS NULL OR "scheduledAt" = "triggerDate");
+      `);
+    }
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Notifications', 'scheduledAt');
+  },
+};

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -14,6 +14,7 @@ const queryInterface = sequelize.getQueryInterface();
 const migrations = [
   require('../database/migrations/20240906-add-credit-balance-to-users'),
   require('../database/migrations/20240907-add-message-html-to-notifications'),
+  require('../database/migrations/20240908-add-scheduled-at-to-notifications'),
 ];
 
 (async () => {
@@ -83,7 +84,19 @@ const migrations = [
       throw new Error('Coluna "messageHtml" não encontrada na tabela Notifications.');
     }
 
-    console.log('Verificação das colunas creditBalance e messageHtml concluída com sucesso.');
+    if (notificationsTable.messageHtml.allowNull !== true) {
+      throw new Error('Coluna "messageHtml" deveria permitir valores nulos.');
+    }
+
+    if (!notificationsTable.scheduledAt) {
+      throw new Error('Coluna "scheduledAt" não encontrada na tabela Notifications.');
+    }
+
+    if (notificationsTable.scheduledAt.allowNull !== true) {
+      throw new Error('Coluna "scheduledAt" deveria permitir valores nulos.');
+    }
+
+    console.log('Verificação das colunas creditBalance, messageHtml e scheduledAt concluída com sucesso.');
   } catch (error) {
     console.error('Teste de schema falhou:', error);
     process.exitCode = 1;


### PR DESCRIPTION
## Summary
- add a migration that introduces a nullable `scheduledAt` column on Notifications and backfills it from `triggerDate` when running on Postgres
- extend the schema test to cover the new migration and assert the expected nullability for `messageHtml` and `scheduledAt`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a36aecf0832f95afa8cac0f1de63