### PR TITLE
Add finance import workflow with CSV and OFX support

### DIFF
--- a/src/middlewares/financeImportUpload.js
+++ b/src/middlewares/financeImportUpload.js
@@ -1,0 +1,31 @@
+const multer = require('multer');
+const path = require('path');
+
+const MAX_SIZE = 2 * 1024 * 1024; // 2MB
+
+const storage = multer.memoryStorage();
+
+const allowedExtensions = new Set(['.csv', '.ofx']);
+const allowedMimes = new Set([
+    'text/csv',
+    'application/vnd.ms-excel',
+    'application/octet-stream',
+    'text/plain',
+    'application/ofx',
+    'application/x-ofx'
+]);
+
+const financeImportUpload = multer({
+    storage,
+    limits: { fileSize: MAX_SIZE },
+    fileFilter: (req, file, cb) => {
+        const extension = path.extname(file.originalname || '').toLowerCase();
+        if (allowedExtensions.has(extension) || allowedMimes.has(file.mimetype)) {
+            cb(null, true);
+            return;
+        }
+        cb(new Error('Formato de arquivo não suportado. Envie um arquivo CSV ou OFX.'));
+    }
+});
+
+module.exports = financeImportUpload;

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -4,10 +4,25 @@ const financeController = require('../controllers/financeController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
 const audit = require('../middlewares/audit');
+const financeImportUpload = require('../middlewares/financeImportUpload');
 const { USER_ROLES } = require('../constants/roles');
 
 // Apenas administradores podem gerenciar finanças
 router.get('/', authMiddleware, permissionMiddleware(USER_ROLES.ADMIN), financeController.listFinanceEntries);
+router.post(
+    '/import/preview',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    financeImportUpload.single('importFile'),
+    financeController.previewFinanceImport
+);
+router.post(
+    '/import/commit',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    audit('financeEntry.import', (req) => req.importAuditResource || 'FinanceImport'),
+    financeController.commitFinanceImport
+);
 router.post(
     '/create',
     authMiddleware,

--- a/src/services/financeImportService.js
+++ b/src/services/financeImportService.js
@@ -1,0 +1,416 @@
+const crypto = require('crypto');
+const path = require('path');
+
+const stripDiacritics = (value) => {
+    return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+};
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, ' ').trim();
+
+const sanitizeDescription = (value) => {
+    if (value === null || value === undefined) {
+        return '';
+    }
+    return normalizeWhitespace(String(value));
+};
+
+const normalizeStatus = (value) => {
+    const allowed = new Set(['pending', 'paid', 'overdue', 'cancelled']);
+    if (!value) {
+        return 'pending';
+    }
+    const normalized = String(value).trim().toLowerCase();
+    return allowed.has(normalized) ? normalized : 'pending';
+};
+
+const normalizeAmount = (value) => {
+    if (value === null || value === undefined || value === '') {
+        throw new Error('Valor não informado.');
+    }
+
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            throw new Error('Valor inválido.');
+        }
+        return Number(value.toFixed(2));
+    }
+
+    const stringValue = String(value).trim();
+    if (!stringValue) {
+        throw new Error('Valor inválido.');
+    }
+
+    let sanitized = stringValue.replace(/[^0-9,.-]/g, '');
+    if (!sanitized) {
+        throw new Error('Valor inválido.');
+    }
+
+    const lastComma = sanitized.lastIndexOf(',');
+    const lastDot = sanitized.lastIndexOf('.');
+
+    if (lastComma > -1 && lastComma > lastDot) {
+        sanitized = sanitized.replace(/\./g, '').replace(',', '.');
+    } else if (sanitized.indexOf(',') > -1 && lastComma === lastDot) {
+        sanitized = sanitized.replace(',', '.');
+    } else {
+        sanitized = sanitized.replace(/,/g, '');
+    }
+
+    const parsed = Number.parseFloat(sanitized);
+    if (!Number.isFinite(parsed)) {
+        throw new Error('Valor inválido.');
+    }
+
+    return Number(parsed.toFixed(2));
+};
+
+const formatISODate = (year, month, day) => {
+    const normalizedYear = String(year).padStart(4, '0');
+    const normalizedMonth = String(month).padStart(2, '0');
+    const normalizedDay = String(day).padStart(2, '0');
+    return `${normalizedYear}-${normalizedMonth}-${normalizedDay}`;
+};
+
+const normalizeDate = (value, fieldName = 'data') => {
+    if (!value) {
+        throw new Error(`${fieldName} não informada.`);
+    }
+
+    if (value instanceof Date) {
+        if (!Number.isFinite(value.getTime())) {
+            throw new Error(`${fieldName} inválida.`);
+        }
+        return formatISODate(value.getUTCFullYear(), value.getUTCMonth() + 1, value.getUTCDate());
+    }
+
+    const stringValue = String(value).trim();
+    if (!stringValue) {
+        throw new Error(`${fieldName} inválida.`);
+    }
+
+    const isoDateMatch = stringValue.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (isoDateMatch) {
+        return formatISODate(isoDateMatch[1], isoDateMatch[2], isoDateMatch[3]);
+    }
+
+    const dateTimeMatch = stringValue.match(/^(\d{4})-(\d{2})-(\d{2})[T\s]/);
+    if (dateTimeMatch) {
+        return formatISODate(dateTimeMatch[1], dateTimeMatch[2], dateTimeMatch[3]);
+    }
+
+    const brDateMatch = stringValue.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+    if (brDateMatch) {
+        return formatISODate(brDateMatch[3], brDateMatch[2], brDateMatch[1]);
+    }
+
+    const compactMatch = stringValue.match(/^(\d{4})(\d{2})(\d{2})/);
+    if (compactMatch) {
+        return formatISODate(compactMatch[1], compactMatch[2], compactMatch[3]);
+    }
+
+    const parsedDate = new Date(stringValue);
+    if (!Number.isFinite(parsedDate.getTime())) {
+        throw new Error(`${fieldName} inválida.`);
+    }
+
+    return formatISODate(
+        parsedDate.getUTCFullYear(),
+        parsedDate.getUTCMonth() + 1,
+        parsedDate.getUTCDate()
+    );
+};
+
+const inferType = (rawType, amount) => {
+    if (rawType) {
+        const normalized = stripDiacritics(String(rawType)).toLowerCase();
+        if (/(payable|despesa|debito|pagamento|saida|debit|debitado)/.test(normalized)) {
+            return 'payable';
+        }
+        if (/(receivable|receita|credito|entrada|credit|deposito|deposit)/.test(normalized)) {
+            return 'receivable';
+        }
+    }
+
+    if (typeof amount === 'number') {
+        if (amount < 0) {
+            return 'payable';
+        }
+        if (amount > 0) {
+            return 'receivable';
+        }
+    }
+
+    return 'payable';
+};
+
+const createEntryHash = (entry) => {
+    const description = sanitizeDescription(entry.description || '');
+    const amount = normalizeAmount(entry.value ?? entry.amount ?? 0);
+    const dueDate = normalizeDate(entry.dueDate || entry.date || entry.paymentDate || entry.data, 'data');
+
+    const payload = `${description.toLowerCase()}|${amount.toFixed(2)}|${dueDate}`;
+    return crypto.createHash('sha256').update(payload).digest('hex');
+};
+
+const detectDelimiter = (headerLine) => {
+    const candidates = [',', ';', '\t', '|'];
+    const best = candidates.map((delimiter) => ({ delimiter, count: headerLine.split(delimiter).length }))
+        .sort((a, b) => b.count - a.count)[0];
+    return (best && best.count > 1) ? best.delimiter : ',';
+};
+
+const splitCsvLine = (line, delimiter) => {
+    const values = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i += 1) {
+        const char = line[i];
+
+        if (char === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+                current += '"';
+                i += 1;
+            } else {
+                inQuotes = !inQuotes;
+            }
+            continue;
+        }
+
+        if (char === delimiter && !inQuotes) {
+            values.push(current.trim());
+            current = '';
+            continue;
+        }
+
+        current += char;
+    }
+
+    values.push(current.trim());
+    return values;
+};
+
+const aliasMap = {
+    description: ['description', 'descricao', 'descrição', 'historico', 'histórico', 'memo', 'name', 'history'],
+    type: ['type', 'tipo', 'natureza', 'categoria', 'transactiontype', 'trntype'],
+    value: ['value', 'valor', 'amount', 'quantia', 'montante'],
+    dueDate: ['duedate', 'data', 'date', 'datavencimento', 'vencimento', 'posteddate', 'dtposted'],
+    paymentDate: ['paymentdate', 'datapagamento', 'payment_date', 'data_pagamento', 'dtpayment'],
+    status: ['status', 'situacao', 'situação']
+};
+
+const normalizeHeader = (header) => {
+    return stripDiacritics(header).toLowerCase().replace(/[^a-z0-9]/g, '');
+};
+
+const resolveHeaderIndexes = (headers) => {
+    const normalizedHeaders = headers.map((header) => normalizeHeader(header));
+    const indexMap = {};
+
+    Object.entries(aliasMap).forEach(([key, aliases]) => {
+        const normalizedAliases = aliases.map(normalizeHeader);
+        const foundIndex = normalizedAliases.map((alias) => normalizedHeaders.indexOf(alias)).find((index) => index !== -1);
+        if (foundIndex !== undefined && foundIndex !== -1) {
+            indexMap[key] = foundIndex;
+        }
+    });
+
+    return indexMap;
+};
+
+const parseCsvContent = (content) => {
+    const warnings = [];
+    const sanitized = content.replace(/\uFEFF/g, '').replace(/\r\n/g, '\n');
+    const lines = sanitized.split(/\n+/).map((line) => line.trim()).filter((line) => line);
+
+    if (!lines.length) {
+        return { entries: [], warnings: ['Arquivo CSV sem linhas válidas.'] };
+    }
+
+    const delimiter = detectDelimiter(lines[0]);
+    const headers = splitCsvLine(lines[0], delimiter);
+    const headerIndexes = resolveHeaderIndexes(headers);
+
+    const requiredColumns = ['description', 'value', 'dueDate'];
+    const missingColumns = requiredColumns.filter((column) => !(column in headerIndexes));
+
+    if (missingColumns.length) {
+        const missingList = missingColumns.join(', ');
+        throw new Error(`Colunas obrigatórias ausentes no CSV: ${missingList}.`);
+    }
+
+    const entries = [];
+
+    for (let lineIndex = 1; lineIndex < lines.length; lineIndex += 1) {
+        const line = lines[lineIndex];
+        if (!line) {
+            continue;
+        }
+
+        const values = splitCsvLine(line, delimiter);
+        if (!values.length) {
+            continue;
+        }
+
+        try {
+            const description = sanitizeDescription(values[headerIndexes.description] || '');
+            const amountRaw = values[headerIndexes.value];
+            const numericAmount = normalizeAmount(amountRaw);
+            const dueDate = normalizeDate(values[headerIndexes.dueDate], 'data');
+            const paymentDate = headerIndexes.paymentDate !== undefined && values[headerIndexes.paymentDate]
+                ? normalizeDate(values[headerIndexes.paymentDate], 'data de pagamento')
+                : null;
+            const typeRaw = headerIndexes.type !== undefined ? values[headerIndexes.type] : null;
+            const statusRaw = headerIndexes.status !== undefined ? values[headerIndexes.status] : null;
+            const type = inferType(typeRaw, numericAmount);
+
+            entries.push({
+                description,
+                type,
+                value: Math.abs(numericAmount),
+                dueDate,
+                paymentDate,
+                status: normalizeStatus(statusRaw),
+                metadata: {
+                    source: 'csv',
+                    line: lineIndex + 1,
+                    originalType: typeRaw || null,
+                    rawAmount: amountRaw
+                }
+            });
+        } catch (error) {
+            warnings.push(`Linha ${lineIndex + 1}: ${error.message}`);
+        }
+    }
+
+    return { entries, warnings };
+};
+
+const extractTagValue = (block, tag) => {
+    if (!block) {
+        return null;
+    }
+
+    const normalizedBlock = String(block);
+    const searchBlock = normalizedBlock.toUpperCase();
+    const openTag = `<${tag}>`.toUpperCase();
+    const startIndex = searchBlock.indexOf(openTag);
+
+    if (startIndex === -1) {
+        return null;
+    }
+
+    const valueStart = startIndex + openTag.length;
+    let valueEnd = searchBlock.indexOf('<', valueStart);
+
+    if (valueEnd === -1) {
+        valueEnd = normalizedBlock.length;
+    }
+
+    const rawValue = normalizedBlock.slice(valueStart, valueEnd);
+    return rawValue.trim();
+};
+
+const parseOfxContent = (content) => {
+    const warnings = [];
+    const sanitized = content.replace(/\r\n/g, '\n');
+    const segments = sanitized.split(/<STMTTRN>/i).slice(1);
+    const entries = [];
+
+    segments.forEach((segment, index) => {
+        const block = segment.split(/<\/STMTTRN>/i)[0];
+        if (!block) {
+            return;
+        }
+
+        try {
+            const amountRaw = extractTagValue(block, 'TRNAMT');
+            const dateRaw = extractTagValue(block, 'DTUSER') || extractTagValue(block, 'DTPOSTED');
+            if (!amountRaw || !dateRaw) {
+                throw new Error('Registro incompleto.');
+            }
+
+            const numericAmount = normalizeAmount(amountRaw);
+            const dueDate = normalizeDate(dateRaw, 'data');
+            const typeRaw = extractTagValue(block, 'TRNTYPE');
+            const descriptionRaw = extractTagValue(block, 'MEMO') || extractTagValue(block, 'NAME') || `Transação ${index + 1}`;
+            const statusRaw = extractTagValue(block, 'STATUS');
+            const paymentDateRaw = extractTagValue(block, 'DTAVAIL') || null;
+
+            entries.push({
+                description: sanitizeDescription(descriptionRaw),
+                type: inferType(typeRaw, numericAmount),
+                value: Math.abs(numericAmount),
+                dueDate,
+                paymentDate: paymentDateRaw ? normalizeDate(paymentDateRaw, 'data de pagamento') : null,
+                status: normalizeStatus(statusRaw),
+                metadata: {
+                    source: 'ofx',
+                    index: index + 1,
+                    originalType: typeRaw || null,
+                    rawAmount: amountRaw
+                }
+            });
+        } catch (error) {
+            warnings.push(`Transação ${index + 1}: ${error.message}`);
+        }
+    });
+
+    return { entries, warnings };
+};
+
+const parseFinanceFile = (buffer, { filename = '', mimetype = '' } = {}) => {
+    if (!buffer || !Buffer.isBuffer(buffer) || buffer.length === 0) {
+        throw new Error('Arquivo vazio ou inválido.');
+    }
+
+    const extension = path.extname(filename).toLowerCase();
+    const normalizedMimetype = mimetype.toLowerCase();
+    const content = buffer.toString('utf8');
+
+    if (extension === '.ofx' || normalizedMimetype.includes('ofx') || /<OFX>/i.test(content)) {
+        return parseOfxContent(content);
+    }
+
+    return parseCsvContent(content);
+};
+
+const prepareEntryForPersistence = (input) => {
+    if (!input) {
+        throw new Error('Entrada inválida.');
+    }
+
+    const description = sanitizeDescription(input.description || '');
+    if (!description) {
+        throw new Error('Descrição é obrigatória.');
+    }
+
+    const numericAmount = normalizeAmount(input.value);
+    const type = inferType(input.type, numericAmount);
+    const dueDate = normalizeDate(input.dueDate, 'data de vencimento');
+    const paymentDate = input.paymentDate ? normalizeDate(input.paymentDate, 'data de pagamento') : null;
+    const status = normalizeStatus(input.status);
+
+    return {
+        description,
+        type,
+        value: Math.abs(numericAmount),
+        dueDate,
+        paymentDate,
+        status,
+        hash: createEntryHash({ description, value: Math.abs(numericAmount), dueDate })
+    };
+};
+
+module.exports = {
+    parseFinanceFile,
+    parseCsvContent,
+    parseOfxContent,
+    sanitizeDescription,
+    normalizeAmount,
+    normalizeDate,
+    inferType,
+    normalizeStatus,
+    createEntryHash,
+    prepareEntryForPersistence
+};

