### PR TITLE
Refactor navigation menu to use centralized shortcuts

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -90,6 +90,111 @@ body {
     padding: 0.75rem 0;
 }
 
+.user-menu-dropdown {
+    min-width: 18rem;
+    padding: 0.75rem 0.75rem 0.5rem;
+}
+
+.user-menu-dropdown .dropdown-header {
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding: 0 0.75rem 0.35rem;
+}
+
+.user-menu-quick-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.user-menu-quick-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 14px;
+    background: rgba(67, 97, 238, 0.12);
+    color: inherit;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.user-menu-quick-link:hover,
+.user-menu-quick-link:focus {
+    background: rgba(67, 97, 238, 0.2);
+    color: var(--brand-primary-dark);
+    box-shadow: 0 15px 30px rgba(67, 97, 238, 0.2);
+    transform: translateY(-1px);
+    text-decoration: none;
+}
+
+.user-menu-quick-icon {
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--brand-primary);
+    display: grid;
+    place-items: center;
+    font-size: 1.1rem;
+    box-shadow: inset 0 0 0 1px rgba(67, 97, 238, 0.08);
+}
+
+.user-menu-link {
+    border-radius: 12px;
+    padding: 0.6rem 0.75rem;
+    font-weight: 500;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.user-menu-link:hover,
+.user-menu-link:focus {
+    background: rgba(67, 97, 238, 0.12);
+    color: var(--brand-primary-dark);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.user-menu-link-icon {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 10px;
+    background: rgba(67, 97, 238, 0.12);
+    color: var(--brand-primary);
+    display: grid;
+    place-items: center;
+    font-size: 1rem;
+}
+
+.user-menu-logout {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    border-width: 1.5px;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.user-menu-logout:hover,
+.user-menu-logout:focus {
+    background: var(--brand-accent);
+    border-color: var(--brand-accent);
+    color: #fff;
+    box-shadow: 0 18px 30px rgba(247, 37, 133, 0.25);
+    transform: translateY(-1px);
+}
+
+.user-menu-dropdown [data-user-menu-focus]:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 0.2rem rgba(67, 97, 238, 0.35);
+}
+
+.user-menu-dropdown hr {
+    margin: 0.65rem 0;
+}
+
 .avatar {
     display: inline-flex;
     align-items: center;
@@ -739,6 +844,12 @@ legend.scheduler-border {
     }
 }
 
+@media (max-width: 575.98px) {
+    .user-menu-quick-actions {
+        grid-template-columns: 1fr;
+    }
+}
+
 body.theme-dark {
     background: #0b1120;
 }
@@ -795,6 +906,40 @@ body.theme-dark {
 .app-shell.theme-dark .navbar .dropdown-item:hover,
 .app-shell.theme-dark .navbar .dropdown-item:focus {
     background-color: rgba(79, 70, 229, 0.25);
+    color: #fff;
+}
+
+.app-shell.theme-dark .user-menu-quick-link {
+    background: rgba(79, 70, 229, 0.18);
+    color: var(--text-color);
+}
+
+.app-shell.theme-dark .user-menu-quick-link:hover,
+.app-shell.theme-dark .user-menu-quick-link:focus {
+    background: rgba(129, 140, 248, 0.25);
+    color: #fff;
+}
+
+.app-shell.theme-dark .user-menu-link:hover,
+.app-shell.theme-dark .user-menu-link:focus {
+    background: rgba(79, 70, 229, 0.22);
+    color: #fff;
+}
+
+.app-shell.theme-dark .user-menu-link-icon {
+    background: rgba(79, 70, 229, 0.25);
+    color: rgba(226, 232, 240, 0.95);
+}
+
+.app-shell.theme-dark .user-menu-quick-icon {
+    background: rgba(30, 41, 59, 0.85);
+    color: rgba(129, 140, 248, 0.95);
+}
+
+.app-shell.theme-dark .user-menu-logout:hover,
+.app-shell.theme-dark .user-menu-logout:focus {
+    background: rgba(244, 63, 94, 0.9);
+    border-color: rgba(244, 63, 94, 0.9);
     color: #fff;
 }
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -145,5 +145,41 @@
                 });
             }
         }
