### PR TITLE
Add finance export chart rendering

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,30 @@
+# Dependências para geração de gráficos em relatórios
+
+Para habilitar a renderização de gráficos nos relatórios de finanças foram adicionadas as seguintes bibliotecas ao projeto:
+
+- [`chart.js` ^4.5.0](https://www.npmjs.com/package/chart.js): motor de gráficos utilizado para definir datasets, estilos modernos e interações de tooltips.
+- [`chartjs-node-canvas` ^5.0.0](https://www.npmjs.com/package/chartjs-node-canvas): camada server-side que renderiza gráficos Chart.js em buffers PNG utilizando Node.js.
+
+## Requisitos de sistema
+
+A biblioteca `chartjs-node-canvas` depende do pacote [`canvas`](https://www.npmjs.com/package/canvas), que por sua vez necessita de bibliotecas nativas. Em distribuições Debian/Ubuntu, instale os pacotes abaixo antes de executar `npm install` em ambientes novos:
+
+```bash
+sudo apt-get update && sudo apt-get install -y \
+    build-essential \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev
+```
+
+## Procedimento de instalação
+
+Após garantir os requisitos do sistema, execute:
+
+```bash
+npm install
+```
+
+Isso instalará todas as dependências, incluindo as novas bibliotecas de geração de gráficos.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "argon2": "^0.44.0",
         "bootstrap": "^5.3.0",
+        "chart.js": "^4.5.0",
+        "chartjs-node-canvas": "^5.0.0",
         "connect-flash": "^0.1.1",
         "dotenv": "^16.0.0",
         "ejs": "^3.1.10",
@@ -1041,6 +1043,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -2121,6 +2129,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvas": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
+      "integrity": "sha512-jk0GxrLtUEmW/TmFsk2WghvgHe8B0pxGilqCL21y8lHkPUGa6FTsnCNtHPOzT8O3y+N+m3espawV80bbBlgfTA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
+    "node_modules/canvas/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -2156,6 +2184,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-node-canvas": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-5.0.0.tgz",
+      "integrity": "sha512-+Lc5phRWjb+UxAIiQpKgvOaG6Mw276YQx2jl2BrxoUtI3A4RYTZuGM5Dq+s4ReYmCY42WEPSR6viF3lDSTxpvw==",
+      "license": "MIT",
+      "dependencies": {
+        "canvas": "^3.1.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "chart.js": "^4.4.8"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "argon2": "^0.44.0",
     "bootstrap": "^5.3.0",
+    "chart.js": "^4.5.0",
+    "chartjs-node-canvas": "^5.0.0",
     "connect-flash": "^0.1.1",
     "dotenv": "^16.0.0",
     "ejs": "^3.1.10",

--- a/src/services/reportChartService.js
+++ b/src/services/reportChartService.js
@@ -1,0 +1,244 @@
+'use strict';
+
+require('chart.js/auto');
+const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 400;
+const DEFAULT_BACKGROUND = '#FFFFFF';
+
+const canvasCache = new Map();
+
+const numberFormatter = new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+});
+
+const toNumber = (value) => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const formatCurrency = (value) => numberFormatter.format(toNumber(value));
+
+const formatMonthLabel = (value) => {
+    if (typeof value === 'string' && /^\d{4}-\d{2}$/.test(value)) {
+        const [year, month] = value.split('-').map((part) => Number.parseInt(part, 10));
+        if (Number.isFinite(year) && Number.isFinite(month)) {
+            const date = new Date(Date.UTC(year, month - 1, 1));
+            if (Number.isFinite(date.getTime())) {
+                return date.toLocaleDateString('pt-BR', {
+                    month: 'short',
+                    year: 'numeric'
+                });
+            }
+        }
+    }
+
+    if (value instanceof Date && Number.isFinite(value.getTime())) {
+        return value.toLocaleDateString('pt-BR', {
+            month: 'short',
+            year: 'numeric'
+        });
+    }
+
+    if (value === null || value === undefined) {
+        return '—';
+    }
+
+    return String(value).trim() || '—';
+};
+
+const getRenderer = (options = {}) => {
+    const width = Number.isFinite(options.width) && options.width > 0
+        ? Math.floor(options.width)
+        : DEFAULT_WIDTH;
+    const height = Number.isFinite(options.height) && options.height > 0
+        ? Math.floor(options.height)
+        : DEFAULT_HEIGHT;
+    const background = typeof options.backgroundColour === 'string' && options.backgroundColour.trim()
+        ? options.backgroundColour
+        : typeof options.backgroundColor === 'string' && options.backgroundColor.trim()
+            ? options.backgroundColor
+            : DEFAULT_BACKGROUND;
+
+    const cacheKey = `${width}x${height}:${background}`;
+
+    if (!canvasCache.has(cacheKey)) {
+        canvasCache.set(cacheKey, new ChartJSNodeCanvas({
+            width,
+            height,
+            backgroundColour: background,
+            chartCallback: (chartJS) => {
+                chartJS.defaults.font.family = 'sans-serif';
+                chartJS.defaults.color = '#1F2937';
+            }
+        }));
+    }
+
+    return {
+        renderer: canvasCache.get(cacheKey),
+        width,
+        height
+    };
+};
+
+const buildChartConfiguration = (summary = {}, options = {}) => {
+    const monthlySummary = Array.isArray(summary?.monthlySummary) ? summary.monthlySummary : [];
+
+    if (!monthlySummary.length) {
+        return null;
+    }
+
+    const labels = monthlySummary.map((item) => formatMonthLabel(item?.month));
+    const payableData = monthlySummary.map((item) => toNumber(item?.payable));
+    const receivableData = monthlySummary.map((item) => toNumber(item?.receivable));
+
+    const hasRelevantData = payableData.some((value) => value !== 0) || receivableData.some((value) => value !== 0);
+
+    if (!hasRelevantData) {
+        return null;
+    }
+
+    const title = typeof options.title === 'string' && options.title.trim()
+        ? options.title.trim()
+        : 'Fluxo Mensal de Pagamentos e Recebimentos';
+
+    return {
+        type: 'line',
+        data: {
+            labels,
+            datasets: [
+                {
+                    label: 'A Receber',
+                    data: receivableData,
+                    borderColor: '#2563EB',
+                    backgroundColor: 'rgba(37, 99, 235, 0.25)',
+                    pointBackgroundColor: '#1D4ED8',
+                    pointBorderColor: '#FFFFFF',
+                    pointBorderWidth: 2,
+                    pointRadius: 4,
+                    tension: 0.35,
+                    fill: true
+                },
+                {
+                    label: 'A Pagar',
+                    data: payableData,
+                    borderColor: '#F97316',
+                    backgroundColor: 'rgba(249, 115, 22, 0.25)',
+                    pointBackgroundColor: '#C2410C',
+                    pointBorderColor: '#FFFFFF',
+                    pointBorderWidth: 2,
+                    pointRadius: 4,
+                    tension: 0.35,
+                    fill: true
+                }
+            ]
+        },
+        options: {
+            responsive: false,
+            maintainAspectRatio: false,
+            layout: {
+                padding: {
+                    top: 16,
+                    right: 24,
+                    bottom: 16,
+                    left: 24
+                }
+            },
+            plugins: {
+                legend: {
+                    position: 'top',
+                    labels: {
+                        color: '#1F2937',
+                        font: {
+                            family: 'sans-serif',
+                            size: 12,
+                            weight: '600'
+                        },
+                        usePointStyle: true,
+                        padding: 16
+                    }
+                },
+                title: {
+                    display: true,
+                    text: title,
+                    color: '#111827',
+                    font: {
+                        family: 'sans-serif',
+                        size: 18,
+                        weight: '700'
+                    },
+                    padding: {
+                        bottom: 12
+                    }
+                },
+                tooltip: {
+                    callbacks: {
+                        label: (context) => {
+                            const value = toNumber(context?.parsed?.y);
+                            return `${context.dataset.label}: ${formatCurrency(value)}`;
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: {
+                        color: '#374151',
+                        font: {
+                            family: 'sans-serif'
+                        }
+                    },
+                    grid: {
+                        color: 'rgba(209, 213, 219, 0.4)'
+                    }
+                },
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        color: '#374151',
+                        font: {
+                            family: 'sans-serif'
+                        },
+                        callback: (value) => formatCurrency(value)
+                    },
+                    grid: {
+                        color: 'rgba(209, 213, 219, 0.25)'
+                    }
+                }
+            }
+        }
+    };
+};
+
+const generateFinanceReportChart = async (summary = {}, options = {}) => {
+    const chartConfiguration = buildChartConfiguration(summary, options);
+
+    if (!chartConfiguration) {
+        return null;
+    }
+
+    const { renderer, width, height } = getRenderer(options);
+    const buffer = await renderer.renderToBuffer(chartConfiguration, 'image/png');
+
+    return {
+        buffer,
+        width,
+        height,
+        dataUrl: `data:image/png;base64,${buffer.toString('base64')}`
+    };
+};
+
+module.exports = {
+    generateFinanceReportChart,
+    utils: {
+        formatMonthLabel,
+        buildChartConfiguration
+    }
+};


### PR DESCRIPTION
## Summary
- add a Chart.js based service to render finance summary charts on the server
- embed the generated chart image into PDF and Excel exports with descriptive captions
- update integration tests and documentation to cover the new chart workflow and dependencies

## Testing
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68c9e8da33d0832faeb1dbb9bc164290