### PR TITLE
feat: add user profile management

### DIFF
--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -16,6 +16,19 @@ const manageUsersValidation = createFilterValidation({
     redirectTo: '/users/manage'
 });
 
+router.get(
+    '/profile',
+    authMiddleware,
+    userController.showProfile
+);
+
+router.post(
+    '/profile',
+    authMiddleware,
+    audit('user.profile.update', (req) => `User:${req.user?.id || 'unknown'}`),
+    userController.updateProfile
+);
+
 // Todas as rotas de gerenciamento de usuários requerem login e perfil de administrador
 router.get(
     '/manage',

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -217,6 +217,16 @@
                             <li>
                                 <a
                                     class="dropdown-item user-menu-link d-flex align-items-center gap-2"
+                                    href="/users/profile"
+                                    data-nav-close="true"
+                                >
+                                    <i class="bi bi-person-circle me-2"></i>
+                                    <span>Perfil</span>
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    class="dropdown-item user-menu-link d-flex align-items-center gap-2"
                                     href="/users/preferences"
                                     data-nav-close="true"
                                 >

--- a/src/views/users/profile.ejs
+++ b/src/views/users/profile.ejs
@@ -1,0 +1,144 @@
+<%- include('../partials/header') %>
+
+<% const profileData = profile || (typeof profileUser !== 'undefined' ? profileUser : {}); %>
+<% const nameValue = profileData && profileData.name ? profileData.name : ''; %>
+<% const emailValue = profileData && profileData.email ? profileData.email : ''; %>
+<% const phoneValue = profileData && profileData.phone ? profileData.phone : ''; %>
+<% const addressValue = profileData && profileData.address ? profileData.address : ''; %>
+<% const birthValue = profileData && profileData.dateOfBirth ? profileData.dateOfBirth : ''; %>
+
+<div class="row justify-content-center py-4 fade-in">
+    <div class="col-xl-7 col-lg-8">
+        <div class="card card-soft p-4 shadow-sm">
+            <div class="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-3">
+                <div>
+                    <h2 class="fw-semibold mb-1">Meu perfil</h2>
+                    <p class="text-muted mb-0">Mantenha seus dados pessoais atualizados para uma experiência mais segura e personalizada.</p>
+                </div>
+                <span class="badge-soft badge-soft-primary d-inline-flex align-items-center px-3 py-2">
+                    <i class="bi bi-shield-lock me-2"></i>
+                    Segurança reforçada
+                </span>
+            </div>
+
+            <% if (success_msg) { %>
+                <div class="alert alert-success alert-auto" data-auto-dismiss="5000">
+                    <i class="bi bi-check-circle me-2"></i><%= success_msg %>
+                </div>
+            <% } else if (error_msg) { %>
+                <div class="alert alert-danger alert-auto" data-auto-dismiss="7000">
+                    <i class="bi bi-exclamation-triangle me-2"></i><%= error_msg %>
+                </div>
+            <% } %>
+
+            <form action="/users/profile" method="POST" class="row g-4 needs-validation" novalidate>
+                <div class="col-md-6">
+                    <label for="profileName" class="form-label fw-semibold">Nome completo</label>
+                    <input
+                        type="text"
+                        class="form-control"
+                        id="profileName"
+                        name="name"
+                        value="<%= nameValue %>"
+                        placeholder="Informe seu nome"
+                        required
+                        minlength="3"
+                    />
+                    <div class="invalid-feedback">Informe um nome com pelo menos 3 caracteres.</div>
+                </div>
+
+                <div class="col-md-6">
+                    <label for="profileEmail" class="form-label fw-semibold">E-mail</label>
+                    <input
+                        type="email"
+                        class="form-control"
+                        id="profileEmail"
+                        value="<%= emailValue %>"
+                        disabled
+                        readonly
+                    />
+                    <div class="form-text">Para alterar o e-mail entre em contato com a equipe responsável.</div>
+                </div>
+
+                <div class="col-md-6">
+                    <label for="profilePhone" class="form-label fw-semibold">Telefone</label>
+                    <input
+                        type="tel"
+                        class="form-control"
+                        id="profilePhone"
+                        name="phone"
+                        value="<%= phoneValue %>"
+                        placeholder="(00) 00000-0000"
+                    />
+                    <div class="form-text">Utilize apenas números. Este campo é opcional.</div>
+                </div>
+
+                <div class="col-md-6">
+                    <label for="profileBirth" class="form-label fw-semibold">Data de nascimento</label>
+                    <input
+                        type="date"
+                        class="form-control"
+                        id="profileBirth"
+                        name="dateOfBirth"
+                        value="<%= birthValue %>"
+                        max="<%= new Date().toISOString().split('T')[0] %>"
+                    />
+                    <div class="form-text">A data de nascimento ajuda na personalização dos lembretes.</div>
+                </div>
+
+                <div class="col-12">
+                    <label for="profileAddress" class="form-label fw-semibold">Endereço</label>
+                    <textarea
+                        id="profileAddress"
+                        name="address"
+                        class="form-control"
+                        rows="3"
+                        placeholder="Rua, número, complemento, cidade"
+                    ><%= addressValue %></textarea>
+                    <div class="form-text">Preencher o endereço permite um atendimento mais ágil.</div>
+                </div>
+
+                <div class="col-md-6">
+                    <label for="profilePassword" class="form-label fw-semibold">Nova senha</label>
+                    <input
+                        type="password"
+                        class="form-control"
+                        id="profilePassword"
+                        name="password"
+                        placeholder="Mínimo de 6 caracteres"
+                        minlength="6"
+                        autocomplete="new-password"
+                    />
+                    <div class="form-text">Deixe em branco para manter a senha atual.</div>
+                </div>
+
+                <div class="col-md-6">
+                    <div class="h-100 d-flex align-items-center rounded border border-dashed px-3 py-3 bg-body-tertiary">
+                        <div class="d-flex align-items-start">
+                            <div class="icon icon-md rounded-circle bg-primary-subtle text-primary me-3">
+                                <i class="bi bi-info-circle"></i>
+                            </div>
+                            <p class="mb-0 small text-muted">
+                                Senhas fortes devem combinar letras maiúsculas, minúsculas, números e símbolos.
+                                Atualize seus dados sempre que houver alguma mudança importante.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-12">
+                    <div class="d-flex justify-content-between flex-wrap gap-2">
+                        <a class="btn btn-outline-secondary" href="/dashboard">
+                            <i class="bi bi-arrow-left me-2"></i>Voltar para o painel
+                        </a>
+                        <button type="submit" class="btn btn-gradient">
+                            <i class="bi bi-check2-circle me-2"></i>Salvar alterações
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<%- include('../partials/footer') %>

--- a/tests/integration/userProfileRoutes.test.js
+++ b/tests/integration/userProfileRoutes.test.js
@@ -1,0 +1,188 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+jest.mock('../../database/models', () => ({
+    User: {
+        findByPk: jest.fn()
+    },
+    UserNotificationPreference: {},
+    AuditLog: {
+        create: jest.fn()
+    },
+    sequelize: {
+        transaction: jest.fn()
+    }
+}));
+
+const { User, AuditLog } = require('../../database/models');
+const { USER_ROLES } = require('../../src/constants/roles');
+const { createRouterTestApp } = require('../utils/createRouterTestApp');
+const { authenticateTestUser } = require('../utils/authTestUtils');
+
+const userRoutes = require('../../src/routes/userRoutes');
+
+describe('Rotas autenticadas de perfil de usuário', () => {
+    let app;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        app = createRouterTestApp({
+            routes: [['/users', userRoutes]]
+        });
+    });
+
+    it('exibe o formulário de perfil com os dados atuais do usuário', async () => {
+        const plainUser = {
+            id: 321,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com',
+            phone: '11999999999',
+            address: 'Rua A, 100',
+            dateOfBirth: '1990-01-01',
+            role: USER_ROLES.CLIENT,
+            active: true
+        };
+
+        User.findByPk.mockResolvedValueOnce({
+            get: jest.fn(() => plainUser)
+        });
+
+        const { agent } = await authenticateTestUser(app, {
+            id: 321,
+            role: USER_ROLES.CLIENT,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com'
+        });
+
+        const response = await agent.get('/users/profile');
+
+        expect(response.status).toBe(200);
+        expect(User.findByPk).toHaveBeenCalledWith(321);
+        expect(response.text).toContain('Meu perfil');
+        expect(response.text).toContain('cliente@exemplo.com');
+        expect(response.text).toContain('Cliente Teste');
+    });
+
+    it('permite que um usuário padrão atualize o próprio perfil', async () => {
+        const userInstance = {
+            id: 321,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com',
+            phone: '11999999999',
+            address: 'Rua A, 100',
+            dateOfBirth: '1990-01-01',
+            role: USER_ROLES.CLIENT,
+            active: true,
+            save: jest.fn().mockResolvedValue(undefined),
+            get: jest.fn(() => ({
+                id: 321,
+                name: 'Cliente Atualizado',
+                email: 'cliente@exemplo.com',
+                phone: '11988887777',
+                address: 'Rua Nova, 200',
+                dateOfBirth: '1991-02-15',
+                role: USER_ROLES.CLIENT,
+                active: true
+            }))
+        };
+
+        User.findByPk.mockResolvedValueOnce(userInstance);
+
+        const { agent } = await authenticateTestUser(app, {
+            id: 321,
+            role: USER_ROLES.CLIENT,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com'
+        });
+
+        const response = await agent
+            .post('/users/profile')
+            .send({
+                name: ' Cliente Atualizado ',
+                phone: ' 11988887777 ',
+                address: ' Rua Nova, 200 ',
+                dateOfBirth: '1991-02-15',
+                password: ' NovaSenha!123 '
+            });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/users/profile');
+        expect(User.findByPk).toHaveBeenCalledWith(321);
+        expect(userInstance.name).toBe('Cliente Atualizado');
+        expect(userInstance.phone).toBe('11988887777');
+        expect(userInstance.address).toBe('Rua Nova, 200');
+        expect(userInstance.dateOfBirth).toBe('1991-02-15');
+        expect(userInstance.password).toBe('NovaSenha!123');
+        expect(userInstance.save).toHaveBeenCalledTimes(1);
+
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(AuditLog.create).toHaveBeenCalledTimes(1);
+        expect(AuditLog.create).toHaveBeenCalledWith(expect.objectContaining({
+            action: 'user.profile.update',
+            resource: 'User:321'
+        }));
+    });
+
+    it('mantém as validações do perfil quando os dados são inválidos', async () => {
+        const validationError = new Error('Validation error');
+        validationError.errors = [{ message: 'Nome é obrigatório.' }];
+
+        const failingInstance = {
+            id: 321,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com',
+            phone: null,
+            address: null,
+            dateOfBirth: null,
+            role: USER_ROLES.CLIENT,
+            active: true,
+            save: jest.fn().mockRejectedValue(validationError),
+            get: jest.fn()
+        };
+
+        User.findByPk.mockResolvedValueOnce(failingInstance);
+
+        const { agent } = await authenticateTestUser(app, {
+            id: 321,
+            role: USER_ROLES.CLIENT,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com'
+        });
+
+        const response = await agent
+            .post('/users/profile')
+            .send({
+                name: '  ',
+                phone: '',
+                address: '',
+                dateOfBirth: '',
+                password: ''
+            });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/users/profile');
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(AuditLog.create).not.toHaveBeenCalled();
+
+        const plainUser = {
+            id: 321,
+            name: 'Cliente Teste',
+            email: 'cliente@exemplo.com',
+            phone: null,
+            address: null,
+            dateOfBirth: null,
+            role: USER_ROLES.CLIENT,
+            active: true
+        };
+
+        User.findByPk.mockResolvedValueOnce({
+            get: jest.fn(() => plainUser)
+        });
+
+        const pageResponse = await agent.get('/users/profile');
+
+        expect(pageResponse.status).toBe(200);
+        expect(pageResponse.text).toContain('Nome é obrigatório.');
+    });
+});

