### PR TITLE
Ensure notifications locals default to array

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,6 +73,7 @@ app.use((req, res, next) => {
     res.locals.getRoleLevel = getRoleLevel;
     res.locals.managerLevel = getRoleLevel(USER_ROLES.MANAGER);
     res.locals.adminLevel = getRoleLevel(USER_ROLES.ADMIN);
+    res.locals.notifications = [];
     next();
 });
 

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -137,7 +137,7 @@
                         </li>
                     <% } %>
                 <% } %>
-                <% if (user && notifications && notifications.length) { %>
+                <% if (user && Array.isArray(notifications) && notifications.length) { %>
                     <li class="nav-item ms-lg-2 mt-3 mt-lg-0">
                         <a
                             class="nav-link position-relative nav-notification px-2"


### PR DESCRIPTION
## Summary
- initialize `res.locals.notifications` as an empty array so the layout always receives the property
- guard the header notification badge with `Array.isArray` before checking `length`

## Testing
- npm test
- Manual login flow and navigation using sqlite-backed local server


------
https://chatgpt.com/codex/tasks/task_e_68c9aed99f90832f88d15e69e7939e3a