### PR TITLE
Add finance filters UI with summaries and tests

### DIFF
--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -1,5 +1,44 @@
 <%- include('../partials/header') %>
 
+<%
+    const filterValues = filters || {};
+    const computedPeriodLabel = periodLabel || 'Todo o período';
+    const summaryTotals = financeTotals || {};
+    const summaryStatus = statusSummary || {};
+    const summaryMonthly = Array.isArray(monthlySummary) ? monthlySummary : [];
+    const currencyFormatter = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' });
+    const formatCurrency = (value) => {
+        const numeric = Number(value);
+        return currencyFormatter.format(Number.isFinite(numeric) ? numeric : 0);
+    };
+    const typeLabels = { payable: 'A pagar', receivable: 'A receber' };
+    const statusLabels = { pending: 'Pendente', paid: 'Pago', overdue: 'Atrasado', cancelled: 'Cancelado' };
+    const statusKeys = Object.keys(statusLabels);
+    const netNumericValue = Number(summaryTotals.net);
+    const netClass = Number.isFinite(netNumericValue) && netNumericValue < 0 ? 'text-danger' : 'text-success';
+    const hasMonthlySummary = summaryMonthly.length > 0;
+    const formatMonthLabel = (monthValue) => {
+        if (!monthValue) {
+            return '—';
+        }
+
+        const safeValue = String(monthValue);
+        const isoDate = `${safeValue}-01T00:00:00Z`;
+        const parsedDate = new Date(isoDate);
+
+        if (Number.isFinite(parsedDate.getTime())) {
+            return parsedDate.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' });
+        }
+
+        const [year, month] = safeValue.split('-');
+        if (year && month) {
+            return `${month}/${year}`;
+        }
+
+        return safeValue;
+    };
+%>
+
 <div class="row fade-in responsive-page-row gy-4">
     <div class="col-12">
         <div class="card card-soft responsive-panel">
@@ -26,6 +65,245 @@
                     <i class="bi bi-exclamation-triangle me-2"></i><%= error_msg %>
                 </div>
             <% } %>
