### PR TITLE
Convert user roles column to enum strings

### DIFF
--- a/database/migrations/20240908-convert-user-role-to-enum.js
+++ b/database/migrations/20240908-convert-user-role-to-enum.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const { ROLE_ORDER } = require('../../src/constants/roles');
+
+const DEFAULT_ROLE = ROLE_ORDER[0];
+const ENUM_TYPE_NAME = 'user_role_enum';
+
+const escapeLiteral = (value) => String(value).replace(/'/g, "''");
+
+const buildPostgresEnumValues = () => ROLE_ORDER
+    .map((role) => `'${escapeLiteral(role)}'`)
+    .join(', ');
+
+const buildPostgresUsingExpression = () => {
+    const stringMatches = ROLE_ORDER
+        .map((role) => `'${escapeLiteral(role)}'`)
+        .join(', ');
+
+    const numericCases = ROLE_ORDER
+        .map((role, index) => `            WHEN role::text = '${index}' THEN '${escapeLiteral(role)}'`)
+        .join('\n');
+
+    const numericBlock = numericCases ? `\n${numericCases}` : '';
+
+    return `(
+        CASE
+            WHEN role IS NULL OR trim(role::text) = '' THEN '${escapeLiteral(DEFAULT_ROLE)}'
+            WHEN role::text IN (${stringMatches}) THEN role::text${numericBlock}
+            ELSE '${escapeLiteral(DEFAULT_ROLE)}'
+        END
+    )::${ENUM_TYPE_NAME}`;
+};
+
+const buildPostgresRevertExpression = () => {
+    const cases = ROLE_ORDER
+        .map((role, index) => `            WHEN role::text = '${escapeLiteral(role)}' THEN ${index}`)
+        .join('\n');
+
+    const caseBlock = cases ? `\n${cases}` : '';
+
+    return `(
+        CASE${caseBlock}
+            ELSE 0
+        END
+    )::INTEGER`;
+};
+
+const buildSqliteUpdateToStrings = () => {
+    const numericCases = ROLE_ORDER
+        .map((role, index) => `            WHEN CAST(role AS TEXT) = '${index}' THEN '${escapeLiteral(role)}'`)
+        .join('\n');
+
+    const stringMatches = ROLE_ORDER
+        .map((role) => `'${escapeLiteral(role)}'`)
+        .join(', ');
+
+    const numericBlock = numericCases ? `\n${numericCases}` : '';
+
+    return `UPDATE "Users"
+SET role = CASE
+            WHEN role IS NULL OR trim(CAST(role AS TEXT)) = '' THEN '${escapeLiteral(DEFAULT_ROLE)}'
+            WHEN CAST(role AS TEXT) IN (${stringMatches}) THEN CAST(role AS TEXT)${numericBlock}
+            ELSE '${escapeLiteral(DEFAULT_ROLE)}'
+        END;`;
+};
+
+const buildSqliteUpdateToNumbers = () => {
+    const cases = ROLE_ORDER
+        .map((role, index) => `            WHEN CAST(role AS TEXT) = '${escapeLiteral(role)}' THEN ${index}`)
+        .join('\n');
+
+    const caseBlock = cases ? `\n${cases}` : '';
+
+    return `UPDATE "Users"
+SET role = CASE${caseBlock}
+            ELSE 0
+        END;`;
+};
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const dialect = queryInterface.sequelize.getDialect();
+
+        if (dialect === 'postgres') {
+            await queryInterface.sequelize.transaction(async (transaction) => {
+                await queryInterface.sequelize.query(
+                    `DO $$
+                    BEGIN
+                        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = '${escapeLiteral(ENUM_TYPE_NAME)}') THEN
+                            CREATE TYPE ${ENUM_TYPE_NAME} AS ENUM (${buildPostgresEnumValues()});
+                        END IF;
+                    END$$;`,
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    'ALTER TABLE "Users" ALTER COLUMN "role" DROP DEFAULT;',
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    `ALTER TABLE "Users" ALTER COLUMN "role" TYPE ${ENUM_TYPE_NAME} USING ${buildPostgresUsingExpression()};`,
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    `UPDATE "Users" SET "role" = '${escapeLiteral(DEFAULT_ROLE)}'::${ENUM_TYPE_NAME} WHERE "role" IS NULL;`,
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    `ALTER TABLE "Users" ALTER COLUMN "role" SET DEFAULT '${escapeLiteral(DEFAULT_ROLE)}'::${ENUM_TYPE_NAME};`,
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    'ALTER TABLE "Users" ALTER COLUMN "role" SET NOT NULL;',
+                    { transaction }
+                );
+            });
+            return;
+        }
+
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.sequelize.query(
+                buildSqliteUpdateToStrings(),
+                { transaction }
+            );
+
+            await queryInterface.changeColumn(
+                'Users',
+                'role',
+                {
+                    type: Sequelize.STRING(32),
+                    allowNull: false,
+                    defaultValue: DEFAULT_ROLE,
+                },
+                { transaction }
+            );
+        });
+    },
+
+    async down(queryInterface, Sequelize) {
+        const dialect = queryInterface.sequelize.getDialect();
+
+        if (dialect === 'postgres') {
+            await queryInterface.sequelize.transaction(async (transaction) => {
+                await queryInterface.sequelize.query(
+                    'ALTER TABLE "Users" ALTER COLUMN "role" DROP DEFAULT;',
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    `ALTER TABLE "Users" ALTER COLUMN "role" TYPE INTEGER USING ${buildPostgresRevertExpression()};`,
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    'UPDATE "Users" SET "role" = 0 WHERE "role" IS NULL;',
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    'ALTER TABLE "Users" ALTER COLUMN "role" SET DEFAULT 0;',
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    'ALTER TABLE "Users" ALTER COLUMN "role" SET NOT NULL;',
+                    { transaction }
+                );
+
+                await queryInterface.sequelize.query(
+                    `DROP TYPE IF EXISTS ${ENUM_TYPE_NAME};`,
+                    { transaction }
+                );
+            });
+            return;
+        }
+
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.sequelize.query(
+                buildSqliteUpdateToNumbers(),
+                { transaction }
+            );
+
+            await queryInterface.changeColumn(
+                'Users',
+                'role',
+                {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    defaultValue: 0,
+                },
+                { transaction }
+            );
+        });
+    },
+};