+
+        const navContainer = document.getElementById('navbarNav');
+        const collapseBreakpoint = window.matchMedia ? window.matchMedia('(max-width: 991.98px)') : null;
+        if (navContainer && window.bootstrap && typeof window.bootstrap.Collapse === 'function') {
+            const getCollapseInstance = () => window.bootstrap.Collapse.getOrCreateInstance(navContainer, {
+                toggle: false
+            });
+
+            const closeNavIfCollapsedView = () => {
+                if (!collapseBreakpoint || collapseBreakpoint.matches) {
+                    getCollapseInstance().hide();
+                }
+            };
+
+            const closableLinks = navContainer.querySelectorAll('[data-nav-close]');
+            closableLinks.forEach((link) => {
+                const scheduleClose = () => window.setTimeout(closeNavIfCollapsedView, 120);
+                link.addEventListener('click', scheduleClose);
+                link.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        scheduleClose();
+                    }
+                });
+            });
+        }
+
+        const userMenuToggle = document.getElementById('userMenu');
+        const userMenuDropdown = document.getElementById('userMenuDropdown');
+        if (userMenuToggle && userMenuDropdown) {
+            userMenuToggle.addEventListener('shown.bs.dropdown', () => {
+                const focusTarget = userMenuDropdown.querySelector('[data-user-menu-focus]');
+                if (focusTarget && typeof focusTarget.focus === 'function') {
+                    focusTarget.focus();
+                }
+            });
+        }
     });
 })();

--- a/server.js
+++ b/server.js
@@ -10,6 +10,11 @@ const cron = require('node-cron'); // para agendamentos de tarefas
 
 const { sequelize, User } = require('./database/models');
 const { USER_ROLES, ROLE_LABELS, ROLE_ORDER, getRoleLevel } = require('./src/constants/roles');
+const {
+    getNavigationShortcuts,
+    getMenuItems,
+    getQuickActions
+} = require('./src/utils/navigation');
 
 const APP_NAME = process.env.APP_NAME || 'Sistema de Gestão Inteligente';
 
@@ -110,6 +115,8 @@ app.use((req, res, next) => {
     res.locals.adminLevel = getRoleLevel(USER_ROLES.ADMIN);
     res.locals.notifications = [];
     res.locals.notificationError = null;
+    res.locals.userMenuItems = [];
+    res.locals.quickActions = [];
     next();
 });
 