+        </div>
+    </div>
+
+    <div class="col-12">
+        <div class="card card-soft responsive-panel">
+            <div class="d-flex flex-column gap-4">
+                <div>
+                    <div class="d-flex flex-column flex-xl-row justify-content-between align-items-start gap-3 mb-3">
+                        <div>
+                            <span class="app-chip mb-2"><i class="bi bi-funnel me-2"></i>Filtros inteligentes</span>
+                            <h3 class="fw-semibold mb-1">Visão consolidada</h3>
+                            <p class="text-muted mb-0">
+                                Período analisado: <span class="fw-semibold"><%= computedPeriodLabel %></span>
+                            </p>
+                        </div>
+                        <div class="text-muted small">
+                            Ajuste o período, o tipo e o status para refinar a análise e exportações.
+                        </div>
+                    </div>
+                    <form
+                        class="row g-3 align-items-end responsive-filter-grid"
+                        data-filter-form
+                        action="/finance"
+                        method="GET"
+                        novalidate
+                    >
+                        <div class="col-12 col-sm-6 col-lg-3 col-xxl-2">
+                            <label class="form-label" for="filterStartDate">Início</label>
+                            <input
+                                type="date"
+                                class="form-control"
+                                id="filterStartDate"
+                                name="startDate"
+                                value="<%= filterValues.startDate || '' %>"
+                            />
+                        </div>
+                        <div class="col-12 col-sm-6 col-lg-3 col-xxl-2">
+                            <label class="form-label" for="filterEndDate">Fim</label>
+                            <input
+                                type="date"
+                                class="form-control"
+                                id="filterEndDate"
+                                name="endDate"
+                                value="<%= filterValues.endDate || '' %>"
+                            />
+                        </div>
+                        <div class="col-12 col-sm-6 col-lg-3 col-xxl-2">
+                            <label class="form-label" for="filterType">Tipo</label>
+                            <select
+                                class="form-select"
+                                id="filterType"
+                                name="type"
+                                data-auto-submit="true"
+                            >
+                                <option value="" <%= filterValues.type ? '' : 'selected' %>>Todos</option>
+                                <option value="payable" <%= filterValues.type === 'payable' ? 'selected' : '' %>>A pagar</option>
+                                <option value="receivable" <%= filterValues.type === 'receivable' ? 'selected' : '' %>>A receber</option>
+                            </select>
+                        </div>
+                        <div class="col-12 col-sm-6 col-lg-3 col-xxl-2">
+                            <label class="form-label" for="filterStatus">Status</label>
+                            <select
+                                class="form-select"
+                                id="filterStatus"
+                                name="status"
+                                data-auto-submit="true"
+                            >
+                                <option value="" <%= filterValues.status ? '' : 'selected' %>>Todos</option>
+                                <option value="pending" <%= filterValues.status === 'pending' ? 'selected' : '' %>>Pendente</option>
+                                <option value="paid" <%= filterValues.status === 'paid' ? 'selected' : '' %>>Pago</option>
+                                <option value="overdue" <%= filterValues.status === 'overdue' ? 'selected' : '' %>>Atrasado</option>
+                                <option value="cancelled" <%= filterValues.status === 'cancelled' ? 'selected' : '' %>>Cancelado</option>
+                            </select>
+                        </div>
+                        <div class="col-12 col-xl-4 col-xxl-4 ms-auto">
+                            <div class="d-flex flex-column flex-sm-row justify-content-end gap-2">
+                                <button type="button" class="btn btn-outline-secondary w-100 w-sm-auto" data-filter-clear>
+                                    Limpar
+                                </button>
+                                <button type="submit" class="btn btn-gradient w-100 w-sm-auto">
+                                    Aplicar filtros
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+
+                <div class="row g-4">
+                    <div class="col-sm-6 col-xl-3">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <div class="d-flex align-items-center justify-content-between mb-3">
+                                    <span class="badge rounded-pill bg-success-subtle text-success">Receitas</span>
+                                    <i class="bi bi-arrow-up-right-circle text-success fs-4" aria-hidden="true"></i>
+                                </div>
+                                <h4 class="fw-semibold mb-1"><%= formatCurrency(summaryTotals.receivable) %></h4>
+                                <p class="text-muted small mb-0">Entradas previstas no período selecionado.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-xl-3">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <div class="d-flex align-items-center justify-content-between mb-3">
+                                    <span class="badge rounded-pill bg-danger-subtle text-danger">Despesas</span>
+                                    <i class="bi bi-arrow-down-right-circle text-danger fs-4" aria-hidden="true"></i>
+                                </div>
+                                <h4 class="fw-semibold mb-1"><%= formatCurrency(summaryTotals.payable) %></h4>
+                                <p class="text-muted small mb-0">Saídas planejadas dentro do período.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-xl-3">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <div class="d-flex align-items-center justify-content-between mb-3">
+                                    <span class="badge rounded-pill bg-primary-subtle text-primary">Saldo</span>
+                                    <i class="bi bi-wallet2 text-primary fs-4" aria-hidden="true"></i>
+                                </div>
+                                <h4 class="fw-semibold mb-1 <%= netClass %>"><%= formatCurrency(summaryTotals.net) %></h4>
+                                <p class="text-muted small mb-0">Resultado projetado após receitas e despesas.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-xl-3">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body">
+                                <div class="d-flex align-items-center justify-content-between mb-3">
+                                    <span class="badge rounded-pill bg-warning-subtle text-warning">Riscos</span>
+                                    <i class="bi bi-exclamation-octagon text-warning fs-4" aria-hidden="true"></i>
+                                </div>
+                                <h4 class="fw-semibold mb-1 text-warning"><%= formatCurrency(summaryTotals.overdue) %></h4>
+                                <p class="text-muted small mb-0">Pagamentos em atraso demandando atenção imediata.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row g-4 align-items-stretch">
+                    <div class="col-12 col-lg-7">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+                                    <div>
+                                        <h4 class="fw-semibold mb-1">Performance mensal</h4>
+                                        <p class="text-muted small mb-0">Comparativo de entradas e saídas para decisões estratégicas.</p>
+                                    </div>
+                                    <span class="badge rounded-pill bg-light text-muted"><%= computedPeriodLabel %></span>
+                                </div>
+                                <div class="ratio ratio-16x9">
+                                    <canvas
+                                        id="financePerformanceChart"
+                                        aria-label="Gráfico de desempenho financeiro mensal"
+                                        role="img"
+                                    ></canvas>
+                                </div>
+                                <% if (hasMonthlySummary) { %>
+                                    <div class="table-responsive small mt-4">
+                                        <table class="table table-sm align-middle mb-0">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">Mês</th>
+                                                    <th scope="col" class="text-end">A receber</th>
+                                                    <th scope="col" class="text-end">A pagar</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <% summaryMonthly.forEach((item) => { %>
+                                                    <tr>
+                                                        <td><%= formatMonthLabel(item.month) %></td>
+                                                        <td class="text-end"><%= formatCurrency(item.receivable) %></td>
+                                                        <td class="text-end"><%= formatCurrency(item.payable) %></td>
+                                                    </tr>
+                                                <% }) %>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                <% } else { %>
+                                    <p class="text-muted small mt-4 mb-0">
+                                        Cadastre lançamentos ou ajuste os filtros para visualizar tendências históricas.
+                                    </p>
+                                <% } %>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-5">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body d-flex flex-column">
+                                <div class="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+                                    <div>
+                                        <h4 class="fw-semibold mb-1">Status por categoria</h4>
+                                        <p class="text-muted small mb-0">Distribuição de valores em cada etapa.</p>
+                                    </div>
+                                    <span class="badge rounded-pill bg-light text-muted">Atualizado em tempo real</span>
+                                </div>
+                                <div class="table-responsive">
+                                    <table class="table table-sm align-middle mb-3">
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">Tipo</th>
+                                                <% statusKeys.forEach((statusKey) => { %>
+                                                    <th scope="col" class="text-end"><%= statusLabels[statusKey] %></th>
+                                                <% }) %>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <% Object.keys(typeLabels).forEach((typeKey) => { %>
+                                                <tr>
+                                                    <td class="fw-semibold"><%= typeLabels[typeKey] %></td>
+                                                    <% statusKeys.forEach((statusKey) => { %>
+                                                        <% const statusValue = summaryStatus && summaryStatus[typeKey] ? summaryStatus[typeKey][statusKey] : 0; %>
+                                                        <td class="text-end"><%= formatCurrency(statusValue) %></td>
+                                                    <% }) %>
+                                                </tr>
+                                            <% }) %>
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div class="bg-light rounded-3 p-3 mt-auto">
+                                    <div class="d-flex flex-column gap-2 small">
+                                        <div class="d-flex justify-content-between">
+                                            <span class="text-muted">Pagamentos liquidados</span>
+                                            <span class="fw-semibold text-success"><%= formatCurrency(summaryTotals.paid) %></span>
+                                        </div>
+                                        <div class="d-flex justify-content-between">
+                                            <span class="text-muted">Pendências</span>
+                                            <span class="fw-semibold text-primary"><%= formatCurrency(summaryTotals.pending) %></span>
+                                        </div>
+                                        <div class="d-flex justify-content-between">
+                                            <span class="text-muted">Atrasos</span>
+                                            <span class="fw-semibold text-warning"><%= formatCurrency(summaryTotals.overdue) %></span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -312,39 +590,60 @@
     </div>
 </div>
 
