### PR TITLE
Handle order from buildUserWhere in custom notifications

### DIFF
--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -415,11 +415,15 @@ async function processCustomNotification(notif) {
     const hasAdvancedFilters = Object.keys(filters).some((key) => !['onlyActive', 'includeProfessional', 'includeClient'].includes(key));
 
     if (notif.sendToAll || hasAdvancedFilters) {
-        const where = buildUserWhere(filters, preferenceOptions);
-        const users = await User.findAll({
+        const { where, order } = buildUserWhere(filters, preferenceOptions);
+        const queryOptions = {
             where,
             include: [userPreferenceInclude]
-        });
+        };
+        if (order?.length) {
+            queryOptions.order = order;
+        }
+        const users = await User.findAll(queryOptions);
         users.forEach(enqueueUser);
     }
 


### PR DESCRIPTION
## Summary
- destructure the result of buildUserWhere when processing custom notifications
- pass along any ordering generated by buildUserWhere to User.findAll while keeping the existing include

## Testing
- npm run test *(fails: test server exits early because module 'pdfkit' is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e8d4866c832f9573843d1bd57d9f