--- a/src/controllers/appointmentController.js
+++ b/src/controllers/appointmentController.js
@@ -2,6 +2,13 @@
 const { Appointment, User, Room, Procedure } = require('../../database/models');
 const { Op } = require('sequelize');
 const { buildQueryFilters } = require('../utils/queryBuilder');
+const { USER_ROLES } = require('../constants/roles');
+
+const PROFESSIONAL_ROLES = [
+    USER_ROLES.SPECIALIST,
+    USER_ROLES.MANAGER,
+    USER_ROLES.ADMIN
+];
 
 
 module.exports = {

--- a/src/routes/appointmentRoutes.js
+++ b/src/routes/appointmentRoutes.js
@@ -5,33 +5,34 @@ const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const authorize = require('../middlewares/authorize');
 const { createFilterValidation } = require('../middlewares/queryValidationMiddleware');
+const { USER_ROLES } = require('../constants/roles');
 
 const appointmentFiltersValidation = createFilterValidation({
     allowedStatuses: ['scheduled', 'completed', 'cancelled', 'no-show', 'pending-confirmation'],
     redirectTo: '/appointments'
 });
 
-// role >= 2 para listar/criar
+// Especialistas (ou níveis superiores) podem listar/criar
 router.get(
     '/',
     authMiddleware,
-    permissionMiddleware(2),
+    permissionMiddleware(USER_ROLES.SPECIALIST),
     ...appointmentFiltersValidation,
     appointmentController.listAppointments
 );
 
 // nova rota p/ tela de criar
-router.get('/create', authMiddleware, authorize('specialist'), appointmentController.showCreate);
-router.post('/create', authMiddleware, authorize('specialist'), appointmentController.createAppointment);
+router.get('/create', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.showCreate);
+router.post('/create', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.createAppointment);
 
 // rota p/ tela de edição
-router.get('/edit/:id', authMiddleware, authorize('specialist'), appointmentController.showEdit);
-router.put('/update/:id', authMiddleware, authorize('specialist'), appointmentController.updateAppointment);
+router.get('/edit/:id', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.showEdit);
+router.put('/update/:id', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.updateAppointment);
 
-router.delete('/delete/:id', authMiddleware, authorize('specialist'), appointmentController.deleteAppointment);
+router.delete('/delete/:id', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.deleteAppointment);
 
 // Calendário gigante
-router.get('/calendar', authMiddleware, authorize('specialist'), appointmentController.showCalendar);
-router.get('/api/events', authMiddleware, authorize('specialist'), appointmentController.apiEvents);
+router.get('/calendar', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.showCalendar);
+router.get('/api/events', authMiddleware, authorize(USER_ROLES.SPECIALIST), appointmentController.apiEvents);
 
 module.exports = router;

--- a/src/routes/auditRoutes.js
+++ b/src/routes/auditRoutes.js
@@ -4,11 +4,12 @@ const router = express.Router();
 const auditController = require('../controllers/auditController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
+const { USER_ROLES } = require('../constants/roles');
 
 router.get(
     '/logs',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     auditController.listLogs
 );
 

--- a/src/routes/campaignRoutes.js
+++ b/src/routes/campaignRoutes.js
@@ -4,6 +4,7 @@ const campaignController = require('../controllers/campaignController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const { createFilterValidation } = require('../middlewares/queryValidationMiddleware');
+const { USER_ROLES } = require('../constants/roles');
 
 const campaignFiltersValidation = createFilterValidation({
     allowedStatuses: ['draft', 'scheduled', 'queued', 'sending', 'sent', 'failed', 'cancelled'],
@@ -13,15 +14,15 @@ const campaignFiltersValidation = createFilterValidation({
 router.get(
     '/',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     ...campaignFiltersValidation,
     campaignController.listCampaigns
 );
 
-router.get('/create', authMiddleware, permissionMiddleware(4), campaignController.showCreate);
-router.post('/', authMiddleware, permissionMiddleware(4), campaignController.createCampaign);
-router.post('/:id/queue', authMiddleware, permissionMiddleware(4), campaignController.queueCampaign);
-router.post('/:id/dispatch', authMiddleware, permissionMiddleware(4), campaignController.dispatchCampaign);
-router.post('/dispatch/pending', authMiddleware, permissionMiddleware(4), campaignController.dispatchPending);
+router.get('/create', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), campaignController.showCreate);
+router.post('/', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), campaignController.createCampaign);
+router.post('/:id/queue', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), campaignController.queueCampaign);
+router.post('/:id/dispatch', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), campaignController.dispatchCampaign);
+router.post('/dispatch/pending', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), campaignController.dispatchPending);
 
 module.exports = router;

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -4,27 +4,28 @@ const financeController = require('../controllers/financeController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const audit = require('../middlewares/audit');
+const { USER_ROLES } = require('../constants/roles');
 
-// Geralmente admin ou financeiro teria role >= 3 ou 4
-router.get('/', authMiddleware, permissionMiddleware(4), financeController.listFinanceEntries);
+// Apenas administradores podem gerenciar finanças
+router.get('/', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), financeController.listFinanceEntries);
 router.post(
     '/create',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     audit('financeEntry.create', (req) => `FinanceEntry:${req.body?.description || 'novo'}`),
     financeController.createFinanceEntry
 );
 router.put(
     '/update/:id',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     audit('financeEntry.update', (req) => `FinanceEntry:${req.params.id}`),
     financeController.updateFinanceEntry
 );
 router.delete(
     '/delete/:id',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     audit('financeEntry.delete', (req) => `FinanceEntry:${req.params.id}`),
     financeController.deleteFinanceEntry
 );

--- a/src/routes/notificationRoutes.js
+++ b/src/routes/notificationRoutes.js
@@ -5,26 +5,27 @@ const notificationController = require('../controllers/notificationController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const { createFilterValidation } = require('../middlewares/queryValidationMiddleware');
+const { USER_ROLES } = require('../constants/roles');
 
 const notificationFiltersValidation = createFilterValidation({
     allowedStatuses: ['active', 'inactive'],
     redirectTo: '/notifications'
 });
 
-// Supondo que apenas admin (role >= 4) possa gerenciar notificações
+// Apenas administradores podem gerenciar notificações
 router.get(
     '/',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     ...notificationFiltersValidation,
     notificationController.listNotifications
 );
-router.get('/create', authMiddleware, permissionMiddleware(4), notificationController.showCreate);
-router.post('/create', authMiddleware, permissionMiddleware(4), notificationController.createNotification);
+router.get('/create', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), notificationController.showCreate);
+router.post('/create', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), notificationController.createNotification);
 
-router.get('/edit/:id', authMiddleware, permissionMiddleware(4), notificationController.showEdit);
-router.put('/update/:id', authMiddleware, permissionMiddleware(4), notificationController.updateNotification);
+router.get('/edit/:id', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), notificationController.showEdit);
+router.put('/update/:id', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), notificationController.updateNotification);
 
