### PR TITLE
Ensure notifications locals default to safe values

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,6 +73,8 @@ app.use((req, res, next) => {
     res.locals.getRoleLevel = getRoleLevel;
     res.locals.managerLevel = getRoleLevel(USER_ROLES.MANAGER);
     res.locals.adminLevel = getRoleLevel(USER_ROLES.ADMIN);
+    res.locals.notifications = [];
+    res.locals.notificationError = null;
     next();
 });
 

--- a/src/middlewares/notificationIndicator.js
+++ b/src/middlewares/notificationIndicator.js
@@ -13,6 +13,13 @@ const buildPreview = (notification) => {
 };
 
 module.exports = async function notificationIndicator(req, res, next) {
+    if (!Array.isArray(res.locals.notifications)) {
+        res.locals.notifications = [];
+    }
+    if (typeof res.locals.notificationError === 'undefined') {
+        res.locals.notificationError = null;
+    }
+
     try {
         if (!req.user || req.method !== 'GET') {
             return next();
@@ -64,9 +71,13 @@ module.exports = async function notificationIndicator(req, res, next) {
             });
 
             res.locals.notifications = sanitized;
+        } else {
+            res.locals.notifications = [];
         }
     } catch (error) {
         console.error('Erro ao carregar indicador de notificações:', error);
+        res.locals.notifications = [];
+        res.locals.notificationError = 'Não foi possível carregar as notificações.';
     }
 
     return next();

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -137,7 +137,7 @@
                         </li>
                     <% } %>
                 <% } %>
-                <% if (user && notifications && notifications.length) { %>
+                <% if (user && Array.isArray(notifications) && notifications.length) { %>
                     <li class="nav-item ms-lg-2 mt-3 mt-lg-0">
                         <a
                             class="nav-link position-relative nav-notification px-2"


### PR DESCRIPTION
## Summary
- initialize notification-related locals in the shared middleware so downstream views have safe defaults
- harden the notification indicator middleware to keep locals defined and surface loading errors gracefully
- guard the header notification badge rendering by checking that the notifications value is an array

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9af54b6a0832fb7cb1ce5a0b17725