--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -31,6 +31,253 @@
 
     <div class="col-12">
         <div class="card card-soft responsive-panel">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div>
+                        <h3 class="fw-semibold mb-1">Importar lançamentos</h3>
+                        <p class="text-muted mb-0">
+                            Carregue extratos em CSV ou OFX para acelerar o registro de receitas e despesas com validação automática.
+                        </p>
+                    </div>
+                    <div class="text-muted small text-lg-end">
+                        Formatos aceitos<br />
+                        <span class="fw-semibold text-primary">CSV · OFX</span>
+                    </div>
+                </div>
+                <form
+                    class="mt-4"
+                    action="/finance/import/preview"
+                    method="POST"
+                    enctype="multipart/form-data"
+                    novalidate
+                >
+                    <div class="row g-3 align-items-center">
+                        <div class="col-12 col-lg">
+                            <div class="input-group input-group-lg shadow-sm">
+                                <span class="input-group-text bg-white">
+                                    <i class="bi bi-upload" aria-hidden="true"></i>
+                                </span>
+                                <input
+                                    class="form-control form-control-lg"
+                                    type="file"
+                                    name="importFile"
+                                    accept=".csv,.ofx,text/csv,application/ofx,application/x-ofx"
+                                    required
+                                    aria-label="Selecionar arquivo CSV ou OFX para importação"
+                                />
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-auto d-grid d-lg-block">
+                            <button class="btn btn-primary btn-lg w-100" type="submit">
+                                <i class="bi bi-search me-2" aria-hidden="true"></i>
+                                Analisar arquivo
+                            </button>
+                        </div>
+                    </div>
+                    <div class="form-text mt-2">
+                        Os arquivos são processados em memória e descartados após a análise. Revise os lançamentos sugeridos antes de concluir.
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <% if (typeof importPreview !== 'undefined' && importPreview) { %>
+        <div class="col-12">
+            <div class="card card-soft border border-primary-subtle responsive-panel">
+                <div class="card-header bg-light d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+                    <div>
+                        <span class="badge rounded-pill bg-primary-subtle text-primary-emphasis">
+                            <i class="bi bi-clipboard-check me-1" aria-hidden="true"></i>
+                            Pré-visualização
+                        </span>
+                        <h3 class="fw-semibold mt-2 mb-0">Revisar lançamentos importados</h3>
+                    </div>
+                    <div class="text-muted small text-lg-end">
+                        <div class="fw-semibold text-dark"><%= importPreview.fileName %></div>
+                        <div>Processado em <%= new Date(importPreview.uploadedAt).toLocaleString('pt-BR') %></div>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+                        <div class="d-flex flex-wrap gap-2">
+                            <span class="badge rounded-pill bg-success-subtle text-success-emphasis">
+                                <i class="bi bi-plus-circle me-1" aria-hidden="true"></i>
+                                <strong><%= importPreview.totals.new %></strong> novo(s)
+                            </span>
+                            <span class="badge rounded-pill bg-warning-subtle text-warning-emphasis">
+                                <i class="bi bi-exclamation-circle me-1" aria-hidden="true"></i>
+                                <strong><%= importPreview.totals.conflicting %></strong> conflito(s)
+                            </span>
+                            <span class="badge rounded-pill bg-secondary-subtle text-secondary-emphasis">
+                                <i class="bi bi-list-check me-1" aria-hidden="true"></i>
+                                <strong><%= importPreview.totals.total %></strong> registro(s)
+                            </span>
+                        </div>
+                        <div class="text-muted small">
+                            Ajuste as informações ou desmarque lançamentos conflitantes antes de importar.
+                        </div>
+                    </div>
+
+                    <% if (importPreview.warnings && importPreview.warnings.length) { %>
+                        <div class="alert alert-warning shadow-sm" role="alert">
+                            <div class="d-flex align-items-start gap-3">
+                                <i class="bi bi-info-circle fs-4" aria-hidden="true"></i>
+                                <div>
+                                    <h6 class="fw-semibold mb-2">Avisos de leitura</h6>
+                                    <ul class="list-unstyled mb-0 small">
+                                        <% importPreview.warnings.forEach(function(warning) { %>
+                                            <li><i class="bi bi-dot me-1"></i><%= warning %></li>
+                                        <% }); %>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    <% } %>
+
+                    <form action="/finance/import/commit" method="POST" class="mt-4">
+                        <div class="table-responsive table-modern responsive-table">
+                            <table class="table align-middle mb-0">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th class="text-center">Importar</th>
+                                        <th>Descrição</th>
+                                        <th class="text-center">Tipo</th>
+                                        <th>Valor (R$)</th>
+                                        <th>Vencimento</th>
+                                        <th>Pagamento</th>
+                                        <th>Status</th>
+                                        <th>Origem</th>
+                                        <th class="text-center">Situação</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <% importPreview.entries.forEach(function(entry, index) { %>
+                                        <tr class="<%= entry.conflict ? 'table-warning' : '' %>">
+                                            <td class="text-center">
+                                                <div class="form-check form-switch d-inline-flex align-items-center justify-content-center">
+                                                    <input
+                                                        class="form-check-input"
+                                                        type="checkbox"
+                                                        name="entries[<%= index %>][include]"
+                                                        value="1"
+                                                        id="importEntry<%= index %>"
+                                                        <%= entry.include ? 'checked' : '' %>
+                                                    />
+                                                </div>
+                                                <input type="hidden" name="entries[<%= index %>][hash]" value="<%= entry.hash %>" />
+                                            </td>
+                                            <td>
+                                                <input
+                                                    type="text"
+                                                    class="form-control form-control-sm"
+                                                    name="entries[<%= index %>][description]"
+                                                    value="<%= entry.description %>"
+                                                    required
+                                                />
+                                            </td>
+                                            <td class="text-center">
+                                                <select class="form-select form-select-sm" name="entries[<%= index %>][type]" required>
+                                                    <option value="payable" <%= entry.type === 'payable' ? 'selected' : '' %>>Pagar</option>
+                                                    <option value="receivable" <%= entry.type === 'receivable' ? 'selected' : '' %>>Receber</option>
+                                                </select>
+                                            </td>
+                                            <td>
+                                                <div class="input-group input-group-sm">
+                                                    <span class="input-group-text">R$</span>
+                                                    <input
+                                                        type="number"
+                                                        class="form-control"
+                                                        name="entries[<%= index %>][value]"
+                                                        step="0.01"
+                                                        min="0"
+                                                        value="<%= Number(entry.value || 0).toFixed(2) %>"
+                                                        required
+                                                    />
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <input
+                                                    type="date"
+                                                    class="form-control form-control-sm"
+                                                    name="entries[<%= index %>][dueDate]"
+                                                    value="<%= entry.dueDate %>"
+                                                    required
+                                                />
+                                            </td>
+                                            <td>
+                                                <input
+                                                    type="date"
+                                                    class="form-control form-control-sm"
+                                                    name="entries[<%= index %>][paymentDate]"
+                                                    value="<%= entry.paymentDate ? entry.paymentDate : '' %>"
+                                                />
+                                            </td>
+                                            <td>
+                                                <select class="form-select form-select-sm" name="entries[<%= index %>][status]">
+                                                    <option value="pending" <%= entry.status === 'pending' ? 'selected' : '' %>>Pendente</option>
+                                                    <option value="paid" <%= entry.status === 'paid' ? 'selected' : '' %>>Pago</option>
+                                                    <option value="overdue" <%= entry.status === 'overdue' ? 'selected' : '' %>>Em atraso</option>
+                                                    <option value="cancelled" <%= entry.status === 'cancelled' ? 'selected' : '' %>>Cancelado</option>
+                                                </select>
+                                            </td>
+                                            <td class="text-muted small">
+                                                <% if (entry.metadata && entry.metadata.source) { %>
+                                                    <span class="badge rounded-pill bg-secondary-subtle text-secondary-emphasis"><%= entry.metadata.source.toUpperCase() %></span>
+                                                <% } %>
+                                                <% if (entry.metadata && entry.metadata.line) { %>
+                                                    <div>Linha <%= entry.metadata.line %></div>
+                                                <% } else if (entry.metadata && entry.metadata.index) { %>
+                                                    <div>Registro <%= entry.metadata.index %></div>
+                                                <% } %>
+                                            </td>
+                                            <td class="text-center">
+                                                <% if (entry.conflictReasons.length) { %>
+                                                    <span class="badge bg-warning-subtle text-warning-emphasis d-inline-flex align-items-center gap-2 mb-2">
+                                                        <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
+                                                        Conflito
+                                                    </span>
+                                                    <div class="small text-muted text-start">
+                                                        <% entry.conflictReasons.forEach(function(reason) { %>
+                                                            <div><i class="bi bi-dot"></i><%= reason %></div>
+                                                        <% }); %>
+                                                    </div>
+                                                <% } else { %>
+                                                    <span class="badge bg-success-subtle text-success-emphasis d-inline-flex align-items-center gap-2">
+                                                        <i class="bi bi-check-circle" aria-hidden="true"></i>
+                                                        Novo
+                                                    </span>
+                                                <% } %>
+                                            </td>
+                                        </tr>
+                                    <% }); %>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mt-4">
+                            <div class="text-muted small">
+                                Importação preparada em <%= new Date(importPreview.uploadedAt).toLocaleString('pt-BR') %>.<br />
+                                <span class="fw-semibold"><%= importPreview.totals.new %></span> lançamento(s) pronto(s) para importação.
+                            </div>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a href="/finance" class="btn btn-outline-secondary btn-sm">
+                                    <i class="bi bi-x-circle me-1" aria-hidden="true"></i>
+                                    Cancelar prévia
+                                </a>
+                                <button type="submit" class="btn btn-primary btn-sm">
+                                    <i class="bi bi-cloud-arrow-down me-2" aria-hidden="true"></i>
+                                    Importar lançamentos selecionados
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    <% } %>
+
+    <div class="col-12">
+        <div class="card card-soft responsive-panel">
             <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-3">
                 <div>
                     <h3 class="fw-semibold mb-1">Lançamentos recentes</h3>