-router.delete('/delete/:id', authMiddleware, permissionMiddleware(4), notificationController.deleteNotification);
+router.delete('/delete/:id', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), notificationController.deleteNotification);
 
 module.exports = router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -8,6 +8,7 @@ const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const upload = require('../middlewares/uploadMiddleware');
 const audit = require('../middlewares/audit');
 const { createFilterValidation } = require('../middlewares/queryValidationMiddleware');
+const { USER_ROLES } = require('../constants/roles');
 
 
 const manageUsersValidation = createFilterValidation({
@@ -15,11 +16,11 @@ const manageUsersValidation = createFilterValidation({
     redirectTo: '/users/manage'
 });
 
-// Todas as rotas de gerenciamento de usuários requerem login e permissão >= 4
+// Todas as rotas de gerenciamento de usuários requerem login e perfil de administrador
 router.get(
     '/manage',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     ...manageUsersValidation,
     userController.manageUsers
 );
@@ -29,7 +30,7 @@ router.get(
 router.post(
     '/create',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     upload.single('profileImage'),
     audit('user.create', (req) => `User:${req.body?.email || 'novo'}`),
     userController.createUser
@@ -38,7 +39,7 @@ router.post(
 router.put(
     '/update/:id',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     upload.single('profileImage'),
     audit('user.update', (req) => `User:${req.params.id}`),
     userController.updateUser
@@ -47,7 +48,7 @@ router.put(
 router.delete(
     '/delete/:id',
     authMiddleware,
-    permissionMiddleware(4),
+    permissionMiddleware(USER_ROLES.ADMIN),
     audit('user.delete', (req) => `User:${req.params.id}`),
     userController.deleteUser
 );

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -7,6 +7,9 @@ process.env.DB_STORAGE = process.env.DB_STORAGE || ':memory:';
 
 const Sequelize = require('sequelize');
 const { sequelize } = require('../database/models');
+const { ROLE_ORDER } = require('../src/constants/roles');
+
+const DEFAULT_ROLE = ROLE_ORDER[0];
 
 const { DataTypes } = Sequelize;
 const queryInterface = sequelize.getQueryInterface();
@@ -14,6 +17,7 @@ const queryInterface = sequelize.getQueryInterface();
 const migrations = [
   require('../database/migrations/20240906-add-credit-balance-to-users'),
   require('../database/migrations/20240907-add-message-html-to-notifications'),
+  require('../database/migrations/20240908-convert-user-role-to-enum'),
 ];
 
 (async () => {
@@ -28,6 +32,11 @@ const migrations = [
         type: DataTypes.STRING,
         allowNull: true,
       },
+      role: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 0,
+      },
       createdAt: {
         type: DataTypes.DATE,
         allowNull: true,
@@ -37,6 +46,13 @@ const migrations = [
         allowNull: true,
       },
     });
+
+    const now = new Date();
+    await queryInterface.bulkInsert('Users', [
+      { name: 'Cliente Base', role: 0, createdAt: now, updatedAt: now },
+      { name: 'Colaborador Base', role: 1, createdAt: now, updatedAt: now },
+      { name: 'Especialista Base', role: 2, createdAt: now, updatedAt: now },
+    ]);
 
     await queryInterface.createTable('Notifications', {
       id: {
@@ -50,6 +66,10 @@ const migrations = [
       },
       message: {
         type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      scheduledAt: {
+        type: DataTypes.DATE,
         allowNull: true,
       },
       createdAt: {
@@ -71,6 +91,38 @@ const migrations = [
     const usersTable = await queryInterface.describeTable('Users');
     const notificationsTable = await queryInterface.describeTable('Notifications');
 
+    if (!usersTable.role) {
+      throw new Error('Coluna "role" não encontrada na tabela Users após migração.');
+    }
+
+    const roleType = (usersTable.role.type || '').toLowerCase();
+    if (roleType.includes('int')) {
+      throw new Error('Coluna "role" deveria ter sido convertida para enum/string.');
+    }
+
+    if (usersTable.role.allowNull) {
+      throw new Error('Coluna "role" deveria ser NOT NULL.');
+    }
+
+    const rawDefault = usersTable.role.defaultValue;
+    const normalizedDefault = typeof rawDefault === 'string'
+      ? rawDefault.replace(/['"`]/g, '')
+      : rawDefault;
+
+    if (normalizedDefault !== DEFAULT_ROLE) {
+      throw new Error(`Valor padrão da coluna "role" deveria ser "${DEFAULT_ROLE}".`);
+    }
+
+    const [roleRows] = await sequelize.query('SELECT role FROM Users ORDER BY id');
+    const roleValues = roleRows.map((row) => row.role);
+
+    const expectedRoles = ROLE_ORDER.slice(0, roleValues.length);
+    expectedRoles.forEach((expected, index) => {
+      if (roleValues[index] !== expected) {
+        throw new Error(`Valor da coluna "role" no registro ${index + 1} deveria ser "${expected}", mas foi "${roleValues[index]}".`);
+      }
+    });
+
     if (!usersTable.creditBalance) {
       throw new Error('Coluna "creditBalance" não encontrada na tabela Users.');
     }
@@ -83,7 +135,11 @@ const migrations = [
       throw new Error('Coluna "messageHtml" não encontrada na tabela Notifications.');
     }
 
-    console.log('Verificação das colunas creditBalance e messageHtml concluída com sucesso.');
+    if (!notificationsTable.scheduledAt) {
+      throw new Error('Coluna "scheduledAt" não encontrada na tabela Notifications.');
+    }
+
+    console.log('Verificação das colunas creditBalance, messageHtml e scheduledAt concluída com sucesso.');
   } catch (error) {
     console.error('Teste de schema falhou:', error);
     process.exitCode = 1;


### PR DESCRIPTION
## Summary
- add a migration that creates the user role enum, migrates integer values to string tokens, and provides a down path back to integers
- extend the schema test to exercise the migration with seeded integer roles and assert defaults/values, plus update role-aware middleware and professional filters to use the exported constants
- switch secured routes to reference USER_ROLES instead of numeric thresholds so the app consistently works with string roles
- update the schema regression test to create the Notifications.scheduledAt column and fail fast if it disappears after migrations

## Testing
- npm run test:schema

------
https://chatgpt.com/codex/tasks/task_e_68c9a36cb250832f93926fe207420733