### PR TITLE
Fix missing navigation utilities import

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const methodOverride = require('method-override');
 const path = require('path');
 const { sequelize, User } = require('./database/models');
 const { USER_ROLES, ROLE_LABELS, ROLE_ORDER, getRoleLevel } = require('./src/constants/roles');
+const { getNavigationShortcuts, getMenuItems, getQuickActions } = require('./src/utils/navigation');
 
 const APP_NAME = process.env.APP_NAME || 'Sistema de Gestão Inteligente';
 


### PR DESCRIPTION
## Summary
- require the navigation utility helpers in `server.js` to prevent runtime reference errors when building menu data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e4decef8832fb690f4ed98ddcb4c