### PR TITLE
Add email and payment controls to appointment editing

### DIFF
--- a/src/views/appointments/editAppointment.ejs
+++ b/src/views/appointments/editAppointment.ejs
@@ -13,6 +13,15 @@
         />
     </div>
     <div class="mb-3">
+        <label class="form-label">E-mail do Cliente</label>
+        <input
+                type="email"
+                class="form-control"
+                name="clientEmail"
+                value="<%= appointment.clientEmail || '' %>"
+        />
+    </div>
+    <div class="mb-3">
         <label class="form-label">Profissional</label>
         <select class="form-select" name="professionalId">
             <% professionals.forEach(p => { %>
@@ -68,6 +77,19 @@
             <option value="completed" <%= appointment.status === 'completed' ? 'selected' : '' %>>Concluído</option>
             <option value="canceled" <%= appointment.status === 'canceled' ? 'selected' : '' %>>Cancelado</option>
         </select>
+    </div>
+    <div class="form-check form-switch mb-3">
+        <input type="hidden" name="paymentConfirmed" value="false" />
+        <input
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                id="paymentConfirmed"
+                name="paymentConfirmed"
+                value="true"
+                <%= appointment.paymentConfirmed ? 'checked' : '' %>
+        />
+        <label class="form-check-label" for="paymentConfirmed">Pagamento confirmado</label>
     </div>
     <button type="submit" class="btn btn-primary">Salvar</button>
 </form>


### PR DESCRIPTION
## Summary
- add client email and payment confirmation controls to the appointment edit view
- ensure payment confirmation posts `true`/`false` values and preserve existing data when fields are omitted
- normalize appointment update logic to maintain current values and convert payment confirmation to boolean

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c9e8d9e294832f9024809b25373c03