--- a/tests/integration/financeImportFlow.test.js
+++ b/tests/integration/financeImportFlow.test.js
@@ -1,0 +1,124 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const path = require('path');
+const request = require('supertest');
+const express = require('express');
+const session = require('express-session');
+const flash = require('connect-flash');
+
+jest.mock('../../src/middlewares/authMiddleware', () => jest.fn((req, res, next) => {
+    req.session = req.session || {};
+    req.user = { id: 1, active: true, role: 'admin' };
+    req.session.user = req.user;
+    next();
+}));
+
+jest.mock('../../src/middlewares/permissionMiddleware', () => () => (req, res, next) => next());
+
+jest.mock('../../src/middlewares/audit', () => () => (req, res, next) => next());
+
+const financeRoutes = require('../../src/routes/financeRoutes');
+const { FinanceEntry, sequelize } = require('../../database/models');
+
+const buildTestApp = () => {
+    const app = express();
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+    app.use(session({
+        secret: 'test-secret',
+        resave: false,
+        saveUninitialized: false
+    }));
+    app.use(flash());
+    app.set('view engine', 'ejs');
+    app.set('views', path.join(__dirname, '../../src/views'));
+    app.use('/finance', financeRoutes);
+    return app;
+};
+
+describe('Fluxo de importação financeira', () => {
+    let app;
+
+    beforeAll(async () => {
+        await sequelize.sync({ force: true });
+        app = buildTestApp();
+    });
+
+    beforeEach(async () => {
+        await FinanceEntry.destroy({ where: {} });
+        await FinanceEntry.create({
+            description: 'Mensalidade Academia',
+            type: 'receivable',
+            value: 2500,
+            dueDate: '2024-01-15',
+            status: 'paid'
+        });
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    it('realiza a pré-visualização e a importação dos lançamentos válidos', async () => {
+        const csvPayload = [
+            'Descrição;Valor;Data;Tipo',
+            'Conta de Luz;-150,30;10/01/2024;Despesa',
+            'Mensalidade Academia;2500;2024-01-15;Receita'
+        ].join('\n');
+
+        const previewResponse = await request(app)
+            .post('/finance/import/preview')
+            .set('Accept', 'application/json')
+            .attach('importFile', Buffer.from(csvPayload, 'utf8'), 'import.csv');
+
+        expect(previewResponse.status).toBe(200);
+        expect(previewResponse.body).toHaveProperty('preview');
+
+        const { preview } = previewResponse.body;
+        expect(preview.entries).toHaveLength(2);
+        expect(preview.totals).toMatchObject({ total: 2, new: 1, conflicting: 1 });
+
+        const commitPayload = {
+            entries: preview.entries.map((entry) => ({
+                include: !entry.conflict,
+                description: entry.description,
+                type: entry.type,
+                value: entry.value,
+                dueDate: entry.dueDate,
+                status: entry.status,
+                paymentDate: entry.paymentDate || ''
+            }))
+        };
+
+        const commitResponse = await request(app)
+            .post('/finance/import/commit')
+            .set('Accept', 'application/json')
+            .send(commitPayload);
+
+        expect(commitResponse.status).toBe(201);
+        expect(commitResponse.body.summary).toMatchObject({
+            created: 1,
+            duplicates: 0,
+            invalid: 0,
+            skipped: 1,
+            totalReceived: 2
+        });
+
+        const entries = await FinanceEntry.findAll({ order: [['dueDate', 'ASC']] });
+        expect(entries).toHaveLength(2);
+
+        const [firstEntry, secondEntry] = entries;
+        expect(firstEntry).toMatchObject({
+            description: 'Conta de Luz',
+            type: 'payable',
+            value: expect.anything(),
+            dueDate: '2024-01-10'
+        });
+        expect(secondEntry).toMatchObject({
+            description: 'Mensalidade Academia',
+            dueDate: '2024-01-15'
+        });
+    });
+});

--- a/tests/unit/financeImportService.test.js
+++ b/tests/unit/financeImportService.test.js
@@ -1,0 +1,138 @@
+const financeImportService = require('../../src/services/financeImportService');
+
+describe('financeImportService', () => {
+    describe('parseFinanceFile - CSV', () => {
+        it('normaliza valores, datas e metadados a partir de um CSV válido', () => {
+            const csvContent = [
+                'Descrição;Valor;Data;Tipo;Status',
+                'Conta de Luz;-150,30;10/01/2024;Despesa;pending',
+                'Mensalidade Academia;2500;2024-01-15;Receita;paid'
+            ].join('\n');
+
+            const buffer = Buffer.from(csvContent, 'utf8');
+            const result = financeImportService.parseFinanceFile(buffer, {
+                filename: 'lancamentos.csv',
+                mimetype: 'text/csv'
+            });
+
+            expect(result.entries).toHaveLength(2);
+            expect(result.warnings).toHaveLength(0);
+
+            const [firstEntry, secondEntry] = result.entries;
+
+            expect(firstEntry).toMatchObject({
+                description: 'Conta de Luz',
+                type: 'payable',
+                value: 150.3,
+                dueDate: '2024-01-10',
+                status: 'pending',
+                metadata: expect.objectContaining({
+                    source: 'csv',
+                    line: 2,
+                    originalType: 'Despesa'
+                })
+            });
+
+            expect(secondEntry).toMatchObject({
+                description: 'Mensalidade Academia',
+                type: 'receivable',
+                value: 2500,
+                dueDate: '2024-01-15',
+                status: 'paid',
+                metadata: expect.objectContaining({
+                    source: 'csv',
+                    line: 3,
+                    originalType: 'Receita'
+                })
+            });
+        });
+    });
+
+    describe('parseFinanceFile - OFX', () => {
+        it('interpreta lançamentos a partir de um arquivo OFX', () => {
+            const ofxContent = `
+<OFX>
+    <BANKTRANLIST>
+        <STMTTRN>
+            <TRNTYPE>DEBIT
+            <DTPOSTED>20240105120000[-03:EST]
+            <TRNAMT>-89.45
+            <MEMO>Supermercado Central
+        </STMTTRN>
+        <STMTTRN>
+            <TRNTYPE>CREDIT
+            <DTPOSTED>20240106
+            <TRNAMT>1500.00
+            <NAME>Pagamento Projeto
+        </STMTTRN>
+    </BANKTRANLIST>
+</OFX>
+`.trim();
+
+            const buffer = Buffer.from(ofxContent, 'utf8');
+            const result = financeImportService.parseFinanceFile(buffer, {
+                filename: 'extrato.ofx',
+                mimetype: 'application/ofx'
+            });
+
+            expect(result.entries).toHaveLength(2);
+
+            const [debitEntry, creditEntry] = result.entries;
+            expect(debitEntry).toMatchObject({
+                description: 'Supermercado Central',
+                type: 'payable',
+                value: 89.45,
+                dueDate: '2024-01-05'
+            });
+
+            expect(creditEntry).toMatchObject({
+                description: 'Pagamento Projeto',
+                type: 'receivable',
+                value: 1500,
+                dueDate: '2024-01-06'
+            });
+        });
+    });
+
+    describe('prepareEntryForPersistence', () => {
+        it('padroniza descrição, valores, datas e hash de um lançamento', () => {
+            const prepared = financeImportService.prepareEntryForPersistence({
+                description: '  Serviço de Consultoria  ',
+                value: '1.234,56',
+                dueDate: '12/02/2024',
+                status: 'paid',
+                type: 'receita'
+            });
+
+            expect(prepared).toMatchObject({
+                description: 'Serviço de Consultoria',
+                type: 'receivable',
+                value: 1234.56,
+                dueDate: '2024-02-12',
+                status: 'paid',
+                paymentDate: null
+            });
+
+            expect(typeof prepared.hash).toBe('string');
+            expect(prepared.hash).toHaveLength(64);
+        });
+    });
+
+    describe('createEntryHash', () => {
+        it('gera o mesmo hash para dados equivalentes', () => {
+            const hashA = financeImportService.createEntryHash({
+                description: 'Mensalidade',
+                value: '150,00',
+                dueDate: '2024-01-10'
+            });
+
+            const hashB = financeImportService.createEntryHash({
+                description: '  mensalidade  ',
+                value: 150,
+                dueDate: '10/01/2024'
+            });
+
+            expect(hashA).toBe(hashB);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add in-memory upload middleware and parser service to normalize CSV/OFX finance imports
- surface preview/review UI with duplicate detection before committing entries
- wire preview/commit endpoints with FinanceEntry bulk creation safeguards and new tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f9a37834832fb38c5c14d37c5576