### PR TITLE
Atualiza seleção e validação de intervalos recorrentes

### DIFF
--- a/database/models/financeEntry.js
+++ b/database/models/financeEntry.js
@@ -1,4 +1,11 @@
 'use strict';
+
+const {
+    FINANCE_RECURRING_INTERVAL_VALUES
+} = require('../../src/constants/financeRecurringIntervals');
+
+const allowedRecurringIntervals = new Set(FINANCE_RECURRING_INTERVAL_VALUES);
+
 module.exports = (sequelize, DataTypes) => {
     const FinanceEntry = sequelize.define('FinanceEntry', {
         description: {
@@ -69,8 +76,9 @@ module.exports = (sequelize, DataTypes) => {
             validate: {
                 isAllowedInterval(value) {
                     if (!value) return;
-                    const allowed = ['weekly', 'biweekly', 'monthly', 'quarterly', 'yearly'];
-                    if (!allowed.includes(value)) {
+
+                    const normalizedValue = typeof value === 'string' ? value.toLowerCase() : value;
+                    if (!allowedRecurringIntervals.has(normalizedValue)) {
                         throw new Error('Intervalo recorrente inválido.');
                     }
                 }

--- a/src/constants/financeRecurringIntervals.js
+++ b/src/constants/financeRecurringIntervals.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const FINANCE_RECURRING_INTERVALS = Object.freeze([
+    { value: 'weekly', label: 'Semanal' },
+    { value: 'biweekly', label: 'Quinzenal' },
+    { value: 'monthly', label: 'Mensal' },
+    { value: 'quarterly', label: 'Trimestral' },
+    { value: 'yearly', label: 'Anual' }
+]);
+
+const FINANCE_RECURRING_INTERVAL_VALUES = Object.freeze(
+    FINANCE_RECURRING_INTERVALS.map((interval) => interval.value)
+);
+
+const FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE = FINANCE_RECURRING_INTERVALS.reduce(
+    (accumulator, interval) => {
+        if (!interval || typeof interval.label !== 'string') {
+            return accumulator;
+        }
+
+        const normalizedLabel = interval.label.trim().toLowerCase();
+        if (normalizedLabel) {
+            accumulator[normalizedLabel] = interval.value;
+        }
+
+        return accumulator;
+    },
+    Object.create(null)
+);
+
+const FINANCE_RECURRING_INTERVAL_VALUE_SET = new Set(
+    FINANCE_RECURRING_INTERVAL_VALUES.map((value) => value.toLowerCase())
+);
+
+const normalizeRecurringInterval = (rawValue) => {
+    if (typeof rawValue !== 'string') {
+        return null;
+    }
+
+    const trimmedValue = rawValue.trim();
+    if (!trimmedValue) {
+        return null;
+    }
+
+    const normalizedValue = trimmedValue.toLowerCase();
+    if (FINANCE_RECURRING_INTERVAL_VALUE_SET.has(normalizedValue)) {
+        return normalizedValue;
+    }
+
+    const mappedValue = FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE[normalizedValue];
+    return mappedValue || null;
+};
+
+module.exports = {
+    FINANCE_RECURRING_INTERVALS,
+    FINANCE_RECURRING_INTERVAL_VALUES,
+    FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE,
+    normalizeRecurringInterval
+};

--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -3,8 +3,17 @@ const PDFDocument = require('pdfkit');
 const ExcelJS = require('exceljs');
 const financeReportingService = require('../services/financeReportingService');
 const reportChartService = require('../services/reportChartService');
+const {
+    FINANCE_RECURRING_INTERVALS,
+    normalizeRecurringInterval
+} = require('../constants/financeRecurringIntervals');
 
 const { utils: reportingUtils } = financeReportingService;
+
+const recurringIntervalOptions = FINANCE_RECURRING_INTERVALS.map((interval) => ({
+    value: interval.value,
+    label: interval.label
+}));
 
 const parseAmount = (value) => {
     if (typeof value === 'number') {
@@ -106,7 +115,8 @@ module.exports = {
                 periodLabel: formatPeriodLabel(filters),
                 statusSummary: summary.statusSummary,
                 monthlySummary: summary.monthlySummary,
-                financeTotals: summary.totals
+                financeTotals: summary.totals,
+                recurringIntervalOptions
             });
         } catch (err) {
             console.error(err);
@@ -124,7 +134,7 @@ module.exports = {
                 value,
                 dueDate,
                 recurring: (recurring === 'true'),
-                recurringInterval: recurringInterval || null
+                recurringInterval: normalizeRecurringInterval(recurringInterval)
             });
             req.flash('success_msg', 'Lançamento criado com sucesso!');
             res.redirect('/finance');
@@ -153,7 +163,7 @@ module.exports = {
             entry.paymentDate = paymentDate || null;
             entry.status = status;
             entry.recurring = (recurring === 'true');
-            entry.recurringInterval = recurringInterval || null;
+            entry.recurringInterval = normalizeRecurringInterval(recurringInterval);
 
             await entry.save();
             req.flash('success_msg', 'Lançamento atualizado!');

--- a/src/services/financeReportingService.js
+++ b/src/services/financeReportingService.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const { FinanceEntry, Sequelize } = require('../../database/models');
+const {
+    FINANCE_RECURRING_INTERVALS,
+    FINANCE_RECURRING_INTERVAL_VALUES,
+    FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE,
+    normalizeRecurringInterval
+} = require('../constants/financeRecurringIntervals');
 
 const { Op } = Sequelize;
 
@@ -203,7 +209,10 @@ module.exports = {
     getFinanceSummary,
     constants: {
         FINANCE_TYPES: [...FINANCE_TYPES],
-        FINANCE_STATUSES: [...FINANCE_STATUSES]
+        FINANCE_STATUSES: [...FINANCE_STATUSES],
+        FINANCE_RECURRING_INTERVALS: FINANCE_RECURRING_INTERVALS.map((interval) => ({ ...interval })),
+        FINANCE_RECURRING_INTERVAL_VALUES: [...FINANCE_RECURRING_INTERVAL_VALUES],
+        FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE: { ...FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE }
     },
     utils: {
         buildTotalsFromStatus,
@@ -211,6 +220,7 @@ module.exports = {
         buildMonthlySummaryFromEntries,
         createEmptyStatusSummary,
         buildDateFilter,
-        isValidISODate
+        isValidISODate,
+        normalizeRecurringInterval
     }
 };

--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -1,5 +1,7 @@
 <%- include('../partials/header') %>
 
+<% const intervalOptions = Array.isArray(recurringIntervalOptions) ? recurringIntervalOptions : []; %>
+
 <div class="row fade-in responsive-page-row gy-4">
     <div class="col-12">
         <div class="card card-soft responsive-panel">
@@ -214,13 +216,15 @@
                                                     </div>
                                                     <div class="mb-3">
                                                         <label class="form-label">Intervalo de recorrência</label>
-                                                        <input
-                                                            type="text"
-                                                            class="form-control"
-                                                            name="recurringInterval"
-                                                            value="<%= entry.recurringInterval || '' %>"
-                                                            placeholder="Ex.: mensal, trimestral"
-                                                        />
+                                                        <select class="form-select" name="recurringInterval">
+                                                            <option value="" <%= entry.recurringInterval ? '' : 'selected' %>>Selecione um intervalo</option>
+                                                            <% intervalOptions.forEach((option) => { %>
+                                                                <% if (!option || !option.value) { return; } %>
+                                                                <option value="<%= option.value %>" <%= entry.recurringInterval === option.value ? 'selected' : '' %>>
+                                                                    <%= option.label %>
+                                                                </option>
+                                                            <% }); %>
+                                                        </select>
                                                     </div>
                                                 </div>
                                                 <div class="modal-footer">
@@ -294,12 +298,13 @@
                 </div>
                 <div class="col-md-3">
                     <label class="form-label">Intervalo (opcional)</label>
-                    <input
-                        type="text"
-                        class="form-control"
-                        name="recurringInterval"
-                        placeholder="Ex.: mensal"
-                    />
+                    <select class="form-select" name="recurringInterval">
+                        <option value="" selected>Selecione um intervalo</option>
+                        <% intervalOptions.forEach((option) => { %>
+                            <% if (!option || !option.value) { return; } %>
+                            <option value="<%= option.value %>"><%= option.label %></option>
+                        <% }); %>
+                    </select>
                 </div>
                 <div class="col-md-12">
                     <div class="responsive-form-actions">

--- a/tests/integration/routes.smoke.test.js
+++ b/tests/integration/routes.smoke.test.js
@@ -74,7 +74,7 @@ describe('Smoke tests das rotas principais', () => {
                 paymentDate: '2024-05-11',
                 status: 'paid',
                 recurring: true,
-                recurringInterval: 'mensal'
+                recurringInterval: 'monthly'
             }
         ]);
 

--- a/tests/unit/controllers/financeController.test.js
+++ b/tests/unit/controllers/financeController.test.js
@@ -1,0 +1,91 @@
+jest.mock('../../../database/models', () => {
+    const { Op } = require('sequelize');
+
+    return {
+        FinanceEntry: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findByPk: jest.fn()
+        },
+        Sequelize: { Op }
+    };
+});
+
+const { FinanceEntry } = require('../../../database/models');
+const financeController = require('../../../src/controllers/financeController');
+
+const buildResponseMock = () => ({
+    redirect: jest.fn()
+});
+
+describe('financeController', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('mapeia rótulos traduzidos para intervalos aceitos ao criar um lançamento', async () => {
+        const req = {
+            body: {
+                description: 'Assinatura do serviço',
+                type: 'payable',
+                value: '199.90',
+                dueDate: '2024-01-10',
+                recurring: 'true',
+                recurringInterval: 'Mensal'
+            },
+            flash: jest.fn()
+        };
+        const res = buildResponseMock();
+
+        FinanceEntry.create.mockResolvedValue({ id: 42 });
+
+        await financeController.createFinanceEntry(req, res);
+
+        expect(FinanceEntry.create).toHaveBeenCalledWith(
+            expect.objectContaining({ recurringInterval: 'monthly' })
+        );
+        expect(req.flash).toHaveBeenCalledWith('success_msg', expect.any(String));
+        expect(res.redirect).toHaveBeenCalledWith('/finance');
+    });
+
+    it('mapeia rótulos traduzidos para intervalos aceitos ao atualizar um lançamento', async () => {
+        const save = jest.fn();
+        const entry = {
+            id: 7,
+            description: 'Original',
+            type: 'payable',
+            value: '0',
+            dueDate: '2024-01-01',
+            paymentDate: null,
+            status: 'pending',
+            recurring: false,
+            recurringInterval: null,
+            save
+        };
+
+        FinanceEntry.findByPk.mockResolvedValue(entry);
+
+        const req = {
+            params: { id: 7 },
+            body: {
+                description: 'Receita recorrente',
+                type: 'receivable',
+                value: '500.00',
+                dueDate: '2024-02-15',
+                paymentDate: '',
+                status: 'paid',
+                recurring: 'true',
+                recurringInterval: 'Quinzenal'
+            },
+            flash: jest.fn()
+        };
+        const res = buildResponseMock();
+
+        await financeController.updateFinanceEntry(req, res);
+
+        expect(entry.recurringInterval).toBe('biweekly');
+        expect(save).toHaveBeenCalledTimes(1);
+        expect(req.flash).toHaveBeenCalledWith('success_msg', expect.any(String));
+        expect(res.redirect).toHaveBeenCalledWith('/finance');
+    });
+});

--- a/tests/unit/views/manageFinance.test.js
+++ b/tests/unit/views/manageFinance.test.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ejs = require('ejs');
 
 const { USER_ROLES, ROLE_LABELS, getRoleLevel } = require('../../../src/constants/roles');
+const { FINANCE_RECURRING_INTERVALS } = require('../../../src/constants/financeRecurringIntervals');
 
 const viewPath = path.join(__dirname, '../../../src/views/finance/manageFinance.ejs');
 
@@ -26,9 +27,10 @@ const buildViewContext = () => ({
             paymentDate: '2024-05-02',
             status: 'paid',
             recurring: true,
-            recurringInterval: 'Mensal'
+            recurringInterval: 'monthly'
         }
     ],
+    recurringIntervalOptions: FINANCE_RECURRING_INTERVALS,
     success_msg: null,
     error_msg: null,
     error: null,
@@ -48,6 +50,9 @@ describe('views/finance/manageFinance', () => {
         expect(html).toContain('data-export-target="/finance/export/excel"');
         expect(html).toContain('Exportar Excel');
         expect(html).toContain('aria-label="Exportar lançamentos filtrados em Excel"');
+
+        expect(html).toContain('option value="monthly"');
+        expect(html).toContain('>Mensal<');
     });
 });
 


### PR DESCRIPTION
## Summary
- replace the recurring interval text fields with translated select options in the finance views
- centralize allowed recurring interval constants and reuse them in controller/service/model logic
- add tests covering controller normalization and adjust existing fixtures to the new options

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f99caa14832f8e6703a4de19b530