### PR TITLE
Fix user dropdown targeting and initialization

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -172,6 +172,9 @@
         }
 
         const userMenuToggle = document.getElementById('userMenu');
+        if (userMenuToggle) {
+            window.bootstrap?.Dropdown?.getOrCreateInstance(userMenuToggle);
+        }
         const userMenuDropdown = document.getElementById('userMenuDropdown');
         if (userMenuToggle && userMenuDropdown) {
             const getDropdownInstance = () => {

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -174,6 +174,8 @@
                             id="userMenu"
                             role="button"
                             data-bs-toggle="dropdown"
+                            data-bs-target="#userMenuDropdown"
+                            aria-controls="userMenuDropdown"
                             aria-expanded="false"
                             aria-haspopup="true"
                         >


### PR DESCRIPTION
## Summary
- add explicit target metadata to the authenticated user menu toggle so Bootstrap can locate the dropdown
- proactively instantiate the Bootstrap dropdown plugin when the navbar loads to keep keyboard listeners working

## Testing
- `npm test` *(fails: health check exits early because FINANCE_RECURRING_INTERVALS is undefined in financeController.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ff3257b0832fb19e9aed0da83d46