--- a/tests/unit/userController.profile.test.js
+++ b/tests/unit/userController.profile.test.js
@@ -1,0 +1,146 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../../database/models', () => ({
+    User: {
+        findByPk: jest.fn()
+    },
+    UserNotificationPreference: {},
+    sequelize: {
+        transaction: jest.fn()
+    }
+}));
+
+const { User } = require('../../database/models');
+const userController = require('../../src/controllers/userController');
+
+const buildResponse = () => ({
+    redirect: jest.fn()
+});
+
+describe('userController.updateProfile', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('atualiza apenas os dados permitidos do próprio usuário', async () => {
+        const sessionUser = {
+            id: 42,
+            name: 'Cliente Original',
+            email: 'cliente@example.com',
+            role: 'client',
+            active: true
+        };
+
+        const updatedPlain = {
+            id: 42,
+            name: 'Cliente Atualizado',
+            email: 'cliente@example.com',
+            phone: '11988887777',
+            address: 'Rua Nova, 200',
+            dateOfBirth: '1991-02-15',
+            role: 'client',
+            active: true
+        };
+
+        const userInstance = {
+            id: 42,
+            name: 'Cliente Original',
+            email: 'cliente@example.com',
+            phone: null,
+            address: null,
+            dateOfBirth: '1990-01-01',
+            role: 'client',
+            active: true,
+            save: jest.fn().mockResolvedValue(undefined),
+            get: jest.fn(() => updatedPlain)
+        };
+
+        User.findByPk.mockResolvedValueOnce(userInstance);
+
+        const req = {
+            user: { ...sessionUser },
+            session: { user: { ...sessionUser } },
+            body: {
+                name: ' Cliente Atualizado ',
+                phone: ' 11988887777 ',
+                address: ' Rua Nova, 200 ',
+                dateOfBirth: '1991-02-15',
+                password: ' NovaSenha!123 ',
+                email: 'ataque@example.com',
+                role: 'admin'
+            },
+            flash: jest.fn()
+        };
+
+        const res = buildResponse();
+
+        await userController.updateProfile(req, res);
+
+        expect(User.findByPk).toHaveBeenCalledWith(42);
+        expect(userInstance.name).toBe('Cliente Atualizado');
+        expect(userInstance.phone).toBe('11988887777');
+        expect(userInstance.address).toBe('Rua Nova, 200');
+        expect(userInstance.dateOfBirth).toBe('1991-02-15');
+        expect(userInstance.password).toBe('NovaSenha!123');
+        expect(userInstance.email).toBe('cliente@example.com');
+        expect(userInstance.save).toHaveBeenCalledTimes(1);
+
+        expect(req.session.user.name).toBe('Cliente Atualizado');
+        expect(req.session.user.address).toBe('Rua Nova, 200');
+        expect(req.user.name).toBe('Cliente Atualizado');
+
+        expect(req.flash).toHaveBeenCalledWith('success_msg', 'Perfil atualizado com sucesso!');
+        expect(res.redirect).toHaveBeenCalledWith('/users/profile');
+    });
+
+    it('retorna mensagem de validação quando o nome é inválido', async () => {
+        const sessionUser = {
+            id: 55,
+            name: 'Cliente Padrão',
+            email: 'cliente.padrao@example.com',
+            role: 'client',
+            active: true
+        };
+
+        const validationError = new Error('Validation error');
+        validationError.errors = [{ message: 'Nome é obrigatório.' }];
+
+        const userInstance = {
+            id: 55,
+            name: 'Cliente Padrão',
+            email: 'cliente.padrao@example.com',
+            phone: null,
+            address: null,
+            dateOfBirth: null,
+            role: 'client',
+            active: true,
+            save: jest.fn().mockRejectedValue(validationError),
+            get: jest.fn()
+        };
+
+        User.findByPk.mockResolvedValueOnce(userInstance);
+
+        const req = {
+            user: { ...sessionUser },
+            session: { user: { ...sessionUser } },
+            body: {
+                name: '  ',
+                phone: '',
+                address: '',
+                dateOfBirth: '',
+                password: ''
+            },
+            flash: jest.fn()
+        };
+
+        const res = buildResponse();
+
+        await userController.updateProfile(req, res);
+
+        expect(User.findByPk).toHaveBeenCalledWith(55);
+        expect(userInstance.save).toHaveBeenCalledTimes(1);
+        expect(req.session.user.name).toBe('Cliente Padrão');
+        expect(req.flash).toHaveBeenCalledWith('error_msg', 'Nome é obrigatório.');
+        expect(res.redirect).toHaveBeenCalledWith('/users/profile');
+    });
+});


### PR DESCRIPTION
## Summary
- add authenticated profile routes and audit logging for the current user
- implement profile display/update logic with normalization and session refresh in the controller
- build a responsive profile page, expose it in the header menu, and cover it with unit and integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f99cd538832fb1414f67af8bf113