### PR TITLE
feat: add finance attachment uploads

### DIFF
--- a/database/migrations/20240915-create-finance-attachments.js
+++ b/database/migrations/20240915-create-finance-attachments.js
@@ -1,0 +1,62 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('FinanceAttachments', {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: Sequelize.INTEGER
+            },
+            financeEntryId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'FinanceEntries',
+                    key: 'id'
+                },
+                onDelete: 'CASCADE',
+                onUpdate: 'CASCADE'
+            },
+            fileName: {
+                type: Sequelize.STRING(255),
+                allowNull: false
+            },
+            mimeType: {
+                type: Sequelize.STRING(120),
+                allowNull: false
+            },
+            size: {
+                type: Sequelize.BIGINT,
+                allowNull: false
+            },
+            checksum: {
+                type: Sequelize.STRING(128),
+                allowNull: false
+            },
+            storageKey: {
+                type: Sequelize.STRING(255),
+                allowNull: false,
+                unique: true
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            }
+        });
+
+        await queryInterface.addIndex('FinanceAttachments', ['financeEntryId']);
+        await queryInterface.addIndex('FinanceAttachments', ['checksum']);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('FinanceAttachments');
+    }
+};

--- a/database/models/financeAttachment.js
+++ b/database/models/financeAttachment.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const path = require('path');
+
+const MAX_FILENAME_LENGTH = 255;
+
+const sanitizeFileName = (name) => {
+    if (!name) {
+        return 'anexo';
+    }
+
+    const base = path.basename(String(name)).replace(/[^\w\d._-]+/g, '-');
+    const trimmed = base.replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+    if (!trimmed) {
+        return 'anexo';
+    }
+
+    return trimmed.slice(0, MAX_FILENAME_LENGTH);
+};
+
+module.exports = (sequelize, DataTypes) => {
+    const FinanceAttachment = sequelize.define('FinanceAttachment', {
+        financeEntryId: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            references: {
+                model: 'FinanceEntries',
+                key: 'id'
+            },
+            onDelete: 'CASCADE'
+        },
+        fileName: {
+            type: DataTypes.STRING(MAX_FILENAME_LENGTH),
+            allowNull: false,
+            validate: {
+                len: {
+                    args: [1, MAX_FILENAME_LENGTH],
+                    msg: 'Nome do arquivo inválido.'
+                }
+            },
+            set(value) {
+                this.setDataValue('fileName', sanitizeFileName(value));
+            }
+        },
+        mimeType: {
+            type: DataTypes.STRING(120),
+            allowNull: false
+        },
+        size: {
+            type: DataTypes.BIGINT,
+            allowNull: false,
+            validate: {
+                min: 0
+            }
+        },
+        checksum: {
+            type: DataTypes.STRING(128),
+            allowNull: false
+        },
+        storageKey: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+            unique: true
+        }
+    }, {
+        tableName: 'FinanceAttachments'
+    });
+
+    FinanceAttachment.associate = (models) => {
+        FinanceAttachment.belongsTo(models.FinanceEntry, {
+            as: 'entry',
+            foreignKey: 'financeEntryId'
+        });
+    };
+
+    return FinanceAttachment;
+};

--- a/database/models/financeEntry.js
+++ b/database/models/financeEntry.js
@@ -80,5 +80,14 @@ module.exports = (sequelize, DataTypes) => {
         tableName: 'FinanceEntries'
     });
 
+    FinanceEntry.associate = (models) => {
+        FinanceEntry.hasMany(models.FinanceAttachment, {
+            as: 'attachments',
+            foreignKey: 'financeEntryId',
+            onDelete: 'CASCADE',
+            hooks: true
+        });
+    };
+
     return FinanceEntry;
 };

--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -1,8 +1,10 @@
-const { FinanceEntry } = require('../../database/models');
+const { FinanceEntry, FinanceAttachment, sequelize } = require('../../database/models');
 const PDFDocument = require('pdfkit');
 const ExcelJS = require('exceljs');
+const { pipeline } = require('stream/promises');
 const financeReportingService = require('../services/financeReportingService');
 const reportChartService = require('../services/reportChartService');
+const fileStorageService = require('../services/fileStorageService');
 
 const { utils: reportingUtils } = financeReportingService;
 