@@ -134,7 +141,6 @@ app.use(async (req, res, next) => {
 
             req.user = sanitizedUser;
             res.locals.user = sanitizedUser;
-            res.locals.userRoleLevel = getRoleLevel(sanitizedUser.role);
             req.session.user = {
                 id: dbUser.id,
                 name: dbUser.name,
@@ -150,6 +156,12 @@ app.use(async (req, res, next) => {
         console.error('Erro ao buscar user no middleware:', error);
         res.locals.user = null;
     }
+
+    const roleForNavigation = res.locals.user && res.locals.user.role ? res.locals.user.role : null;
+    const navigationContext = getNavigationShortcuts(roleForNavigation);
+    res.locals.userRoleLevel = navigationContext.level;
+    res.locals.userMenuItems = getMenuItems(navigationContext.shortcuts);
+    res.locals.quickActions = getQuickActions(navigationContext.shortcuts);
 
     return next();
 });

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -1,0 +1,172 @@
+const { USER_ROLES, getRoleLevel } = require('../constants/roles');
+
+const rawShortcuts = [
+    {
+        label: 'Sobre',
+        route: '/pages/sobre',
+        icon: 'bi-info-circle',
+        minimumRole: USER_ROLES.CLIENT,
+        groups: ['menu']
+    },
+    {
+        label: 'Contato',
+        route: '/pages/contact',
+        icon: 'bi-envelope',
+        minimumRole: USER_ROLES.CLIENT,
+        groups: ['menu']
+    },
+    {
+        label: 'Painel',
+        route: '/dashboard',
+        icon: 'bi-graph-up-arrow',
+        minimumRole: USER_ROLES.MANAGER,
+        groups: ['menu', 'quick']
+    },
+    {
+        label: 'Agendamentos',
+        route: '/appointments',
+        icon: 'bi-calendar-check',
+        minimumRole: USER_ROLES.MANAGER,
+        groups: ['menu', 'quick']
+    },
+    {
+        label: 'Procedimentos',
+        route: '/procedures',
+        icon: 'bi-clipboard2-heart',
+        minimumRole: USER_ROLES.MANAGER,
+        groups: ['menu']
+    },
+    {
+        label: 'Salas',
+        route: '/rooms',
+        icon: 'bi-door-open',
+        minimumRole: USER_ROLES.MANAGER,
+        groups: ['menu']
+    },
+    {
+        label: 'Administração',
+        route: '/admin',
+        icon: 'bi-shield-check',
+        minimumRole: USER_ROLES.ADMIN,
+        groups: ['menu', 'quick']
+    },
+    {
+        label: 'Usuários',
+        route: '/users/manage',
+        icon: 'bi-people',
+        minimumRole: USER_ROLES.ADMIN,
+        groups: ['menu']
+    },
+    {
+        label: 'Financeiro',
+        route: '/finance',
+        icon: 'bi-cash-coin',
+        minimumRole: USER_ROLES.ADMIN,
+        groups: ['menu', 'quick']
+    },
+    {
+        label: 'Notificações',
+        route: '/notifications',
+        icon: 'bi-bell',
+        minimumRole: USER_ROLES.ADMIN,
+        groups: ['menu']
+    }
+];
+
+const normalizeGroups = (groups) => {
+    if (!Array.isArray(groups) || !groups.length) {
+        return Object.freeze(['menu']);
+    }
+
+    const uniqueGroups = groups
+        .map((group) => (typeof group === 'string' ? group.trim() : ''))
+        .filter(Boolean);
+
+    if (!uniqueGroups.length) {
+        uniqueGroups.push('menu');
+    }
+
+    return Object.freeze(Array.from(new Set(uniqueGroups)));
+};
+
+const NAVIGATION_BLUEPRINT = Object.freeze(
+    rawShortcuts
+        .map((shortcut) => {
+            const minimumRole = shortcut.minimumRole || USER_ROLES.CLIENT;
+            const minimumLevel = getRoleLevel(minimumRole);
+
+            if (minimumLevel < 0) {
+                return null;
+            }
+
+            return Object.freeze({
+                label: String(shortcut.label),
+                route: String(shortcut.route),
+                icon: String(shortcut.icon),
+                minimumRole,
+                minimumLevel,
+                groups: normalizeGroups(shortcut.groups)
+            });
+        })
+        .filter(Boolean)
+);
+
+const cloneShortcut = (shortcut) => ({
+    label: shortcut.label,
+    route: shortcut.route,
+    icon: shortcut.icon,
+    minimumRole: shortcut.minimumRole,
+    minimumLevel: shortcut.minimumLevel,
+    groups: shortcut.groups
+});
+
+const selectShortcutsByGroup = (shortcuts = [], group) => {
+    if (!group) {
+        return [];
+    }
+
+    return shortcuts
+        .filter((shortcut) => Array.isArray(shortcut.groups) && shortcut.groups.includes(group))
+        .map(cloneShortcut);
+};
+
+/**
+ * Retorna a lista de atalhos de navegação disponíveis para o papel informado.
+ * A função é pura, não altera estruturas existentes e sempre devolve novos objetos.
+ *
+ * @param {string} role - Papel do usuário autenticado.
+ * @returns {
+ *   level: number,
+ *   shortcuts: Array<
+ *     {
+ *       label: string,
+ *       route: string,
+ *       icon: string,
+ *       minimumRole: string,
+ *       minimumLevel: number,
+ *       groups: string[]
+ *     }
+ *   >
+ * }
+ */
+const getNavigationShortcuts = (role) => {
+    const level = getRoleLevel(role);
+
+    if (level < 0) {
+        return { level: -1, shortcuts: [] };
+    }
+
+    const shortcuts = NAVIGATION_BLUEPRINT.filter((shortcut) => level >= shortcut.minimumLevel).map(cloneShortcut);
+
+    return { level, shortcuts };
+};
+
+const getMenuItems = (shortcuts = []) => selectShortcutsByGroup(shortcuts, 'menu');
+const getQuickActions = (shortcuts = []) => selectShortcutsByGroup(shortcuts, 'quick');
+
+module.exports = {
+    NAVIGATION_BLUEPRINT,
+    getNavigationShortcuts,
+    getMenuItems,
+    getQuickActions
+};

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -78,7 +78,7 @@
                         </a>
                     </li>
                 <% } else { %>
-                    <li class="nav-item dropdown">
+                    <li class="nav-item dropdown user-menu-item">
                         <a
                             class="nav-link dropdown-toggle d-flex align-items-center"
                             href="#"
@@ -86,6 +86,7 @@
                             role="button"
                             data-bs-toggle="dropdown"
                             aria-expanded="false"
+                            aria-haspopup="true"
                         >
                             <span class="avatar avatar-sm me-2">
                                 <% if (user.profileImage) { %>
@@ -107,55 +108,77 @@
                                 </small>
                             </div>
                         </a>
-                        <ul class="dropdown-menu dropdown-menu-end shadow">
-                            <li><span class="dropdown-item-text text-muted">Bem-vindo(a)!</span></li>
-                            <li><hr class="dropdown-divider" /></li>
-                            <li><a class="dropdown-item" href="/logout"><i class="bi bi-box-arrow-left me-2"></i>Sair</a></li>
+                        <ul
+                            class="dropdown-menu dropdown-menu-end shadow user-menu-dropdown"
+                            aria-labelledby="userMenu"
+                            id="userMenuDropdown"
+                            role="menu"
+                        >
+                            <li class="dropdown-header text-muted small" role="presentation">
+                                Bem-vindo(a), <span class="fw-semibold"><%= user.name %></span>
+                            </li>
+                            <% let focusAssigned = false; %>
+                            <% if (Array.isArray(quickActions) && quickActions.length) { %>
+                                <li class="px-3 pt-2" role="presentation">
+                                    <div class="user-menu-quick-actions" role="group" aria-label="Ações rápidas">
+                                        <% quickActions.forEach((action) => { %>
+                                            <a
+                                                class="user-menu-quick-link"
+                                                href="<%= action.route %>"
+                                                role="menuitem"
+                                                data-nav-close
+                                                <%= !focusAssigned ? 'data-user-menu-focus' : '' %>
+                                            >
+                                                <span class="user-menu-quick-icon" aria-hidden="true">
+                                                    <i class="bi <%= action.icon %>"></i>
+                                                </span>
+                                                <span class="user-menu-quick-label"><%= action.label %></span>
+                                            </a>
+                                            <% focusAssigned = true; %>
+                                        <% }) %>
+                                    </div>
+                                </li>
+                                <li role="presentation"><hr class="dropdown-divider" /></li>
+                            <% } %>
+                            <% if (Array.isArray(userMenuItems) && userMenuItems.length) { %>
+                                <li class="user-menu-list" role="presentation">
+                                    <ul class="list-unstyled mb-0" role="none">
+                                        <% userMenuItems.forEach((item) => { %>
+                                            <li role="none">
+                                                <a
+                                                    class="dropdown-item user-menu-link d-flex align-items-center gap-3"
+                                                    href="<%= item.route %>"
+                                                    role="menuitem"
+                                                    data-nav-close
+                                                    <%= !focusAssigned ? 'data-user-menu-focus' : '' %>
+                                                >
+                                                    <span class="user-menu-link-icon" aria-hidden="true">
+                                                        <i class="bi <%= item.icon %>"></i>
+                                                    </span>
+                                                    <span class="flex-grow-1"><%= item.label %></span>
+                                                    <i class="bi bi-chevron-right opacity-50" aria-hidden="true"></i>
+                                                </a>
+                                                <% focusAssigned = true; %>
+                                            </li>
+                                        <% }) %>
+                                    </ul>
+                                </li>
+                                <li role="presentation"><hr class="dropdown-divider" /></li>
+                            <% } %>
+                            <li class="px-3 pb-2" role="presentation">
+                                <a
+                                    class="btn btn-outline-danger w-100 user-menu-logout"
+                                    href="/logout"
+                                    role="menuitem"
+                                    data-nav-close
+                                    <%= !focusAssigned ? 'data-user-menu-focus' : '' %>
+                                >
+                                    <i class="bi bi-box-arrow-right me-2" aria-hidden="true"></i>
+                                    Sair
+                                </a>
+                            </li>
                         </ul>
                     </li>
-
-                    <% if (userRoleLevel >= 0) { %>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/pages/sobre">Sobre</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/pages/contact">Contato</a>
-                        </li>
-                    <% } %>
-
-                    <% if (userRoleLevel >= managerLevel) { %>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/dashboard">
-                                <i class="bi bi-graph-up-arrow me-1"></i>Painel
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/appointments">Agendamentos</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/procedures">Procedimentos</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/rooms">Salas</a>
-                        </li>
-                    <% } %>
-
-                    <% if (userRoleLevel >= adminLevel) { %>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/admin">
-                                <i class="bi bi-shield-check me-1"></i>Administração
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/users/manage">Usuários</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/finance">Financeiro</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/notifications">Notificações</a>
-                        </li>
-                    <% } %>
                 <% } %>
                 <% if (user && Array.isArray(notifications) && notifications.length) { %>
                     <li class="nav-item ms-lg-2 mt-3 mt-lg-0">

--- a/tests/unit/utils/navigation.test.js
+++ b/tests/unit/utils/navigation.test.js
@@ -1,0 +1,50 @@
+const { USER_ROLES, getRoleLevel } = require('../../../src/constants/roles');
+const {
+    NAVIGATION_BLUEPRINT,
+    getNavigationShortcuts,
+    getMenuItems,
+    getQuickActions
+} = require('../../../src/utils/navigation');
+
+describe('utils/navigation', () => {
+    it('returns empty shortcuts for unknown role', () => {
+        const { level, shortcuts } = getNavigationShortcuts('unknown-role');
+        expect(level).toBe(-1);
+        expect(shortcuts).toEqual([]);
+        expect(getMenuItems()).toEqual([]);
+        expect(getQuickActions()).toEqual([]);
+    });
+
+    it('resolves manager shortcuts without admin-only routes', () => {
+        const { level, shortcuts } = getNavigationShortcuts(USER_ROLES.MANAGER);
+        expect(level).toBe(getRoleLevel(USER_ROLES.MANAGER));
+        const routes = shortcuts.map((item) => item.route);
+        expect(routes).toEqual(expect.arrayContaining(['/dashboard', '/appointments', '/procedures', '/rooms']));
+        ['/admin', '/users/manage', '/finance'].forEach((restrictedRoute) => {
+            expect(routes).not.toContain(restrictedRoute);
+        });
+    });
+
+    it('quick actions are a subset of available shortcuts', () => {
+        const { shortcuts } = getNavigationShortcuts(USER_ROLES.ADMIN);
+        const quickActions = getQuickActions(shortcuts);
+        const shortcutRoutes = shortcuts.map((item) => item.route);
+        quickActions.forEach((action) => {
+            expect(shortcutRoutes).toContain(action.route);
+        });
+        expect(quickActions.length).toBeGreaterThan(0);
+    });
+
+    it('does not mutate blueprint or cached results', () => {
+        const { shortcuts } = getNavigationShortcuts(USER_ROLES.ADMIN);
+        const firstRoute = shortcuts[0].route;
+        shortcuts[0].label = 'Rótulo alterado';
+
+        const { shortcuts: secondCall } = getNavigationShortcuts(USER_ROLES.ADMIN);
+        const blueprintItem = NAVIGATION_BLUEPRINT.find((item) => item.route === firstRoute);
+        const recalculated = secondCall.find((item) => item.route === firstRoute);
+
+        expect(blueprintItem.label).not.toBe('Rótulo alterado');
+        expect(recalculated.label).not.toBe('Rótulo alterado');
+    });
+});

--- a/tests/unit/views/header.test.js
+++ b/tests/unit/views/header.test.js
@@ -1,0 +1,55 @@
+const path = require('path');
+const ejs = require('ejs');
+const { USER_ROLES, ROLE_LABELS } = require('../../../src/constants/roles');
+const {
+    getNavigationShortcuts,
+    getMenuItems,
+    getQuickActions
+} = require('../../../src/utils/navigation');
+
+describe('views/partials/header', () => {
+    it('renders only the shortcuts allowed for the user role', async () => {
+        const { shortcuts } = getNavigationShortcuts(USER_ROLES.MANAGER);
+        const userMenuItems = getMenuItems(shortcuts);
+        const quickActions = getQuickActions(shortcuts);
+
+        const html = await ejs.renderFile(
+            path.join(__dirname, '../../../src/views/partials/header.ejs'),
+            {
+                pageTitle: 'Área interna',
+                appName: 'Sistema Teste',
+                user: { name: 'Maria Gestora', role: USER_ROLES.MANAGER, profileImage: null },
+                roleLabels: ROLE_LABELS,
+                notifications: [],
+                userMenuItems,
+                quickActions,
+                success_msg: null,
+                error_msg: null,
+                error: null
+            }
+        );
+
+        const expectedRoutes = [
+            '/dashboard',
+            '/appointments',
+            '/procedures',
+            '/rooms',
+            '/pages/sobre',
+            '/pages/contact'
+        ];
+        expectedRoutes.forEach((route) => {
+            expect(html).toContain(`href="${route}"`);
+        });
+
+        const forbiddenRoutes = ['/admin', '/users/manage', '/finance'];
+        forbiddenRoutes.forEach((route) => {
+            expect(html).not.toContain(`href="${route}"`);
+        });
+
+        expect(html).toContain('user-menu-quick-link');
+        expect(html).toContain('user-menu-link');
+        expect(html).toContain('user-menu-logout');
+        const navCloseMatches = html.match(/data-nav-close/g) || [];
+        expect(navCloseMatches.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary
- add a navigation utility that maps role-based shortcuts and expose quick actions
- wire the server and header partial to consume the new shortcuts and refresh dropdown styling/behaviour
- cover the navigation helper and header rendering with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d90c95ec832fb8b5a513c2b34d95