### PR TITLE
Fix accent color column type for notifications

### DIFF
--- a/database/migrations/20240911-fix-accent-color-on-notifications.js
+++ b/database/migrations/20240911-fix-accent-color-on-notifications.js
@@ -1,0 +1,44 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            const tableDefinition = await queryInterface.describeTable('Notifications', { transaction });
+
+            if (tableDefinition.accentColor) {
+                await queryInterface.removeColumn('Notifications', 'accentColor', { transaction });
+            }
+
+            await queryInterface.addColumn(
+                'Notifications',
+                'accentColor',
+                {
+                    type: Sequelize.STRING(9),
+                    allowNull: false,
+                    defaultValue: '#0d6efd'
+                },
+                { transaction }
+            );
+        });
+    },
+
+    async down(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            const tableDefinition = await queryInterface.describeTable('Notifications', { transaction });
+
+            if (tableDefinition.accentColor) {
+                await queryInterface.removeColumn('Notifications', 'accentColor', { transaction });
+            }
+
+            await queryInterface.addColumn(
+                'Notifications',
+                'accentColor',
+                {
+                    type: Sequelize.DATE,
+                    allowNull: true
+                },
+                { transaction }
+            );
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a defensive migration that recreates the Notifications.accentColor column as a non-null string with the expected default
- expand the schema regression test to cover the new migration and assert the accentColor metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e699fe8c832f8b8c0ca560ee8661