### PR TITLE
Add smoke tests and responsive layout improvements

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -9,6 +9,32 @@
     --text-color: #1f2933;
     --muted-color: #6c7a91;
     --shadow-soft: 0 15px 35px rgba(67, 97, 238, 0.15);
+
+    /* Responsive design tokens */
+    --bp-xs: 375px; /* mobile portrait */
+    --bp-sm: 576px; /* small devices */
+    --bp-md: 768px; /* tablets */
+    --bp-lg: 1024px; /* landscape tablets / small laptops */
+    --bp-xl: 1280px; /* desktops */
+    --layout-max-width: 1200px;
+    --container-inline-padding: clamp(1rem, 3vw, 2.25rem);
+    --section-gap-xl: 2.75rem;
+    --section-gap-lg: 2.25rem;
+    --section-gap-md: 1.75rem;
+    --section-gap-sm: 1.5rem;
+    --section-gap-xs: 1.25rem;
+    --card-padding-xl: 2.5rem;
+    --card-padding-lg: 2.25rem;
+    --card-padding-md: 1.75rem;
+    --card-padding-sm: 1.5rem;
+    --card-padding-xs: 1.25rem;
+    --card-padding-xxs: 1rem;
+    --table-min-width-lg: 960px;
+    --table-min-width-md: 768px;
+    --table-min-width-sm: 640px;
+    --table-min-width-xs: 560px;
+    --form-control-gap: 1.25rem;
+    --form-control-gap-sm: 1rem;
 }
 
 * {
@@ -311,17 +337,32 @@ body {
 
 fieldset.scheduler-border {
     border: 1px solid var(--surface-300) !important;
-    border-radius: 14px;
-    padding: 1rem 1.25rem 1.15rem;
-    margin-bottom: 1.25rem;
+    border-radius: 16px;
+    padding: var(--card-padding-sm) var(--card-padding-md);
+    margin-bottom: var(--form-control-gap);
+    background: rgba(255, 255, 255, 0.65);
 }
 
 legend.scheduler-border {
     font-size: 1rem;
     font-weight: 600;
-    padding: 0 0.65rem;
+    padding: 0 0.75rem;
     width: auto;
     color: var(--brand-primary-dark);
+}
+
+@media (max-width: 1024px) {
+    fieldset.scheduler-border {
+        padding: var(--card-padding-sm);
+        border-radius: 14px;
+    }
+}
+
+@media (max-width: 768px) {
+    fieldset.scheduler-border {
+        padding: var(--card-padding-xs);
+        margin-bottom: var(--form-control-gap-sm);
+    }
 }
 
 .theme-toggle {
@@ -720,6 +761,194 @@ legend.scheduler-border {
     margin-bottom: 1rem;
 }
 
+.responsive-page-row {
+    --bs-gutter-x: var(--section-gap-md);
+    --bs-gutter-y: var(--section-gap-lg);
+}
+
+.responsive-panel {
+    padding: var(--card-padding-lg);
+    border-radius: 22px;
+    transition: padding 0.3s ease, border-radius 0.3s ease;
+}
+
+.responsive-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--form-control-gap);
+}
+
+.responsive-form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+}
+
+.responsive-form-actions .btn {
+    min-width: 180px;
+}
+
+.responsive-form-switch {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    background: rgba(67, 97, 238, 0.08);
+}
+
+.responsive-form-switch .form-check-label {
+    font-weight: 500;
+}
+
+.responsive-filter-grid {
+    --bs-gutter-y: 1.5rem;
+}
+
+.responsive-filter-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.responsive-filter-actions .btn {
+    flex: 1 1 auto;
+}
+
+.responsive-filter-actions .btn:last-child {
+    flex: 0 0 auto;
+}
+
+.responsive-table {
+    border-radius: 20px;
+    overflow-x: auto;
+    box-shadow: none;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(67, 97, 238, 0.25) transparent;
+}
+
+.responsive-table::-webkit-scrollbar {
+    height: 8px;
+}
+
+.responsive-table::-webkit-scrollbar-thumb {
+    background: rgba(67, 97, 238, 0.3);
+    border-radius: 8px;
+}
+
+.responsive-table table {
+    min-width: var(--table-min-width-lg);
+}
+
+@media (max-width: 1280px) {
+    .responsive-page-row {
+        --bs-gutter-y: var(--section-gap-md);
+    }
+
+    .responsive-panel {
+        padding: var(--card-padding-md);
+    }
+
+    .responsive-table table {
+        min-width: var(--table-min-width-md);
+    }
+}
+
+@media (max-width: 1024px) {
+    .responsive-page-row {
+        --bs-gutter-x: var(--section-gap-sm);
+        --bs-gutter-y: var(--section-gap-sm);
+    }
+
+    .responsive-panel {
+        padding: var(--card-padding-sm);
+        border-radius: 20px;
+    }
+
+    .responsive-form {
+        gap: var(--form-control-gap-sm);
+    }
+
+    .responsive-form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .responsive-form-actions .btn {
+        min-width: 0;
+        width: 100%;
+    }
+
+    .responsive-form-switch {
+        padding: 0.75rem;
+    }
+
+    .responsive-filter-grid > [class*='col-'] {
+        flex: 0 0 100% !important;
+        max-width: 100% !important;
+    }
+
+    .responsive-filter-actions {
+        width: 100%;
+        gap: 0.5rem;
+    }
+
+    .responsive-filter-actions .btn {
+        width: 100%;
+    }
+
+    .responsive-table table {
+        min-width: 100%;
+    }
+}
+
+@media (max-width: 768px) {
+    .responsive-page-row {
+        --bs-gutter-x: var(--section-gap-xs);
+        --bs-gutter-y: var(--section-gap-xs);
+    }
+
+    .responsive-panel {
+        padding: var(--card-padding-xs);
+        border-radius: 18px;
+    }
+
+    .responsive-form-switch {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .responsive-table table {
+        font-size: 0.95rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .responsive-panel {
+        padding: var(--card-padding-xxs);
+    }
+
+    .responsive-table {
+        margin-inline: -0.75rem;
+        padding-inline: 0.75rem;
+    }
+
+    .responsive-table table {
+        min-width: var(--table-min-width-xs);
+        font-size: 0.9rem;
+    }
+
+    .responsive-filter-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .responsive-filter-actions .btn {
+        width: 100%;
+    }
+}
+
 @media (max-width: 991.98px) {
     .landing-cta-floating {
         display: none !important;
@@ -922,6 +1151,7 @@ body.theme-dark {
 
 .app-shell.theme-dark fieldset.scheduler-border {
     border-color: rgba(148, 163, 184, 0.3) !important;
+    background: rgba(17, 24, 39, 0.82);
 }
 
 .app-shell.theme-dark legend.scheduler-border {

--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -1,213 +1,281 @@
 <%- include('../partials/header') %>
 
-<div class="row">
+<div class="row fade-in responsive-page-row gy-4">
     <div class="col-12">
-        <h2>Gerenciar Finanças</h2>
+        <div class="card card-soft responsive-panel">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                <div>
+                    <span class="app-chip mb-2"><i class="bi bi-cash-stack me-2"></i>Saúde financeira</span>
+                    <h2 class="fw-semibold mb-2">Gerenciar finanças estratégicas</h2>
+                    <p class="text-muted mb-0">
+                        Acompanhe lançamentos, status e recorrências com visibilidade completa para decisões rápidas.
+                    </p>
+                </div>
+                <div class="text-muted small text-lg-end">
+                    Lançamentos cadastrados<br />
+                    <span class="fw-semibold text-primary"><%= entries.length %></span>
+                </div>
+            </div>
 
-        <!-- Alertas de feedback -->
-        <% if (success_msg) { %>
-            <div class="alert alert-success"><%= success_msg %></div>
-        <% } else if (error_msg) { %>
-            <div class="alert alert-danger"><%= error_msg %></div>
-        <% } %>
+            <% if (success_msg) { %>
+                <div class="alert alert-success alert-auto mt-4" data-auto-dismiss="5000">
+                    <i class="bi bi-check-circle me-2"></i><%= success_msg %>
+                </div>
+            <% } else if (error_msg) { %>
+                <div class="alert alert-danger alert-auto mt-4" data-auto-dismiss="5000">
+                    <i class="bi bi-exclamation-triangle me-2"></i><%= error_msg %>
+                </div>
+            <% } %>
+        </div>
+    </div>
 
-        <!-- Tabela de Lançamentos -->
-        <table class="table table-bordered table-striped align-middle">
-            <thead class="table-dark">
-            <tr>
-                <th>ID</th>
-                <th>Descrição</th>
-                <th>Tipo</th>
-                <th>Valor</th>
-                <th>Vencimento</th>
-                <th>Pagamento</th>
-                <th>Status</th>
-                <th style="width: 180px;">Ações</th>
-            </tr>
-            </thead>
-            <tbody>
-            <% entries.forEach(entry => { %>
-                <tr>
-                    <td><%= entry.id %></td>
-                    <td><%= entry.description %></td>
-                    <td>
-                        <% if (entry.type === 'payable') { %>
-                            <span class="badge text-bg-danger">Pagar</span>
-                        <% } else { %>
-                            <span class="badge text-bg-success">Receber</span>
-                        <% } %>
-                    </td>
-                    <td>R$ <%= entry.value %></td>
-                    <td><%= entry.dueDate %></td>
-                    <td><%= entry.paymentDate ? entry.paymentDate : '—' %></td>
-                    <td><%= entry.status %></td>
-                    <td>
-                        <!-- Botão para abrir Modal de Edição -->
-                        <button
-                                type="button"
-                                class="btn btn-warning btn-sm"
-                                data-bs-toggle="modal"
-                                data-bs-target="#editFinanceModal<%= entry.id %>"
-                        >
-                            Editar
-                        </button>
-
-                        <!-- Form de exclusão -->
-                        <form
-                                action="/finance/delete/<%= entry.id %>?_method=DELETE"
-                                method="POST"
-                                style="display:inline-block;"
-                        >
-                            <button class="btn btn-danger btn-sm" type="submit">
-                                Excluir
-                            </button>
-                        </form>
-
-                        <!-- Modal de Edição -->
-                        <div
-                                class="modal fade"
-                                id="editFinanceModal<%= entry.id %>"
-                                tabindex="-1"
-                                aria-hidden="true"
-                        >
-                            <div class="modal-dialog">
-                                <form
-                                        action="/finance/update/<%= entry.id %>?_method=PUT"
-                                        method="POST"
-                                        class="modal-content"
-                                >
-                                    <div class="modal-header">
-                                        <h5 class="modal-title">Editar Lançamento #<%= entry.id %></h5>
+    <div class="col-12">
+        <div class="card card-soft responsive-panel">
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-3">
+                <div>
+                    <h3 class="fw-semibold mb-1">Lançamentos recentes</h3>
+                    <p class="text-muted mb-0">Monitoramento contínuo de receitas, despesas e recorrências.</p>
+                </div>
+                <span class="badge rounded-pill bg-light text-muted">
+                    <i class="bi bi-shield-lock me-2"></i>Auditoria ativa
+                </span>
+            </div>
+            <div class="table-responsive table-modern responsive-table">
+                <table class="table align-middle mb-0">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>ID</th>
+                            <th>Descrição</th>
+                            <th>Tipo</th>
+                            <th>Valor</th>
+                            <th>Vencimento</th>
+                            <th>Pagamento</th>
+                            <th>Status</th>
+                            <th class="text-center" style="width: 200px;">Ações</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <% entries.forEach(entry => { %>
+                            <tr>
+                                <td><%= entry.id %></td>
+                                <td><%= entry.description %></td>
+                                <td>
+                                    <% if (entry.type === 'payable') { %>
+                                        <span class="badge text-bg-danger">Pagar</span>
+                                    <% } else { %>
+                                        <span class="badge text-bg-success">Receber</span>
+                                    <% } %>
+                                </td>
+                                <td>R$ <%= entry.value %></td>
+                                <td><%= entry.dueDate %></td>
+                                <td><%= entry.paymentDate ? entry.paymentDate : '—' %></td>
+                                <td><%= entry.status %></td>
+                                <td>
+                                    <div class="d-flex flex-wrap justify-content-center gap-2">
                                         <button
-                                                type="button"
-                                                class="btn-close"
-                                                data-bs-dismiss="modal"
-                                                aria-label="Close"
-                                        ></button>
-                                    </div>
-                                    <div class="modal-body">
-                                        <input type="hidden" name="id" value="<%= entry.id %>" />
-
-                                        <div class="mb-3">
-                                            <label class="form-label">Descrição</label>
-                                            <input
-                                                    type="text"
-                                                    class="form-control"
-                                                    name="description"
-                                                    value="<%= entry.description %>"
-                                                    required
-                                            />
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Tipo</label>
-                                            <select class="form-select" name="type" required>
-                                                <option value="payable" <%= entry.type === 'payable' ? 'selected' : '' %>>Pagar</option>
-                                                <option value="receivable" <%= entry.type === 'receivable' ? 'selected' : '' %>>Receber</option>
-                                            </select>
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Valor (R$)</label>
-                                            <input
-                                                    type="number"
-                                                    step="0.01"
-                                                    class="form-control"
-                                                    name="value"
-                                                    value="<%= entry.value %>"
-                                                    required
-                                            />
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Data de Vencimento</label>
-                                            <input
-                                                    type="date"
-                                                    class="form-control"
-                                                    name="dueDate"
-                                                    value="<%= entry.dueDate %>"
-                                                    required
-                                            />
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Data de Pagamento</label>
-                                            <input
-                                                    type="date"
-                                                    class="form-control"
-                                                    name="paymentDate"
-                                                    value="<%= entry.paymentDate ? entry.paymentDate : '' %>"
-                                            />
-                                        </div>
-                                        <div class="mb-3">
-                                            <label class="form-label">Status</label>
-                                            <select class="form-select" name="status">
-                                                <option value="pending" <%= entry.status === 'pending' ? 'selected' : '' %>>Pendente</option>
-                                                <option value="paid" <%= entry.status === 'paid' ? 'selected' : '' %>>Pago</option>
-                                                <option value="overdue" <%= entry.status === 'overdue' ? 'selected' : '' %>>Atrasado</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button
-                                                type="button"
-                                                class="btn btn-secondary"
-                                                data-bs-dismiss="modal"
+                                            type="button"
+                                            class="btn btn-outline-primary btn-sm"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#editFinanceModal<%= entry.id %>"
                                         >
-                                            Cancelar
+                                            <i class="bi bi-pencil me-1"></i>Editar
                                         </button>
-                                        <button type="submit" class="btn btn-primary">Salvar</button>
-                                    </div>
-                                </form>
-                            </div>
-                        </div>
-                        <!-- Fim Modal -->
-                    </td>
-                </tr>
-            <% }) %>
-            </tbody>
-        </table>
 
-        <!-- Form de criação de novo lançamento -->
-        <h3>Novo Lançamento</h3>
-        <form action="/finance/create" method="POST" class="mt-3 row g-3">
-            <div class="col-md-4">
-                <label class="form-label">Descrição</label>
-                <input
+                                        <form
+                                            action="/finance/delete/<%= entry.id %>?_method=DELETE"
+                                            method="POST"
+                                            class="d-inline"
+                                        >
+                                            <button class="btn btn-outline-danger btn-sm" type="submit">
+                                                <i class="bi bi-trash me-1"></i>Excluir
+                                            </button>
+                                        </form>
+                                    </div>
+
+                                    <div
+                                        class="modal fade"
+                                        id="editFinanceModal<%= entry.id %>"
+                                        tabindex="-1"
+                                        aria-hidden="true"
+                                    >
+                                        <div class="modal-dialog">
+                                            <form
+                                                action="/finance/update/<%= entry.id %>?_method=PUT"
+                                                method="POST"
+                                                class="modal-content"
+                                            >
+                                                <div class="modal-header">
+                                                    <h5 class="modal-title">Editar Lançamento #<%= entry.id %></h5>
+                                                    <button
+                                                        type="button"
+                                                        class="btn-close"
+                                                        data-bs-dismiss="modal"
+                                                        aria-label="Close"
+                                                    ></button>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <input type="hidden" name="id" value="<%= entry.id %>" />
+
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Descrição</label>
+                                                        <input
+                                                            type="text"
+                                                            class="form-control"
+                                                            name="description"
+                                                            value="<%= entry.description %>"
+                                                            required
+                                                        />
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Tipo</label>
+                                                        <select class="form-select" name="type" required>
+                                                            <option value="payable" <%= entry.type === 'payable' ? 'selected' : '' %>>Pagar</option>
+                                                            <option value="receivable" <%= entry.type === 'receivable' ? 'selected' : '' %>>Receber</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Valor (R$)</label>
+                                                        <input
+                                                            type="number"
+                                                            step="0.01"
+                                                            class="form-control"
+                                                            name="value"
+                                                            value="<%= entry.value %>"
+                                                            required
+                                                        />
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Data de Vencimento</label>
+                                                        <input
+                                                            type="date"
+                                                            class="form-control"
+                                                            name="dueDate"
+                                                            value="<%= entry.dueDate %>"
+                                                            required
+                                                        />
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Data de Pagamento</label>
+                                                        <input
+                                                            type="date"
+                                                            class="form-control"
+                                                            name="paymentDate"
+                                                            value="<%= entry.paymentDate ? entry.paymentDate : '' %>"
+                                                        />
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Status</label>
+                                                        <select class="form-select" name="status">
+                                                            <option value="pending" <%= entry.status === 'pending' ? 'selected' : '' %>>Pendente</option>
+                                                            <option value="paid" <%= entry.status === 'paid' ? 'selected' : '' %>>Pago</option>
+                                                            <option value="overdue" <%= entry.status === 'overdue' ? 'selected' : '' %>>Atrasado</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Recorrência</label>
+                                                        <select class="form-select" name="recurring">
+                                                            <option value="true" <%= entry.recurring ? 'selected' : '' %>>Lançamento recorrente</option>
+                                                            <option value="false" <%= !entry.recurring ? 'selected' : '' %>>Evento único</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Intervalo de recorrência</label>
+                                                        <input
+                                                            type="text"
+                                                            class="form-control"
+                                                            name="recurringInterval"
+                                                            value="<%= entry.recurringInterval || '' %>"
+                                                            placeholder="Ex.: mensal, trimestral"
+                                                        />
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button
+                                                        type="button"
+                                                        class="btn btn-outline-secondary"
+                                                        data-bs-dismiss="modal"
+                                                    >
+                                                        Cancelar
+                                                    </button>
+                                                    <button type="submit" class="btn btn-gradient">Salvar</button>
+                                                </div>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                        <% }) %>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 col-xxl-10">
+        <div class="card card-soft responsive-panel">
+            <h3 class="fw-semibold mb-2">Novo lançamento</h3>
+            <p class="text-muted mb-4">Cadastre receitas ou despesas com recorrência opcional e acompanhe tudo no painel.</p>
+            <form action="/finance/create" method="POST" class="row g-3 responsive-filter-grid">
+                <div class="col-md-5">
+                    <label class="form-label">Descrição</label>
+                    <input
                         type="text"
                         class="form-control"
                         name="description"
                         required
-                />
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Tipo</label>
-                <select class="form-select" name="type" required>
-                    <option value="payable">Pagar</option>
-                    <option value="receivable">Receber</option>
-                </select>
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Valor (R$)</label>
-                <input
+                        placeholder="Ex.: Pagamento fornecedor"
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Tipo</label>
+                    <select class="form-select" name="type" required>
+                        <option value="payable">Pagar</option>
+                        <option value="receivable">Receber</option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">Valor (R$)</label>
+                    <input
                         type="number"
                         step="0.01"
                         class="form-control"
                         name="value"
                         required
-                />
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Vencimento</label>
-                <input
+                    />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">Vencimento</label>
+                    <input
                         type="date"
                         class="form-control"
                         name="dueDate"
                         required
-                />
-            </div>
-            <div class="col-md-2 align-self-end">
-                <button type="submit" class="btn btn-success w-100">
-                    Criar
-                </button>
-            </div>
-        </form>
+                    />
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Recorrência</label>
+                    <select class="form-select" name="recurring">
+                        <option value="false">Não recorrente</option>
+                        <option value="true">Recorrente</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Intervalo (opcional)</label>
+                    <input
+                        type="text"
+                        class="form-control"
+                        name="recurringInterval"
+                        placeholder="Ex.: mensal"
+                    />
+                </div>
+                <div class="col-md-12">
+                    <div class="responsive-form-actions">
+                        <button type="reset" class="btn btn-outline-secondary">Limpar</button>
+                        <button type="submit" class="btn btn-gradient">Criar lançamento</button>
+                    </div>
+                </div>
+            </form>
+        </div>
     </div>
 </div>
 

--- a/src/views/notifications/createNotification.ejs
+++ b/src/views/notifications/createNotification.ejs
@@ -2,9 +2,9 @@
 
 <% const availableRoles = roleOptions || []; %>
 
-<div class="row justify-content-center fade-in">
-    <div class="col-12 col-xl-10">
-        <div class="card card-soft p-4">
+<div class="row justify-content-center fade-in responsive-page-row">
+    <div class="col-12 col-xxl-10">
+        <div class="card card-soft responsive-panel">
             <div class="d-flex flex-wrap justify-content-between align-items-center mb-4">
                 <div>
                     <h2 class="fw-semibold mb-1">Nova notificação automatizada</h2>
@@ -23,7 +23,7 @@
                 </div>
             <% } %>
 
-            <form action="/notifications/create" method="POST" class="needs-validation" novalidate>
+            <form action="/notifications/create" method="POST" class="needs-validation responsive-form" novalidate>
                 <fieldset class="scheduler-border">
                     <legend class="scheduler-border">Conteúdo</legend>
                     <div class="row g-3">
@@ -86,13 +86,13 @@
                             </select>
                         </div>
                         <div class="col-md-4">
-                            <div class="form-check form-switch">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="sendToAll" name="sendToAll" value="true" />
                                 <label class="form-check-label" for="sendToAll">Enviar para todos os usuários</label>
                             </div>
                         </div>
                         <div class="col-md-4">
-                            <div class="form-check form-switch">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="active" name="active" value="true" checked />
                                 <label class="form-check-label" for="active">Notificação ativa</label>
                             </div>
@@ -159,20 +159,20 @@
                             <label class="form-label">Fim do período</label>
                             <input type="datetime-local" class="form-control" name="dateRangeEnd" />
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
-                            <div class="form-check form-switch me-4">
+                        <div class="col-md-4">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="onlyActive" name="onlyActive" value="true" <%= defaultFilters.onlyActive ? 'checked' : '' %> />
                                 <label class="form-check-label" for="onlyActive">Somente usuários ativos</label>
                             </div>
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
-                            <div class="form-check form-switch me-4">
+                        <div class="col-md-4">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="includeProfessional" name="includeProfessional" value="true" <%= defaultFilters.includeProfessional ? 'checked' : '' %> />
                                 <label class="form-check-label" for="includeProfessional">Enviar ao profissional</label>
                             </div>
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
-                            <div class="form-check form-switch">
+                        <div class="col-md-4">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="includeClient" name="includeClient" value="true" <%= defaultFilters.includeClient ? 'checked' : '' %> />
                                 <label class="form-check-label" for="includeClient">Enviar ao cliente</label>
                             </div>
@@ -180,7 +180,7 @@
                     </div>
                 </fieldset>
 
-                <div class="d-flex justify-content-end gap-3">
+                <div class="responsive-form-actions">
                     <a href="/notifications" class="btn btn-outline-secondary">Cancelar</a>
                     <button type="submit" class="btn btn-gradient">Salvar notificação</button>
                 </div>

--- a/src/views/notifications/editNotification.ejs
+++ b/src/views/notifications/editNotification.ejs
@@ -13,9 +13,9 @@
 <% const includeClient = filters.includeClient !== false; %>
 <% const onlyActive = filters.onlyActive !== false; %>
 
-<div class="row justify-content-center fade-in">
-    <div class="col-12 col-xl-10">
-        <div class="card card-soft p-4">
+<div class="row justify-content-center fade-in responsive-page-row">
+    <div class="col-12 col-xxl-10">
+        <div class="card card-soft responsive-panel">
             <div class="d-flex flex-wrap justify-content-between align-items-center mb-4">
                 <div>
                     <h2 class="fw-semibold mb-1">Editar notificação</h2>
@@ -24,7 +24,7 @@
                 <a href="/notifications" class="btn btn-outline-secondary rounded-pill"><i class="bi bi-arrow-left"></i> Voltar</a>
             </div>
 
-            <form action="/notifications/update/<%= notif.id %>?_method=PUT" method="POST" class="needs-validation" novalidate>
+            <form action="/notifications/update/<%= notif.id %>?_method=PUT" method="POST" class="needs-validation responsive-form" novalidate>
                 <fieldset class="scheduler-border">
                     <legend class="scheduler-border">Conteúdo</legend>
                     <div class="row g-3">
@@ -88,13 +88,13 @@
                             </select>
                         </div>
                         <div class="col-md-4">
-                            <div class="form-check form-switch">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="sendToAll" name="sendToAll" value="true" <%= notif.sendToAll ? 'checked' : '' %> />
                                 <label class="form-check-label" for="sendToAll">Enviar para todos os usuários</label>
                             </div>
                         </div>
                         <div class="col-md-4">
-                            <div class="form-check form-switch">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="active" name="active" value="true" <%= notif.active ? 'checked' : '' %> />
                                 <label class="form-check-label" for="active">Notificação ativa</label>
                             </div>
@@ -164,20 +164,20 @@
                             <label class="form-label">Fim do período</label>
                             <input type="datetime-local" class="form-control" name="dateRangeEnd" value="<%= toDateTimeLocal(filters.dateRangeEnd) %>" />
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
-                            <div class="form-check form-switch me-4">
+                        <div class="col-md-4">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="onlyActive" name="onlyActive" value="true" <%= onlyActive ? 'checked' : '' %> />
                                 <label class="form-check-label" for="onlyActive">Somente usuários ativos</label>
                             </div>
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
-                            <div class="form-check form-switch me-4">
+                        <div class="col-md-4">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="includeProfessional" name="includeProfessional" value="true" <%= includeProfessional ? 'checked' : '' %> />
                                 <label class="form-check-label" for="includeProfessional">Enviar ao profissional</label>
                             </div>
                         </div>
-                        <div class="col-md-4 d-flex align-items-center">
-                            <div class="form-check form-switch">
+                        <div class="col-md-4">
+                            <div class="form-check form-switch responsive-form-switch">
                                 <input class="form-check-input" type="checkbox" role="switch" id="includeClient" name="includeClient" value="true" <%= includeClient ? 'checked' : '' %> />
                                 <label class="form-check-label" for="includeClient">Enviar ao cliente</label>
                             </div>
@@ -185,7 +185,7 @@
                     </div>
                 </fieldset>
 
-                <div class="d-flex justify-content-end gap-3">
+                <div class="responsive-form-actions">
                     <a href="/notifications" class="btn btn-outline-secondary">Cancelar</a>
                     <button type="submit" class="btn btn-gradient">Salvar alterações</button>
                 </div>

--- a/src/views/notifications/manageNotifications.ejs
+++ b/src/views/notifications/manageNotifications.ejs
@@ -2,7 +2,7 @@
 
 <% const currentFilters = filters || {}; %>
 
-<div class="row gy-4 fade-in">
+<div class="row gy-4 fade-in responsive-page-row">
     <div class="col-12">
         <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
             <div>
@@ -22,11 +22,11 @@
             </div>
         <% } %>
 
-        <div class="card card-soft p-4 mb-4">
+        <div class="card card-soft responsive-panel mb-4">
             <form
                 action="/notifications"
                 method="GET"
-                class="row g-3 align-items-end"
+                class="row g-3 align-items-end responsive-filter-grid"
                 data-filter-form
             >
                 <div class="col-lg-4 col-md-6">
@@ -73,19 +73,21 @@
                         min="<%= currentFilters.startDate || '' %>"
                     />
                 </div>
-                <div class="col-lg-1 col-md-12 d-flex gap-2">
-                    <button type="submit" class="btn btn-gradient flex-grow-1" data-submit-filters>
-                        <i class="bi bi-funnel me-2"></i>Filtrar
-                    </button>
-                    <button type="button" class="btn btn-outline-secondary" data-reset-filters>
-                        <i class="bi bi-x-lg"></i>
-                    </button>
+                <div class="col-lg-2 col-md-12">
+                    <div class="responsive-filter-actions">
+                        <button type="submit" class="btn btn-gradient" data-submit-filters>
+                            <i class="bi bi-funnel me-2"></i>Filtrar
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" data-reset-filters>
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+                    </div>
                 </div>
             </form>
         </div>
 
-        <div class="card card-soft p-4">
-            <div class="table-responsive table-modern">
+        <div class="card card-soft responsive-panel">
+            <div class="table-responsive table-modern responsive-table">
                 <table class="table align-middle mb-0">
                     <thead>
                     <tr>

--- a/tests/integration/routes.smoke.test.js
+++ b/tests/integration/routes.smoke.test.js
@@ -1,0 +1,115 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+jest.mock('../../database/models', () => {
+    const { Op } = require('sequelize');
+
+    return {
+        FinanceEntry: {
+            findAll: jest.fn()
+        },
+        Notification: {
+            findAll: jest.fn()
+        },
+        User: {},
+        Procedure: {},
+        Room: {},
+        Sequelize: { Op },
+        sequelize: {}
+    };
+});
+
+const request = require('supertest');
+const { FinanceEntry, Notification } = require('../../database/models');
+const { createRouterTestApp } = require('../utils/createRouterTestApp');
+const { authenticateTestUser } = require('../utils/authTestUtils');
+
+const authRoutes = require('../../src/routes/authRoutes');
+const dashboardRoutes = require('../../src/routes/dashboardRoutes');
+const financeRoutes = require('../../src/routes/financeRoutes');
+const notificationRoutes = require('../../src/routes/notificationRoutes');
+
+describe('Smoke tests das rotas principais', () => {
+    let app;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        app = createRouterTestApp({
+            routes: [
+                ['/', authRoutes],
+                ['/dashboard', dashboardRoutes],
+                ['/finance', financeRoutes],
+                ['/notifications', notificationRoutes]
+            ]
+        });
+    });
+
+    it('retorna a landing page com elementos principais', async () => {
+        const response = await request(app).get('/');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Transforme sua gestão');
+        expect(response.text).toContain('Inteligência operacional');
+    });
+
+    it('renderiza o dashboard para administradores autenticados', async () => {
+        const { agent } = await authenticateTestUser(app);
+
+        const response = await agent.get('/dashboard');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Visão gerencial inteligente');
+        expect(response.text).toContain('Próximos atendimentos');
+    });
+
+    it('lista lançamentos financeiros com sucesso', async () => {
+        FinanceEntry.findAll.mockResolvedValue([
+            {
+                id: 1,
+                description: 'Mensalidade corporativa',
+                type: 'receivable',
+                value: '1500.00',
+                dueDate: '2024-05-10',
+                paymentDate: '2024-05-11',
+                status: 'paid',
+                recurring: true,
+                recurringInterval: 'mensal'
+            }
+        ]);
+
+        const { agent } = await authenticateTestUser(app);
+        const response = await agent.get('/finance');
+
+        expect(FinanceEntry.findAll).toHaveBeenCalledTimes(1);
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Gerenciar finanças estratégicas');
+        expect(response.text).toContain('Lançamentos recentes');
+        expect(response.text).toContain('Mensalidade corporativa');
+    });
+
+    it('exibe campanhas de notificações disponíveis', async () => {
+        Notification.findAll.mockResolvedValue([
+            {
+                get: () => ({
+                    id: 7,
+                    title: 'Boas-vindas',
+                    message: 'Seja bem-vindo ao novo ciclo!',
+                    repeatFrequency: 'daily',
+                    filters: { onlyActive: true },
+                    sendToAll: true,
+                    triggerDate: null,
+                    userId: null
+                })
+            }
+        ]);
+
+        const { agent } = await authenticateTestUser(app);
+        const response = await agent.get('/notifications');
+
+        expect(Notification.findAll).toHaveBeenCalledTimes(1);
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Campanhas e notificações');
+        expect(response.text).toContain('Boas-vindas');
+    });
+});

--- a/tests/unit/partialsRender.test.js
+++ b/tests/unit/partialsRender.test.js
@@ -1,0 +1,79 @@
+const path = require('path');
+const ejs = require('ejs');
+
+const {
+    USER_ROLES,
+    ROLE_LABELS,
+    ROLE_ORDER,
+    getRoleLevel
+} = require('../../src/constants/roles');
+
+const partialsDir = path.join(__dirname, '..', '..', 'src', 'views', 'partials');
+
+const roleOptions = ROLE_ORDER.map((role) => ({ value: role, label: ROLE_LABELS[role] }));
+
+const baseContext = {
+    appName: 'Sistema de Gestão Inteligente',
+    pageTitle: 'Teste',
+    success_msg: null,
+    error_msg: null,
+    error: null,
+    roleLabels: ROLE_LABELS,
+    roleOptions,
+    roles: USER_ROLES,
+    managerLevel: getRoleLevel(USER_ROLES.MANAGER),
+    adminLevel: getRoleLevel(USER_ROLES.ADMIN),
+    notifications: []
+};
+
+describe('Renderização de parciais críticas', () => {
+    it('renderiza o header para visitantes sem erros', async () => {
+        const html = await ejs.renderFile(
+            path.join(partialsDir, 'header.ejs'),
+            {
+                ...baseContext,
+                user: null,
+                userRoleLevel: -1,
+                notifications: []
+            },
+            { async: true }
+        );
+
+        expect(html).toContain('<nav');
+        expect(html).toContain('Entrar');
+    });
+
+    it('renderiza o header para administradores com notificações', async () => {
+        const html = await ejs.renderFile(
+            path.join(partialsDir, 'header.ejs'),
+            {
+                ...baseContext,
+                user: {
+                    id: 42,
+                    name: 'Admin QA',
+                    role: USER_ROLES.ADMIN,
+                    active: true
+                },
+                userRoleLevel: getRoleLevel(USER_ROLES.ADMIN),
+                notifications: [
+                    { id: 1, title: 'Alerta', preview: 'Nova notificação disponível' }
+                ]
+            },
+            { async: true }
+        );
+
+        expect(html).toContain('Administração');
+        expect(html).toContain('data-testid="notification-badge"');
+    });
+
+    it('renderiza o footer exibindo o nome do app', async () => {
+        const html = await ejs.renderFile(
+            path.join(partialsDir, 'footer.ejs'),
+            baseContext,
+            { async: true }
+        );
+
+        expect(html).toContain('&copy;');
+        expect(html).toContain(baseContext.appName);
+    });
+});

--- a/tests/utils/authTestUtils.js
+++ b/tests/utils/authTestUtils.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const { USER_ROLES } = require('../../src/constants/roles');
+
+const buildTestUser = (overrides = {}) => ({
+    id: overrides.id ?? 1000,
+    name: overrides.name || 'Administrador Teste',
+    email: overrides.email || 'admin.teste@example.com',
+    role: overrides.role || USER_ROLES.ADMIN,
+    active: overrides.active !== false,
+    profileImage: overrides.profileImage ?? null
+});
+
+const authenticateTestUser = async (app, overrides = {}) => {
+    const agent = request.agent(app);
+    const user = buildTestUser(overrides);
+    const payload = { user };
+
+    if (Array.isArray(overrides.notifications)) {
+        payload.notifications = overrides.notifications;
+    }
+
+    await agent
+        .post('/__test/login')
+        .send(payload);
+
+    return { agent, user };
+};
+
+const logoutTestAgent = async (agent) => {
+    await agent.post('/__test/logout');
+};
+
+module.exports = {
+    authenticateTestUser,
+    buildTestUser,
+    logoutTestAgent
+};

--- a/tests/utils/createRouterTestApp.js
+++ b/tests/utils/createRouterTestApp.js
@@ -1,0 +1,123 @@
+const express = require('express');
+const session = require('express-session');
+const flash = require('connect-flash');
+const path = require('path');
+
+const {
+    USER_ROLES,
+    ROLE_LABELS,
+    ROLE_ORDER,
+    getRoleLevel
+} = require('../../src/constants/roles');
+
+const DEFAULT_APP_NAME = 'Sistema de Gestão Inteligente';
+
+const sanitizeUser = (user = {}) => ({
+    id: user.id ?? 999,
+    name: user.name || 'Usuário Teste',
+    email: user.email || 'usuario@example.com',
+    role: user.role || USER_ROLES.ADMIN,
+    active: user.active !== false,
+    profileImage: user.profileImage || null
+});
+
+const normalizeFlashMessages = (messages) => {
+    if (!messages) {
+        return null;
+    }
+
+    const values = (Array.isArray(messages) ? messages : [messages])
+        .map((message) => {
+            if (typeof message === 'string') {
+                return message.trim();
+            }
+
+            if (message && typeof message.message === 'string') {
+                return message.message.trim();
+            }
+
+            if (message && typeof message.toString === 'function') {
+                return message.toString().trim();
+            }
+
+            return '';
+        })
+        .filter(Boolean);
+
+    if (!values.length) {
+        return null;
+    }
+
+    return values.join(' ');
+};
+
+const createRouterTestApp = ({ routes = [] } = {}) => {
+    const app = express();
+
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+
+    app.use(session({
+        secret: 'router-test-session',
+        resave: false,
+        saveUninitialized: false
+    }));
+    app.use(flash());
+
+    app.set('view engine', 'ejs');
+    app.set('views', path.join(__dirname, '..', '..', 'src', 'views'));
+
+    const roleOptions = ROLE_ORDER.map((role) => ({ value: role, label: ROLE_LABELS[role] }));
+
+    app.use((req, res, next) => {
+        res.locals.appName = DEFAULT_APP_NAME;
+        res.locals.pageTitle = DEFAULT_APP_NAME;
+        res.locals.roles = USER_ROLES;
+        res.locals.roleLabels = ROLE_LABELS;
+        res.locals.roleOptions = roleOptions;
+        res.locals.success_msg = normalizeFlashMessages(req.flash('success_msg'));
+        res.locals.error_msg = normalizeFlashMessages(req.flash('error_msg'));
+        res.locals.error = normalizeFlashMessages(req.flash('error'));
+        res.locals.notifications = Array.isArray(req.session.notifications) ? req.session.notifications : [];
+        res.locals.notificationError = null;
+        res.locals.managerLevel = getRoleLevel(USER_ROLES.MANAGER);
+        res.locals.adminLevel = getRoleLevel(USER_ROLES.ADMIN);
+
+        const sessionUser = req.session.user;
+        if (sessionUser && sessionUser.active) {
+            req.user = sessionUser;
+            res.locals.user = sessionUser;
+            res.locals.userRoleLevel = getRoleLevel(sessionUser.role);
+        } else {
+            req.user = null;
+            res.locals.user = null;
+            res.locals.userRoleLevel = -1;
+        }
+
+        return next();
+    });
+
+    app.post('/__test/login', (req, res) => {
+        const sanitizedUser = sanitizeUser(req.body.user);
+        req.session.user = sanitizedUser;
+        req.session.notifications = Array.isArray(req.body.notifications) ? req.body.notifications : [];
+        res.status(204).end();
+    });
+
+    app.post('/__test/logout', (req, res) => {
+        req.session.regenerate((error) => {
+            if (error) {
+                return res.status(500).json({ message: 'Não foi possível encerrar a sessão de teste.' });
+            }
+            return res.status(204).end();
+        });
+    });
+
+    routes.forEach(([basePath, router]) => {
+        app.use(basePath, router);
+    });
+
+    return app;
+};
+
+module.exports = { createRouterTestApp };


### PR DESCRIPTION
## Summary
- add responsive design tokens and helper classes to support new finance and notifications layouts
- refresh finance and notification views to use the responsive wrappers and modern card/table styling
- introduce authentication helpers plus smoke and partial rendering tests to cover critical routes and EJS partials

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d92639f8832f85f0214fb5e3d437