@@ -71,9 +73,17 @@ const buildFiltersFromQuery = (query = {}) => {
 
 const buildEntriesQueryOptions = (filters = {}) => {
     const options = {
+        include: [
+            {
+                model: FinanceAttachment,
+                as: 'attachments',
+                attributes: ['id', 'fileName', 'mimeType', 'size', 'createdAt']
+            }
+        ],
         order: [
             ['dueDate', 'ASC'],
-            ['id', 'ASC']
+            ['id', 'ASC'],
+            [{ model: FinanceAttachment, as: 'attachments' }, 'createdAt', 'DESC']
         ]
     };
 
@@ -89,6 +99,55 @@ const createSummaryPromise = (entriesPromise, filters) => {
     return entriesPromise.then(entries =>
         financeReportingService.getFinanceSummary(filters, { entries })
     );
+};
+
+const toArray = (value) => (Array.isArray(value) ? value : []);
+
+const removeStoredFiles = async (storageKeys = []) => {
+    await Promise.all(storageKeys.map(async (storageKey) => {
+        try {
+            await fileStorageService.deleteStoredFile(storageKey);
+        } catch (storageError) {
+            console.error('Erro ao remover arquivo armazenado:', storageError);
+        }
+    }));
+};
+
+const persistAttachments = async (entryId, files, transaction) => {
+    const storedKeys = [];
+
+    const attachmentFiles = toArray(files).filter((file) => file && Buffer.isBuffer(file.buffer) && file.size > 0);
+    if (!attachmentFiles.length) {
+        return storedKeys;
+    }
+
+    for (const file of attachmentFiles) {
+        const { storageKey, checksum, sanitizedFileName } = await fileStorageService.saveBuffer({
+            buffer: file.buffer,
+            originalName: file.originalname
+        });
+
+        try {
+            await FinanceAttachment.create({
+                financeEntryId: entryId,
+                fileName: sanitizedFileName,
+                mimeType: file.mimetype,
+                size: file.size,
+                checksum,
+                storageKey
+            }, { transaction });
+            storedKeys.push(storageKey);
+        } catch (error) {
+            try {
+                await fileStorageService.deleteStoredFile(storageKey);
+            } catch (storageError) {
+                console.error('Erro ao remover arquivo após falha ao criar anexo:', storageError);
+            }
+            throw error;
+        }
+    }
+
+    return storedKeys;
 };
 
 module.exports = {
@@ -116,19 +175,40 @@ module.exports = {
     },
 
     createFinanceEntry: async (req, res) => {
+        let transaction;
+        let storedKeys = [];
+
         try {
             const { description, type, value, dueDate, recurring, recurringInterval } = req.body;
-            await FinanceEntry.create({
+
+            transaction = await sequelize.transaction();
+
+            const entry = await FinanceEntry.create({
                 description,
                 type,
                 value,
                 dueDate,
                 recurring: (recurring === 'true'),
                 recurringInterval: recurringInterval || null
-            });
+            }, { transaction });
+
+            storedKeys = await persistAttachments(entry.id, req.files, transaction);
+
+            await transaction.commit();
+
             req.flash('success_msg', 'Lançamento criado com sucesso!');
             res.redirect('/finance');
         } catch (err) {
+            if (transaction) {
+                try {
+                    await transaction.rollback();
+                } catch (rollbackError) {
+                    console.error('Erro ao desfazer transação de criação:', rollbackError);
+                }
+            }
+
+            await removeStoredFiles(storedKeys);
+
             console.error(err);
             req.flash('error_msg', 'Erro ao criar lançamento.');
             res.redirect('/finance');
@@ -136,12 +216,19 @@ module.exports = {
     },
 
     updateFinanceEntry: async (req, res) => {
+        let transaction;
+        let storedKeys = [];
+
         try {
             const { id } = req.params;
             const { description, type, value, dueDate, paymentDate, status, recurring, recurringInterval } = req.body;
 
-            const entry = await FinanceEntry.findByPk(id);
+            transaction = await sequelize.transaction();
+
+            const entry = await FinanceEntry.findByPk(id, { transaction });
+
             if (!entry) {
+                await transaction.rollback();
                 req.flash('error_msg', 'Lançamento não encontrado.');
                 return res.redirect('/finance');
             }
@@ -155,10 +242,25 @@ module.exports = {
             entry.recurring = (recurring === 'true');
             entry.recurringInterval = recurringInterval || null;
 
-            await entry.save();
+            await entry.save({ transaction });
+
+            storedKeys = await persistAttachments(entry.id, req.files, transaction);
+
+            await transaction.commit();
+
             req.flash('success_msg', 'Lançamento atualizado!');
             res.redirect('/finance');
         } catch (err) {
+            if (transaction) {
+                try {
+                    await transaction.rollback();
+                } catch (rollbackError) {
+                    console.error('Erro ao desfazer transação de atualização:', rollbackError);
+                }
+            }
+
+            await removeStoredFiles(storedKeys);
+
             console.error(err);
             req.flash('error_msg', 'Erro ao atualizar lançamento.');
             res.redirect('/finance');
@@ -173,7 +275,20 @@ module.exports = {
                 req.flash('error_msg', 'Lançamento não encontrado.');
                 return res.redirect('/finance');
             }
+
+            const attachments = await FinanceAttachment.findAll({
+                where: { financeEntryId: entry.id },
+                attributes: ['storageKey'],
+                raw: true
+            });
+
             await entry.destroy();
+
+            const storageKeys = attachments.map((item) => item.storageKey).filter(Boolean);
+            if (storageKeys.length) {
+                await removeStoredFiles(storageKeys);
+            }
+
             req.flash('success_msg', 'Lançamento removido com sucesso.');
             res.redirect('/finance');
         } catch (err) {
@@ -371,6 +486,42 @@ module.exports = {
                 res.status(500).json({ error: 'Erro ao exportar Excel.' });
             } else {
                 res.end();
+            }
+        }
+    },
+
+    downloadAttachment: async (req, res) => {
+        try {
+            const { attachmentId } = req.params;
+
+            const attachment = await FinanceAttachment.findByPk(attachmentId);
+            if (!attachment) {
+                req.flash('error_msg', 'Anexo não encontrado.');
+                return res.redirect('/finance');
+            }
+
+            let stream;
+            try {
+                stream = fileStorageService.createReadStream(attachment.storageKey);
+            } catch (error) {
+                console.error('Erro ao acessar anexo de finanças:', error);
+                req.flash('error_msg', 'Arquivo de anexo indisponível.');
+                return res.redirect('/finance');
+            }
+
+            res.setHeader('Content-Type', attachment.mimeType || 'application/octet-stream');
+            if (Number.isFinite(Number(attachment.size))) {
+                res.setHeader('Content-Length', String(attachment.size));
+            }
+            res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(attachment.fileName)}"`);
+            res.setHeader('Cache-Control', 'no-store');
+
+            await pipeline(stream, res);
+        } catch (err) {
+            console.error('Erro ao baixar anexo financeiro:', err);
+            if (!res.headersSent) {
+                req.flash('error_msg', 'Erro ao baixar anexo.');
+                res.redirect('/finance');
             }
         }
     }

--- a/src/middlewares/financeAttachmentUpload.js
+++ b/src/middlewares/financeAttachmentUpload.js
@@ -1,0 +1,72 @@
+const multer = require('multer');
+
+const MAX_SIZE = Number.parseInt(process.env.FINANCE_ATTACHMENT_MAX_SIZE, 10) || (10 * 1024 * 1024);
+const MAX_FILES = Number.parseInt(process.env.FINANCE_ATTACHMENT_MAX_FILES, 10) || 5;
+
+const ALLOWED_MIME_TYPES = new Set([
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'image/jpg',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'text/csv',
+    'text/plain',
+    'application/zip',
+    'application/x-zip-compressed'
+]);
+
+const storage = multer.memoryStorage();
+
+const multerInstance = multer({
+    storage,
+    limits: {
+        fileSize: MAX_SIZE,
+        files: MAX_FILES
+    },
+    fileFilter: (req, file, cb) => {
+        if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+            cb(null, true);
+            return;
+        }
+
+        const error = new Error('Tipo de arquivo não suportado para anexos financeiros.');
+        error.code = 'UNSUPPORTED_FILE_TYPE';
+        cb(error);
+    }
+});
+
+const uploadAttachments = (req, res, next) => {
+    const handler = multerInstance.array('attachments');
+    handler(req, res, (err) => {
+        if (!err) {
+            return next();
+        }
+
+        if (typeof req.flash === 'function') {
+            if (err.code === 'LIMIT_FILE_SIZE') {
+                req.flash('error_msg', 'Anexo excede o tamanho máximo permitido (10MB).');
+                return res.redirect('/finance');
+            }
+
+            if (err.code === 'LIMIT_FILE_COUNT') {
+                req.flash('error_msg', 'Limite de anexos atingido para este lançamento.');
+                return res.redirect('/finance');
+            }
+
+            if (err.code === 'UNSUPPORTED_FILE_TYPE') {
+                req.flash('error_msg', 'Tipo de arquivo não suportado para anexos financeiros.');
+                return res.redirect('/finance');
+            }
+        }
+
+        next(err);
+    });
+};
+
+module.exports = {
+    uploadAttachments,
+    multerInstance
+};

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -5,6 +5,7 @@ const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const audit = require('../middlewares/audit');
 const { USER_ROLES } = require('../constants/roles');
+const { uploadAttachments } = require('../middlewares/financeAttachmentUpload');
 
 // Apenas administradores podem gerenciar finanças
 router.get('/', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), financeController.listFinanceEntries);
@@ -12,6 +13,7 @@ router.post(
     '/create',
     authMiddleware,
     permissionMiddleware(USER_ROLES.ADMIN),
+    uploadAttachments,
     audit('financeEntry.create', (req) => `FinanceEntry:${req.body?.description || 'novo'}`),
     financeController.createFinanceEntry
 );
@@ -19,6 +21,7 @@ router.put(
     '/update/:id',
     authMiddleware,
     permissionMiddleware(USER_ROLES.ADMIN),
+    uploadAttachments,
     audit('financeEntry.update', (req) => `FinanceEntry:${req.params.id}`),
     financeController.updateFinanceEntry
 );
@@ -52,6 +55,14 @@ router.get(
         return `FinanceExport:excel:${start}-${end}`;
     }),
     financeController.exportExcel
+);
+
+router.get(
+    '/attachments/:attachmentId/download',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    audit('financeAttachment.download', (req) => `FinanceAttachment:${req.params.attachmentId}`),
+    financeController.downloadAttachment
 );
 
 

--- a/src/services/fileStorageService.js
+++ b/src/services/fileStorageService.js
@@ -1,0 +1,112 @@
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+const crypto = require('crypto');
+
+const DEFAULT_STORAGE_ROOT = process.env.FINANCE_STORAGE_PATH
+    ? path.resolve(process.env.FINANCE_STORAGE_PATH)
+    : path.resolve(process.cwd(), 'storage', 'finance');
+
+const DIRECTORY_MODE = 0o750;
+const FILE_MODE = 0o640;
+
+const ensureDirectory = async (target) => {
+    await fsp.mkdir(target, { recursive: true, mode: DIRECTORY_MODE });
+};
+
+const normalizeStorageKey = (storageKey) => {
+    if (!storageKey) {
+        throw new Error('Storage key inválido.');
+    }
+    const normalized = storageKey.replace(/\\/g, '/').replace(/^\/+/, '');
+    if (!normalized) {
+        throw new Error('Storage key inválido.');
+    }
+    return normalized;
+};
+
+const resolveStoragePath = (storageKey) => {
+    const normalizedKey = normalizeStorageKey(storageKey);
+    const fullPath = path.resolve(DEFAULT_STORAGE_ROOT, normalizedKey);
+    if (!fullPath.startsWith(DEFAULT_STORAGE_ROOT)) {
+        throw new Error('Tentativa de acesso fora do diretório de armazenamento.');
+    }
+    return fullPath;
+};
+
+const sanitizeFileName = (name) => {
+    if (!name) {
+        return 'anexo';
+    }
+
+    const base = path.basename(String(name));
+    const cleaned = base.replace(/[^\w\d._-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+    if (!cleaned) {
+        return 'anexo';
+    }
+
+    return cleaned.slice(0, 255);
+};
+
+const generateStorageKey = (originalName) => {
+    const safeName = sanitizeFileName(originalName);
+    const extension = path.extname(safeName);
+    const randomBytes = crypto.randomBytes(16).toString('hex');
+    const folder = randomBytes.slice(0, 2);
+    const timestamp = Date.now();
+    const finalName = `${timestamp}-${randomBytes}${extension}`;
+    return path.join(folder, finalName).replace(/\\/g, '/');
+};
+
+const computeChecksum = (buffer) => {
+    return crypto.createHash('sha256').update(buffer).digest('hex');
+};
+
+const saveBuffer = async ({ buffer, originalName }) => {
+    if (!Buffer.isBuffer(buffer)) {
+        throw new Error('Buffer inválido para armazenamento.');
+    }
+
+    await ensureDirectory(DEFAULT_STORAGE_ROOT);
+
+    const storageKey = generateStorageKey(originalName);
+    const absolutePath = resolveStoragePath(storageKey);
+    await ensureDirectory(path.dirname(absolutePath));
+
+    await fsp.writeFile(absolutePath, buffer, { mode: FILE_MODE, flag: 'w' });
+
+    const checksum = computeChecksum(buffer);
+
+    return {
+        storageKey,
+        checksum,
+        sanitizedFileName: sanitizeFileName(originalName)
+    };
+};
+
+const deleteStoredFile = async (storageKey) => {
+    try {
+        const absolutePath = resolveStoragePath(storageKey);
+        await fsp.unlink(absolutePath);
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return;
+        }
+        throw error;
+    }
+};
+
+const createReadStream = (storageKey) => {
+    const absolutePath = resolveStoragePath(storageKey);
+    return fs.createReadStream(absolutePath);
+};
+
+module.exports = {
+    getStorageRoot: () => DEFAULT_STORAGE_ROOT,
+    saveBuffer,
+    deleteStoredFile,
+    createReadStream,
+    resolveStoragePath,
+    sanitizeFileName
+};

--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -92,7 +92,17 @@
                         <% entries.forEach(entry => { %>
                             <tr>
                                 <td><%= entry.id %></td>
-                                <td><%= entry.description %></td>
+                                <td>
+                                    <div class="d-flex flex-column">
+                                        <span class="fw-semibold"><%= entry.description %></span>
+                                        <% if (entry.attachments && entry.attachments.length) { %>
+                                            <span class="text-muted small">
+                                                <i class="bi bi-paperclip me-1" aria-hidden="true"></i>
+                                                <%= entry.attachments.length %> anexo<%= entry.attachments.length > 1 ? 's' : '' %>
+                                            </span>
+                                        <% } %>
+                                    </div>
+                                </td>
                                 <td>
                                     <% if (entry.type === 'payable') { %>
                                         <span class="badge text-bg-danger">Pagar</span>
@@ -136,6 +146,7 @@
                                             <form
                                                 action="/finance/update/<%= entry.id %>?_method=PUT"
                                                 method="POST"
+                                                enctype="multipart/form-data"
                                                 class="modal-content"
                                             >
                                                 <div class="modal-header">
@@ -222,6 +233,48 @@
                                                             placeholder="Ex.: mensal, trimestral"
                                                         />
                                                     </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label">Anexos cadastrados</label>
+                                                        <% if (entry.attachments && entry.attachments.length) { %>
+                                                            <ul class="list-group list-group-flush rounded shadow-sm">
+                                                                <% entry.attachments.forEach((attachment) => { %>
+                                                                    <li class="list-group-item d-flex align-items-center justify-content-between gap-3">
+                                                                        <div class="d-flex align-items-center gap-2 text-truncate">
+                                                                            <i class="bi bi-paperclip text-primary" aria-hidden="true"></i>
+                                                                            <span class="text-truncate" title="<%= attachment.fileName %>"><%= attachment.fileName %></span>
+                                                                        </div>
+                                                                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 text-sm-end">
+                                                                            <span class="text-muted small"><%= Math.max(1, Math.round((attachment.size || 0) / 1024)) %> KB</span>
+                                                                            <a
+                                                                                class="btn btn-outline-primary btn-sm"
+                                                                                href="/finance/attachments/<%= attachment.id %>/download"
+                                                                            >
+                                                                                <i class="bi bi-download me-1" aria-hidden="true"></i>Baixar
+                                                                            </a>
+                                                                        </div>
+                                                                    </li>
+                                                                <% }); %>
+                                                            </ul>
+                                                        <% } else { %>
+                                                            <p class="text-muted small mb-0">Nenhum anexo disponível para este lançamento.</p>
+                                                        <% } %>
+                                                    </div>
+                                                    <div class="mb-3">
+                                                        <label class="form-label" for="entry-attachments-<%= entry.id %>">
+                                                            Adicionar novos anexos
+                                                        </label>
+                                                        <input
+                                                            type="file"
+                                                            class="form-control"
+                                                            id="entry-attachments-<%= entry.id %>"
+                                                            name="attachments"
+                                                            multiple
+                                                            accept=".pdf,.png,.jpg,.jpeg,.doc,.docx,.xls,.xlsx,.csv,.txt,.zip"
+                                                        />
+                                                        <div class="form-text">
+                                                            Anexe arquivos relevantes (até 10MB por arquivo).
+                                                        </div>
+                                                    </div>
                                                 </div>
                                                 <div class="modal-footer">
                                                     <button
@@ -248,7 +301,7 @@
         <div class="card card-soft responsive-panel">
             <h3 class="fw-semibold mb-2">Novo lançamento</h3>
             <p class="text-muted mb-4">Cadastre receitas ou despesas com recorrência opcional e acompanhe tudo no painel.</p>
-            <form action="/finance/create" method="POST" class="row g-3 responsive-filter-grid">
+            <form action="/finance/create" method="POST" enctype="multipart/form-data" class="row g-3 responsive-filter-grid">
                 <div class="col-md-5">
                     <label class="form-label">Descrição</label>
                     <input
@@ -300,6 +353,20 @@
                         name="recurringInterval"
                         placeholder="Ex.: mensal"
                     />
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label" for="new-entry-attachments">Anexar documentos</label>
+                    <input
+                        type="file"
+                        class="form-control"
+                        id="new-entry-attachments"
+                        name="attachments"
+                        multiple
+                        accept=".pdf,.png,.jpg,.jpeg,.doc,.docx,.xls,.xlsx,.csv,.txt,.zip"
+                    />
+                    <div class="form-text">
+                        Upload seguro com limite de 10MB por arquivo. Tipos aceitos: PDF, imagens e documentos do Office.
+                    </div>
                 </div>
                 <div class="col-md-12">
                     <div class="responsive-form-actions">

--- a/tests/integration/financeController.attachments.test.js
+++ b/tests/integration/financeController.attachments.test.js
@@ -1,0 +1,133 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const fs = require('fs');
+const fsp = require('fs/promises');
+const os = require('os');
+const path = require('path');
+const express = require('express');
+const session = require('express-session');
+const flash = require('connect-flash');
+const request = require('supertest');
+
+const storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'finance-attachments-'));
+process.env.FINANCE_STORAGE_PATH = storageRoot;
+
+jest.mock('../../src/middlewares/authMiddleware', () => jest.fn((req, res, next) => {
+    req.session = req.session || {};
+    req.user = { id: 1, role: 'admin', active: true };
+    req.session.user = req.user;
+    next();
+}));
+
+jest.mock('../../src/middlewares/permissionMiddleware', () => () => (req, res, next) => next());
+
+jest.mock('../../src/middlewares/audit', () => () => (req, res, next) => next());
+
+const financeRoutes = require('../../src/routes/financeRoutes');
+const fileStorageService = require('../../src/services/fileStorageService');
+const { FinanceEntry, FinanceAttachment, sequelize } = require('../../database/models');
+
+const buildApp = () => {
+    const app = express();
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+    app.use(session({
+        secret: 'finance-test-secret',
+        resave: false,
+        saveUninitialized: false
+    }));
+    app.use(flash());
+    app.use('/finance', financeRoutes);
+    return app;
+};
+
+describe('FinanceController attachments', () => {
+    let app;
+
+    beforeEach(async () => {
+        await sequelize.sync({ force: true });
+        await fsp.rm(storageRoot, { recursive: true, force: true });
+        await fsp.mkdir(storageRoot, { recursive: true });
+        app = buildApp();
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+        await fsp.rm(storageRoot, { recursive: true, force: true });
+    });
+
+    it('permite enviar anexos ao criar um lançamento financeiro', async () => {
+        const pdfBuffer = Buffer.from('%PDF-1.4\n%FinanceAttachmentTest');
+
+        const response = await request(app)
+            .post('/finance/create')
+            .field('description', 'Pagamento fornecedor tecnologia')
+            .field('type', 'payable')
+            .field('value', '1250.55')
+            .field('dueDate', '2024-09-30')
+            .field('recurring', 'false')
+            .field('recurringInterval', '')
+            .attach('attachments', pdfBuffer, { filename: 'Notas   fiscais.pdf', contentType: 'application/pdf' });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/finance');
+
+        const entry = await FinanceEntry.findOne({
+            include: [{ model: FinanceAttachment, as: 'attachments' }]
+        });
+
+        expect(entry).toBeTruthy();
+        expect(entry.attachments).toHaveLength(1);
+
+        const [attachment] = entry.attachments;
+        expect(attachment.fileName).toBe('Notas-fiscais.pdf');
+        expect(attachment.mimeType).toBe('application/pdf');
+        expect(Number(attachment.size)).toBe(pdfBuffer.length);
+
+        const storedContent = await fsp.readFile(fileStorageService.resolveStoragePath(attachment.storageKey));
+        expect(storedContent.equals(pdfBuffer)).toBe(true);
+    });
+
+    it('permite realizar download autenticado dos anexos cadastrados', async () => {
+        const entry = await FinanceEntry.create({
+            description: 'Serviço de consultoria',
+            type: 'receivable',
+            value: '2200.00',
+            dueDate: '2024-10-15',
+            recurring: false,
+            recurringInterval: null
+        });
+
+        const noteBuffer = Buffer.from('Relatorio financeiro confidencial');
+        const { storageKey, checksum, sanitizedFileName } = await fileStorageService.saveBuffer({
+            buffer: noteBuffer,
+            originalName: 'relatorio.txt'
+        });
+
+        const attachment = await FinanceAttachment.create({
+            financeEntryId: entry.id,
+            fileName: sanitizedFileName,
+            mimeType: 'text/plain',
+            size: noteBuffer.length,
+            checksum,
+            storageKey
+        });
+
+        const response = await request(app)
+            .get(`/finance/attachments/${attachment.id}/download`)
+            .buffer(true)
+            .parse((res, callback) => {
+                const chunks = [];
+                res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+                res.on('end', () => callback(null, Buffer.concat(chunks)));
+            });
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toContain('text/plain');
+        expect(response.headers['content-disposition']).toContain('relatorio.txt');
+        expect(Buffer.isBuffer(response.body)).toBe(true);
+        expect(response.body.equals(noteBuffer)).toBe(true);
+    });
+});

--- a/tests/unit/views/manageFinance.test.js
+++ b/tests/unit/views/manageFinance.test.js
@@ -26,7 +26,14 @@ const buildViewContext = () => ({
             paymentDate: '2024-05-02',
             status: 'paid',
             recurring: true,
-            recurringInterval: 'Mensal'
+            recurringInterval: 'Mensal',
+            attachments: [
+                {
+                    id: 701,
+                    fileName: 'comprovante.pdf',
+                    size: 20480
+                }
+            ]
         }
     ],
     success_msg: null,
@@ -48,6 +55,17 @@ describe('views/finance/manageFinance', () => {
         expect(html).toContain('data-export-target="/finance/export/excel"');
         expect(html).toContain('Exportar Excel');
         expect(html).toContain('aria-label="Exportar lançamentos filtrados em Excel"');
+    });
+
+    it('exibe controles de upload e anexos vinculados aos lançamentos', async () => {
+        const context = buildViewContext();
+        const html = await ejs.renderFile(viewPath, context, { async: true });
+
+        expect(html).toContain('enctype="multipart/form-data"');
+        expect(html).toContain('name="attachments"');
+        expect(html).toContain('href="/finance/attachments/701/download"');
+        expect(html).toContain('comprovante.pdf');
+        expect(html).toContain('bi bi-paperclip');
     });
 });
 


### PR DESCRIPTION
## Summary
- add a FinanceAttachment model and migration to persist metadata for uploaded files
- handle secure attachment storage, upload validation, and download flow through the finance controller and routes
- enhance the finance management UI and automated tests to cover attachment rendering and end-to-end uploads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f99ec20c832f82e37088e5082bbb