+<script
+    src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"
+    referrerpolicy="no-referrer"
+    defer
+></script>
 <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const exportLinks = document.querySelectorAll('[data-export-target]');
-        if (!exportLinks.length) {
-            return;
-        }
+    const rawMonthlySummary = <%- JSON.stringify(summaryMonthly) %>;
+    const monthlySummaryData = Array.isArray(rawMonthlySummary) ? rawMonthlySummary : [];
+    const chartCurrencyFormatter = new Intl.NumberFormat('pt-BR', {
+        style: 'currency',
+        currency: 'BRL'
+    });
 
-        const buildFiltersQuery = () => {
+    document.addEventListener('DOMContentLoaded', () => {
+        const filterForms = document.querySelectorAll('[data-filter-form]');
+        const exportLinks = document.querySelectorAll('[data-export-target]');
+
+        const buildFiltersQuery = (scope) => {
             if (typeof URLSearchParams === 'undefined') {
                 return window.location.search ? window.location.search.replace(/^\?/, '') : '';
             }
 
             const params = new URLSearchParams(window.location.search || '');
-            const filterForms = document.querySelectorAll('[data-filter-form]');
+            const forms = scope ? [scope] : Array.from(document.querySelectorAll('[data-filter-form]'));
 
-            filterForms.forEach((form) => {
+            forms.filter(Boolean).forEach((form) => {
                 const fields = form.querySelectorAll('input[name], select[name], textarea[name]');
                 fields.forEach((field) => {
-                    const { name } = field;
-                    if (!name) {
+                    if (!field || !field.name) {
                         return;
                     }
 
                     const rawValue = typeof field.value === 'string' ? field.value.trim() : field.value;
                     if (rawValue) {
-                        params.set(name, rawValue);
+                        params.set(field.name, rawValue);
                     } else {
-                        params.delete(name);
+                        params.delete(field.name);
                     }
                 });
             });
 
             return params.toString();
+        };
+
+        const submitFormWithFilters = (form) => {
+            if (!form) {
+                return;
+            }
+
+            const action = form.getAttribute('action') || window.location.pathname || '/finance';
+            const queryString = buildFiltersQuery(form);
+            const finalUrl = queryString ? `${action}?${queryString}` : action;
+
+            window.location.assign(finalUrl);
         };
 
         const applyQueryToLink = (link) => {
@@ -358,18 +657,186 @@
             link.setAttribute('href', finalUrl);
         };
 
-        exportLinks.forEach((link) => {
-            applyQueryToLink(link);
+        const refreshExportLinks = () => {
+            if (!exportLinks.length) {
+                return;
+            }
 
-            link.addEventListener('focus', () => applyQueryToLink(link));
-            link.addEventListener('mouseenter', () => applyQueryToLink(link));
-            link.addEventListener('click', () => applyQueryToLink(link));
-            link.addEventListener('auxclick', (event) => {
-                if (event.button === 1) {
-                    applyQueryToLink(link);
+            exportLinks.forEach((link) => {
+                applyQueryToLink(link);
+
+                if (!link.__financeExportListenersBound) {
+                    link.addEventListener('focus', () => applyQueryToLink(link));
+                    link.addEventListener('mouseenter', () => applyQueryToLink(link));
+                    link.addEventListener('click', () => applyQueryToLink(link));
+                    link.addEventListener('auxclick', (event) => {
+                        if (event.button === 1) {
+                            applyQueryToLink(link);
+                        }
+                    });
+                    link.__financeExportListenersBound = true;
                 }
             });
+        };
+
+        filterForms.forEach((form) => {
+            form.addEventListener('submit', (event) => {
+                event.preventDefault();
+                submitFormWithFilters(form);
+            });
+
+            const clearButton = form.querySelector('[data-filter-clear]');
+            if (clearButton) {
+                clearButton.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    form.reset();
+                    submitFormWithFilters(form);
+                });
+            }
+
+            const fields = form.querySelectorAll('input[name], select[name], textarea[name]');
+            fields.forEach((field) => {
+                if (!field) {
+                    return;
+                }
+
+                const updateExportTargets = () => refreshExportLinks();
+                field.addEventListener('input', updateExportTargets);
+                field.addEventListener('change', () => {
+                    updateExportTargets();
+
+                    if (field.dataset.autoSubmit === 'true') {
+                        submitFormWithFilters(form);
+                    }
+                });
+            });
         });
+
+        refreshExportLinks();
+
+        const chartElement = document.getElementById('financePerformanceChart');
+
+        const formatChartMonthLabel = (value) => {
+            if (!value) {
+                return '';
+            }
+
+            const safeValue = String(value);
+            const isoDate = `${safeValue}-01T00:00:00`;
+            const parsedDate = new Date(isoDate);
+
+            if (Number.isFinite(parsedDate.getTime())) {
+                return parsedDate.toLocaleDateString('pt-BR', { month: 'short', year: 'numeric' });
+            }
+
+            const parts = safeValue.split('-');
+            if (parts.length === 2) {
+                return `${parts[1]}/${parts[0]}`;
+            }
+
+            return safeValue;
+        };
+
+        const renderFinanceChart = () => {
+            if (!chartElement || typeof window.Chart === 'undefined') {
+                return false;
+            }
+
+            const context = chartElement.getContext('2d');
+            if (!context) {
+                return false;
+            }
+
+            const labels = monthlySummaryData.map((item) => formatChartMonthLabel(item.month));
+            const receivableData = monthlySummaryData.map((item) => {
+                const value = Number.parseFloat(item?.receivable ?? 0);
+                return Number.isFinite(value) ? value : 0;
+            });
+            const payableData = monthlySummaryData.map((item) => {
+                const value = Number.parseFloat(item?.payable ?? 0);
+                return Number.isFinite(value) ? value : 0;
+            });
+
+            if (chartElement.__financeChartInstance) {
+                chartElement.__financeChartInstance.destroy();
+            }
+
+            chartElement.__financeChartInstance = new window.Chart(context, {
+                type: 'line',
+                data: {
+                    labels,
+                    datasets: [
+                        {
+                            label: 'A receber',
+                            data: receivableData,
+                            borderColor: '#198754',
+                            backgroundColor: 'rgba(25, 135, 84, 0.15)',
+                            tension: 0.35,
+                            fill: true,
+                            pointRadius: 4,
+                            pointBackgroundColor: '#198754'
+                        },
+                        {
+                            label: 'A pagar',
+                            data: payableData,
+                            borderColor: '#dc3545',
+                            backgroundColor: 'rgba(220, 53, 69, 0.15)',
+                            tension: 0.35,
+                            fill: true,
+                            pointRadius: 4,
+                            pointBackgroundColor: '#dc3545'
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: {
+                        intersect: false,
+                        mode: 'index'
+                    },
+                    plugins: {
+                        legend: {
+                            position: 'bottom'
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: (context) => {
+                                    const value = Number.isFinite(context.parsed?.y) ? context.parsed.y : 0;
+                                    return `${context.dataset.label}: ${chartCurrencyFormatter.format(value)}`;
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            ticks: {
+                                maxRotation: 0,
+                                minRotation: 0
+                            }
+                        },
+                        y: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: (value) => {
+                                    const numeric = Number(value);
+                                    return chartCurrencyFormatter.format(Number.isFinite(numeric) ? numeric : 0);
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            return true;
+        };
+
+        if (chartElement && monthlySummaryData.length) {
+            const chartRendered = renderFinanceChart();
+            if (!chartRendered) {
+                window.addEventListener('load', renderFinanceChart, { once: true });
+            }
+        }
     });
 </script>
 

--- a/tests/integration/financeFilters.integration.test.js
+++ b/tests/integration/financeFilters.integration.test.js
@@ -1,0 +1,94 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const { createRouterTestApp } = require('../utils/createRouterTestApp');
+const { authenticateTestUser } = require('../utils/authTestUtils');
+
+const financeRoutes = require('../../src/routes/financeRoutes');
+const financeReportingService = require('../../src/services/financeReportingService');
+const { FinanceEntry, Sequelize } = require('../../database/models');
+
+describe('Finance routes filtering', () => {
+    let app;
+
+    beforeAll(() => {
+        app = createRouterTestApp({
+            routes: [['/finance', financeRoutes]]
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('applies filters and renders the computed summaries for the selected scope', async () => {
+        const filteredEntries = [
+            {
+                id: 1,
+                description: 'Plano empresarial',
+                type: 'receivable',
+                status: 'paid',
+                value: '1200.50',
+                dueDate: '2024-03-05',
+                paymentDate: '2024-03-06',
+                recurring: false,
+                recurringInterval: null
+            },
+            {
+                id: 2,
+                description: 'Consultoria estratégica',
+                type: 'receivable',
+                status: 'paid',
+                value: '800.00',
+                dueDate: '2024-03-18',
+                paymentDate: '2024-03-19',
+                recurring: false,
+                recurringInterval: null
+            }
+        ];
+
+        const findAllSpy = jest.spyOn(FinanceEntry, 'findAll').mockResolvedValue(filteredEntries);
+        const summarySpy = jest.spyOn(financeReportingService, 'getFinanceSummary');
+
+        const { agent } = await authenticateTestUser(app);
+        const response = await agent.get(
+            '/finance?startDate=2024-03-01&endDate=2024-03-31&type=receivable&status=paid'
+        );
+
+        expect(response.status).toBe(200);
+        expect(findAllSpy).toHaveBeenCalledTimes(1);
+
+        const findAllArgs = findAllSpy.mock.calls[0][0];
+        expect(findAllArgs).toMatchObject({
+            order: expect.any(Array),
+            where: expect.objectContaining({
+                type: 'receivable',
+                status: 'paid'
+            })
+        });
+
+        const { Op } = Sequelize;
+        expect(findAllArgs.where.dueDate[Op.gte]).toBe('2024-03-01');
+        expect(findAllArgs.where.dueDate[Op.lte]).toBe('2024-03-31');
+
+        expect(summarySpy).toHaveBeenCalledWith(
+            {
+                startDate: '2024-03-01',
+                endDate: '2024-03-31',
+                type: 'receivable',
+                status: 'paid'
+            },
+            expect.objectContaining({ entries: filteredEntries })
+        );
+
+        const normalizedHtml = response.text.replace(/\u00a0/g, ' ');
+        expect(normalizedHtml).toContain('Visão consolidada');
+        expect(normalizedHtml).toContain('R$ 2.000,50');
+        expect(normalizedHtml).toContain('Status por categoria');
+        expect(normalizedHtml).toContain('<option value="receivable" selected>');
+        expect(normalizedHtml).toContain('<option value="paid" selected>');
+        expect(normalizedHtml).toContain('Performance mensal');
+        expect(normalizedHtml).toContain('março de 2024');
+    });
+});

--- a/tests/unit/views/manageFinance.test.js
+++ b/tests/unit/views/manageFinance.test.js
@@ -27,7 +27,51 @@ const buildViewContext = () => ({
             status: 'paid',
             recurring: true,
             recurringInterval: 'Mensal'
+        },
+        {
+            id: 102,
+            description: 'Serviço de consultoria',
+            type: 'payable',
+            value: '450.00',
+            dueDate: '2024-05-10',
+            paymentDate: null,
+            status: 'pending',
+            recurring: false,
+            recurringInterval: null
         }
+    ],
+    filters: {
+        startDate: '2024-05-01',
+        endDate: '2024-05-31',
+        type: 'receivable',
+        status: 'paid'
+    },
+    periodLabel: '01/05/2024 a 31/05/2024',
+    financeTotals: {
+        receivable: 3200.75,
+        payable: 1850.25,
+        net: 1350.5,
+        overdue: 420.0,
+        paid: 2800.5,
+        pending: 250.25
+    },
+    statusSummary: {
+        receivable: {
+            pending: 250.25,
+            paid: 2800.5,
+            overdue: 150,
+            cancelled: 0
+        },
+        payable: {
+            pending: 0,
+            paid: 1400,
+            overdue: 270,
+            cancelled: 180.25
+        }
+    },
+    monthlySummary: [
+        { month: '2024-04', receivable: 1800.25, payable: 950.5 },
+        { month: '2024-05', receivable: 1400.5, payable: 899.75 }
     ],
     success_msg: null,
     error_msg: null,
@@ -48,6 +92,34 @@ describe('views/finance/manageFinance', () => {
         expect(html).toContain('data-export-target="/finance/export/excel"');
         expect(html).toContain('Exportar Excel');
         expect(html).toContain('aria-label="Exportar lançamentos filtrados em Excel"');
+    });
+
+    it('renders filter form with active parameters and auto-submit controls', async () => {
+        const html = await ejs.renderFile(viewPath, buildViewContext(), { async: true });
+
+        expect(html).toContain('data-filter-form');
+        expect(html).toContain('name="startDate"');
+        expect(html).toContain('value="2024-05-01"');
+        expect(html).toContain('name="endDate"');
+        expect(html).toContain('value="2024-05-31"');
+        expect(html).toContain('<option value="receivable" selected>');
+        expect(html).toContain('<option value="paid" selected>');
+        expect(html).toContain('data-auto-submit="true"');
+    });
+
+    it('shows finance summaries, chart area and status distribution', async () => {
+        const html = await ejs.renderFile(viewPath, buildViewContext(), { async: true });
+        const normalizedHtml = html.replace(/\u00a0/g, ' ');
+
+        expect(normalizedHtml).toContain('Visão consolidada');
+        expect(normalizedHtml).toContain('Performance mensal');
+        expect(normalizedHtml).toContain('Status por categoria');
+        expect(normalizedHtml).toContain('R$ 3.200,75');
+        expect(normalizedHtml).toContain('R$ 1.850,25');
+        expect(normalizedHtml).toContain('abril de 2024');
+        expect(normalizedHtml).toContain('maio de 2024');
+        expect(normalizedHtml).toContain('financePerformanceChart');
+        expect(normalizedHtml).toContain('chart.umd.min.js');
     });
 });
 


### PR DESCRIPTION
## Summary
- extend finance list filters to support type and status and reuse sanitized query parameters
- redesign the finance management view with responsive filters, summary cards, status tables and a Chart.js trend area mirroring export data
- update inline scripts to sync filters with exports and render the client chart, adding unit and integration coverage for the new behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f997c158832f974a42d70b8e17c6