### PR TITLE
Add monthly finance goals projections

### DIFF
--- a/database/migrations/20240913-create-finance-goals.js
+++ b/database/migrations/20240913-create-finance-goals.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('FinanceGoals', {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: Sequelize.INTEGER
+            },
+            month: {
+                allowNull: false,
+                type: Sequelize.DATEONLY,
+                unique: true
+            },
+            targetNetAmount: {
+                allowNull: false,
+                type: Sequelize.DECIMAL(12, 2),
+                defaultValue: 0
+            },
+            notes: {
+                allowNull: true,
+                type: Sequelize.STRING(255)
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE
+            }
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('FinanceGoals');
+    }
+};

--- a/database/models/financeGoal.js
+++ b/database/models/financeGoal.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const normalizeMonthValue = (value) => {
+    if (!value) {
+        return null;
+    }
+
+    let reference;
+
+    if (value instanceof Date) {
+        reference = value;
+    } else if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        if (/^\d{4}-\d{2}$/.test(trimmed)) {
+            reference = new Date(`${trimmed}-01T00:00:00Z`);
+        } else {
+            reference = new Date(trimmed);
+        }
+    }
+
+    if (!(reference instanceof Date) || Number.isNaN(reference.getTime())) {
+        return null;
+    }
+
+    const normalized = new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), 1));
+    return normalized.toISOString().slice(0, 10);
+};
+
+module.exports = (sequelize, DataTypes) => {
+    const FinanceGoal = sequelize.define('FinanceGoal', {
+        month: {
+            type: DataTypes.DATEONLY,
+            allowNull: false,
+            unique: true,
+            validate: {
+                isDate: {
+                    msg: 'Período da meta inválido.'
+                }
+            }
+        },
+        targetNetAmount: {
+            type: DataTypes.DECIMAL(12, 2),
+            allowNull: false,
+            defaultValue: 0,
+            validate: {
+                isDecimal: {
+                    msg: 'Valor da meta deve ser numérico.'
+                }
+            }
+        },
+        notes: {
+            type: DataTypes.STRING(255),
+            allowNull: true
+        }
+    }, {
+        tableName: 'FinanceGoals',
+        indexes: [
+            {
+                unique: true,
+                fields: ['month']
+            }
+        ]
+    });
+
+    FinanceGoal.addHook('beforeValidate', (goal) => {
+        if (!goal) {
+            return;
+        }
+
+        const normalizedMonth = normalizeMonthValue(goal.month);
+        if (normalizedMonth) {
+            goal.month = normalizedMonth;
+        }
+    });
+
+    FinanceGoal.normalizeMonthValue = normalizeMonthValue;
+
+    return FinanceGoal;
+};

--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -1,4 +1,4 @@
-const { FinanceEntry } = require('../../database/models');
+const { FinanceEntry, FinanceGoal } = require('../../database/models');
 const PDFDocument = require('pdfkit');
 const ExcelJS = require('exceljs');
 const financeReportingService = require('../services/financeReportingService');
@@ -12,6 +12,34 @@ const parseAmount = (value) => {
     }
     const parsed = Number.parseFloat(value);
     return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const normalizeAmountInput = (value) => {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null;
+    }
+
+    if (typeof value === 'string') {
+        let cleaned = value.trim();
+        if (!cleaned) {
+            return null;
+        }
+
+        if (cleaned.includes('.') && cleaned.includes(',')) {
+            cleaned = cleaned.replace(/\./g, '').replace(',', '.');
+        } else if (cleaned.includes(',')) {
+            cleaned = cleaned.replace(',', '.');
+        }
+
+        const parsed = Number.parseFloat(cleaned);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+
+    return null;
 };
 
 const currencyFormatter = new Intl.NumberFormat('pt-BR', {
@@ -91,14 +119,108 @@ const createSummaryPromise = (entriesPromise, filters) => {
     );
 };
 
+const parseMonthInput = (value) => {
+    if (!value) {
+        return null;
+    }
+
+    if (value instanceof Date) {
+        return Number.isFinite(value.getTime()) ? value : null;
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        const byNumber = new Date(value);
+        return Number.isFinite(byNumber.getTime()) ? byNumber : null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        if (/^\d{4}-\d{2}$/.test(trimmed)) {
+            const date = new Date(`${trimmed}-01T00:00:00Z`);
+            return Number.isFinite(date.getTime()) ? date : null;
+        }
+
+        if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+            const date = new Date(`${trimmed}T00:00:00Z`);
+            return Number.isFinite(date.getTime()) ? date : null;
+        }
+
+        const parsed = new Date(trimmed);
+        return Number.isFinite(parsed.getTime()) ? parsed : null;
+    }
+
+    return null;
+};
+
+const normalizeGoalMonth = (value) => {
+    if (typeof FinanceGoal?.normalizeMonthValue === 'function') {
+        return FinanceGoal.normalizeMonthValue(value);
+    }
+
+    const parsed = parseMonthInput(value);
+    if (!parsed) {
+        return null;
+    }
+
+    const normalized = new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), 1));
+    return normalized.toISOString().slice(0, 10);
+};
+
+const formatGoalMonthKey = (value) => {
+    const parsed = parseMonthInput(value);
+    if (!parsed) {
+        return '';
+    }
+    return `${parsed.getUTCFullYear()}-${String(parsed.getUTCMonth() + 1).padStart(2, '0')}`;
+};
+
+const formatGoalMonthLabel = (value) => {
+    const parsed = parseMonthInput(value);
+    if (!parsed) {
+        return '--';
+    }
+    return parsed.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' });
+};
+
+const serializeGoalForView = (goal) => {
+    const plain = typeof goal?.get === 'function' ? goal.get({ plain: true }) : goal || {};
+    const amountNumber = parseAmount(plain.targetNetAmount);
+    const monthKey = formatGoalMonthKey(plain.month);
+
+    return {
+        id: plain.id,
+        month: plain.month,
+        monthKey,
+        monthLabel: formatGoalMonthLabel(plain.month),
+        targetNetAmount: amountNumber,
+        targetNetAmountInput: Number.isFinite(amountNumber) ? amountNumber.toFixed(2) : '0.00',
+        formattedAmount: formatCurrency(amountNumber),
+        notes: plain.notes || ''
+    };
+};
+
 module.exports = {
     listFinanceEntries: async (req, res) => {
         try {
             const filters = buildFiltersFromQuery(req.query);
             const entriesPromise = FinanceEntry.findAll(buildEntriesQueryOptions(filters));
             const summaryPromise = createSummaryPromise(entriesPromise, filters);
+            const goalsPromise = FinanceGoal.findAll({
+                order: [['month', 'ASC']]
+            });
 
-            const [entries, summary] = await Promise.all([entriesPromise, summaryPromise]);
+            const [entries, summary, goals] = await Promise.all([entriesPromise, summaryPromise, goalsPromise]);
+
+            const projections = Array.isArray(summary.projections) ? summary.projections : [];
+            const projectionHighlight = projections.find((item) => item.isFuture && item.hasGoal)
+                || projections.find((item) => item.isFuture)
+                || projections.find((item) => item.isCurrent)
+                || null;
+            const projectionAlerts = projections.filter((item) => item.needsAttention);
 
             res.render('finance/manageFinance', {
                 entries,
@@ -106,7 +228,15 @@ module.exports = {
                 periodLabel: formatPeriodLabel(filters),
                 statusSummary: summary.statusSummary,
                 monthlySummary: summary.monthlySummary,
-                financeTotals: summary.totals
+                financeTotals: summary.totals,
+                financeProjections: projections,
+                projectionHighlight,
+                projectionAlerts,
+                financeGoals: goals.map(serializeGoalForView),
+                goalSummary: {
+                    total: goals.length,
+                    alerts: projectionAlerts.length
+                }
             });
         } catch (err) {
             console.error(err);
@@ -180,6 +310,83 @@ module.exports = {
             console.error(err);
             req.flash('error_msg', 'Erro ao excluir lançamento.');
             res.redirect('/finance');
+        }
+    },
+
+    saveFinanceGoal: async (req, res) => {
+        try {
+            const { goalId, month, targetNetAmount, notes } = req.body;
+            const normalizedMonth = normalizeGoalMonth(month);
+
+            if (!normalizedMonth) {
+                req.flash('error_msg', 'Período da meta inválido.');
+                return res.redirect('/finance');
+            }
+
+            const parsedAmount = normalizeAmountInput(targetNetAmount);
+            if (!Number.isFinite(parsedAmount)) {
+                req.flash('error_msg', 'Valor da meta inválido.');
+                return res.redirect('/finance');
+            }
+
+            const cleanedNotes = sanitizeText(notes);
+            const finalNotes = cleanedNotes ? cleanedNotes : null;
+
+            if (goalId) {
+                const goal = await FinanceGoal.findByPk(goalId);
+                if (!goal) {
+                    req.flash('error_msg', 'Meta financeira não encontrada.');
+                    return res.redirect('/finance');
+                }
+
+                goal.month = normalizedMonth;
+                goal.targetNetAmount = parsedAmount;
+                goal.notes = finalNotes;
+                await goal.save();
+                req.flash('success_msg', 'Meta financeira atualizada com sucesso!');
+            } else {
+                const [goal, created] = await FinanceGoal.findOrCreate({
+                    where: { month: normalizedMonth },
+                    defaults: {
+                        targetNetAmount: parsedAmount,
+                        notes: finalNotes
+                    }
+                });
+
+                if (!created) {
+                    goal.targetNetAmount = parsedAmount;
+                    goal.notes = finalNotes;
+                    await goal.save();
+                    req.flash('success_msg', 'Meta financeira atualizada com sucesso!');
+                } else {
+                    req.flash('success_msg', 'Meta financeira cadastrada com sucesso!');
+                }
+            }
+
+            return res.redirect('/finance');
+        } catch (error) {
+            console.error(error);
+            req.flash('error_msg', 'Erro ao salvar meta financeira.');
+            return res.redirect('/finance');
+        }
+    },
+
+    deleteFinanceGoal: async (req, res) => {
+        try {
+            const { id } = req.params;
+            const goal = await FinanceGoal.findByPk(id);
+            if (!goal) {
+                req.flash('error_msg', 'Meta financeira não encontrada.');
+                return res.redirect('/finance');
+            }
+
+            await goal.destroy();
+            req.flash('success_msg', 'Meta financeira removida.');
+            return res.redirect('/finance');
+        } catch (error) {
+            console.error(error);
+            req.flash('error_msg', 'Erro ao remover meta financeira.');
+            return res.redirect('/finance');
         }
     },
 

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -30,6 +30,25 @@ router.delete(
     financeController.deleteFinanceEntry
 );
 
+router.post(
+    '/goals',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    audit('financeGoal.save', (req) => {
+        const month = req.body?.month || req.body?.goalMonth || 'unknown';
+        return `FinanceGoal:save:${month}`;
+    }),
+    financeController.saveFinanceGoal
+);
+
+router.delete(
+    '/goals/:id',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    audit('financeGoal.delete', (req) => `FinanceGoal:${req.params.id}`),
+    financeController.deleteFinanceGoal
+);
+
 router.get(
     '/export/pdf',
     authMiddleware,

--- a/src/services/financeReportingService.js
+++ b/src/services/financeReportingService.js
@@ -1,11 +1,21 @@
 'use strict';
 
-const { FinanceEntry, Sequelize } = require('../../database/models');
+const { FinanceEntry, FinanceGoal, Sequelize } = require('../../database/models');
 
 const { Op } = Sequelize;
 
 const FINANCE_TYPES = ['payable', 'receivable'];
 const FINANCE_STATUSES = ['pending', 'paid', 'overdue', 'cancelled'];
+const DEFAULT_PROJECTION_MONTHS = 6;
+const MAX_PROJECTION_MONTHS = 24;
+
+const toNullableNumber = (value) => {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+};
 
 const toNumber = (value) => {
     if (typeof value === 'number') {
@@ -13,6 +23,56 @@ const toNumber = (value) => {
     }
     const parsed = Number.parseFloat(value);
     return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const roundNumber = (value) => {
+    const parsed = toNumber(value);
+    return Number.isFinite(parsed) ? Number(parsed.toFixed(2)) : 0;
+};
+
+const roundNullable = (value) => {
+    const parsed = toNullableNumber(value);
+    return Number.isFinite(parsed) ? Number(parsed.toFixed(2)) : null;
+};
+
+const parseDateCandidate = (value) => {
+    if (!value) {
+        return null;
+    }
+
+    if (value instanceof Date) {
+        return Number.isFinite(value.getTime()) ? value : null;
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        const fromNumber = new Date(value);
+        return Number.isFinite(fromNumber.getTime()) ? fromNumber : null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return null;
+        }
+
+        if (/^\d{4}-\d{2}$/.test(trimmed)) {
+            const monthDate = new Date(`${trimmed}-01T00:00:00Z`);
+            return Number.isFinite(monthDate.getTime()) ? monthDate : null;
+        }
+
+        const parsed = new Date(trimmed);
+        return Number.isFinite(parsed.getTime()) ? parsed : null;
+    }
+
+    return null;
+};
+
+const parseProjectionMonths = (value) => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return DEFAULT_PROJECTION_MONTHS;
+    }
+    return Math.min(parsed, MAX_PROJECTION_MONTHS);
 };
 
 const isValidISODate = (value) => {
@@ -118,6 +178,305 @@ const buildMonthlySummaryFromEntries = (entries) => {
         .map(month => ({ month, ...monthly[month] }));
 };
 
+const startOfMonth = (date) => {
+    const reference = parseDateCandidate(date) || new Date();
+    return new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), 1));
+};
+
+const endOfMonth = (date) => {
+    const reference = parseDateCandidate(date) || new Date();
+    return new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+};
+
+const normalizeIntervalKey = (value) => {
+    if (typeof value !== 'string') {
+        return '';
+    }
+    return value
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim();
+};
+
+const INTERVAL_MAP = {
+    monthly: { months: 1 },
+    mensal: { months: 1 },
+    mensalmente: { months: 1 },
+    '1m': { months: 1 },
+    biweekly: { days: 14 },
+    quinzenal: { days: 14 },
+    '2w': { days: 14 },
+    weekly: { days: 7 },
+    semanal: { days: 7 },
+    '1w': { days: 7 },
+    quarterly: { months: 3 },
+    trimestral: { months: 3 },
+    '3m': { months: 3 },
+    yearly: { years: 1 },
+    anual: { years: 1 },
+    annually: { years: 1 },
+    '12m': { years: 1 }
+};
+
+const DEFAULT_INTERVAL = INTERVAL_MAP.monthly;
+
+const resolveInterval = (value) => {
+    const key = normalizeIntervalKey(value);
+    return INTERVAL_MAP[key] || DEFAULT_INTERVAL;
+};
+
+const addDaysUTC = (date, days) => {
+    const reference = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+    reference.setUTCDate(reference.getUTCDate() + days);
+    return reference;
+};
+
+const addMonthsUTC = (date, months) => {
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth();
+    const day = date.getUTCDate();
+    const base = new Date(Date.UTC(year, month + months, 1));
+    const lastDay = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth() + 1, 0)).getUTCDate();
+    base.setUTCDate(Math.min(day, lastDay));
+    return base;
+};
+
+const addYearsUTC = (date, years) => addMonthsUTC(date, years * 12);
+
+const advanceDateByInterval = (date, interval) => {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    const { years = 0, months = 0, days = 0 } = interval || {};
+
+    let result = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+
+    if (years) {
+        result = addYearsUTC(result, years);
+    }
+
+    if (months) {
+        result = addMonthsUTC(result, months);
+    }
+
+    if (days) {
+        result = addDaysUTC(result, days);
+    }
+
+    return result;
+};
+
+const buildProjectionBuckets = (referenceDate, months) => {
+    const reference = startOfMonth(referenceDate);
+    const totalMonths = Math.min(Math.max(months, 1), MAX_PROJECTION_MONTHS);
+    const buckets = [];
+
+    for (let index = 0; index < totalMonths; index += 1) {
+        const current = new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth() + index, 1));
+        buckets.push({
+            month: formatMonth(current),
+            label: current.toLocaleDateString('pt-BR', { month: 'short', year: 'numeric' }),
+            start: current,
+            end: endOfMonth(current)
+        });
+    }
+
+    return buckets;
+};
+
+const buildActualMonthlyMap = (entries, monthKeys) => {
+    const summary = buildMonthlySummaryFromEntries(entries);
+    const keySet = new Set(monthKeys);
+    return summary.reduce((acc, item) => {
+        if (keySet.has(item.month)) {
+            acc[item.month] = {
+                payable: toNumber(item.payable),
+                receivable: toNumber(item.receivable)
+            };
+        }
+        return acc;
+    }, {});
+};
+
+const buildRecurringProjectionMap = (entries, buckets) => {
+    if (!Array.isArray(entries) || !entries.length || !Array.isArray(buckets) || !buckets.length) {
+        return {};
+    }
+
+    const monthKeys = new Set(buckets.map(bucket => bucket.month));
+    const rangeStart = buckets[0].start;
+    const rangeEnd = buckets[buckets.length - 1].end;
+    const projection = {};
+
+    for (const entry of entries) {
+        if (!entry?.recurring || !FINANCE_TYPES.includes(entry.type)) {
+            continue;
+        }
+
+        const value = toNumber(entry.value);
+        if (!value) {
+            continue;
+        }
+
+        const dueDate = parseDateCandidate(entry.dueDate);
+        if (!dueDate) {
+            continue;
+        }
+
+        const interval = resolveInterval(entry.recurringInterval);
+        let occurrence = advanceDateByInterval(dueDate, interval);
+        let safety = 0;
+
+        while (occurrence && occurrence <= rangeEnd && safety < 500) {
+            safety += 1;
+            if (occurrence >= rangeStart) {
+                const monthKey = formatMonth(occurrence);
+                if (monthKeys.has(monthKey)) {
+                    if (!projection[monthKey]) {
+                        projection[monthKey] = { payable: 0, receivable: 0 };
+                    }
+                    projection[monthKey][entry.type] += value;
+                }
+            }
+
+            occurrence = advanceDateByInterval(occurrence, interval);
+        }
+    }
+
+    return projection;
+};
+
+const fetchGoalsForMonths = async (monthKeys, options = {}) => {
+    if (Array.isArray(options.goals)) {
+        return options.goals;
+    }
+
+    if (!Array.isArray(monthKeys) || !monthKeys.length) {
+        return [];
+    }
+
+    const monthValues = monthKeys.map((key) => {
+        if (typeof key === 'string' && /^\d{4}-\d{2}$/.test(key)) {
+            return `${key}-01`;
+        }
+        return key;
+    });
+
+    return FinanceGoal.findAll({
+        attributes: ['id', 'month', 'targetNetAmount', 'notes'],
+        where: {
+            month: { [Op.in]: monthValues }
+        },
+        order: [['month', 'ASC']],
+        raw: true
+    });
+};
+
+const buildGoalsMap = (goals) => {
+    if (!Array.isArray(goals)) {
+        return {};
+    }
+
+    return goals.reduce((acc, goal) => {
+        const monthKey = formatMonth(goal.month);
+        if (monthKey) {
+            acc[monthKey] = {
+                id: goal.id || null,
+                targetNetAmount: toNullableNumber(goal.targetNetAmount),
+                notes: goal.notes || null
+            };
+        }
+        return acc;
+    }, {});
+};
+
+const combineProjectionData = (buckets, actualMap, recurringMap, goalMap, referenceDate) => {
+    if (!Array.isArray(buckets) || !buckets.length) {
+        return [];
+    }
+
+    const referenceStart = startOfMonth(referenceDate);
+    const currentMonthKey = formatMonth(referenceDate);
+
+    return buckets.map((bucket) => {
+        const actual = actualMap[bucket.month] || { payable: 0, receivable: 0 };
+        const recurring = recurringMap[bucket.month] || { payable: 0, receivable: 0 };
+
+        const actualPayable = toNumber(actual.payable);
+        const actualReceivable = toNumber(actual.receivable);
+        const recurringPayable = toNumber(recurring.payable);
+        const recurringReceivable = toNumber(recurring.receivable);
+
+        const projectedReceivable = actualReceivable + recurringReceivable;
+        const projectedPayable = actualPayable + recurringPayable;
+
+        const projectedNet = projectedReceivable - projectedPayable;
+        const actualNet = actualReceivable - actualPayable;
+
+        const goal = goalMap[bucket.month];
+        const targetNet = goal ? toNullableNumber(goal.targetNetAmount) : null;
+        const achieved = targetNet !== null ? projectedNet >= targetNet : null;
+        const gapToGoal = targetNet !== null ? projectedNet - targetNet : null;
+
+        return {
+            month: bucket.month,
+            label: bucket.label,
+            start: bucket.start,
+            end: bucket.end,
+            actual: {
+                receivable: roundNumber(actualReceivable),
+                payable: roundNumber(actualPayable),
+                net: roundNumber(actualNet)
+            },
+            projected: {
+                receivable: roundNumber(projectedReceivable),
+                payable: roundNumber(projectedPayable),
+                net: roundNumber(projectedNet)
+            },
+            goal: goal ? {
+                id: goal.id,
+                targetNetAmount: targetNet !== null ? roundNumber(targetNet) : null,
+                notes: goal.notes,
+                achieved,
+                gapToGoal: roundNullable(gapToGoal)
+            } : null,
+            hasGoal: Boolean(goal),
+            needsAttention: Boolean(goal) && achieved === false,
+            isCurrent: bucket.month === currentMonthKey,
+            isFuture: bucket.start.getTime() > referenceStart.getTime(),
+            isPast: bucket.start.getTime() < referenceStart.getTime()
+        };
+    });
+};
+
+const buildMonthlyProjectionFromEntries = async (entries, { referenceDate, months } = {}, options = {}) => {
+    const reference = parseDateCandidate(referenceDate) || new Date();
+    const projectionMonths = parseProjectionMonths(months);
+    const buckets = buildProjectionBuckets(reference, projectionMonths);
+
+    if (!buckets.length) {
+        return [];
+    }
+
+    const monthKeys = buckets.map(bucket => bucket.month);
+    const actualMap = buildActualMonthlyMap(entries, monthKeys);
+    const recurringMap = buildRecurringProjectionMap(entries, buckets);
+    const goals = await fetchGoalsForMonths(monthKeys, options);
+    const goalMap = buildGoalsMap(goals);
+
+    return combineProjectionData(buckets, actualMap, recurringMap, goalMap, reference);
+};
+
+const resolveProjectionSettings = (filters = {}, options = {}) => {
+    const referenceCandidate = options.referenceDate ?? filters.referenceDate ?? filters.startDate;
+    const referenceDate = parseDateCandidate(referenceCandidate) || new Date();
+    const monthsCandidate = options.projectionMonths ?? filters.projectionMonths ?? filters.monthsAhead ?? filters.months;
+    const months = parseProjectionMonths(monthsCandidate);
+    return { referenceDate, months };
+};
+
 const buildTotalsFromStatus = (statusSummary) => {
     const totals = {
         payable: 0,
@@ -187,19 +546,29 @@ const getMonthlySummary = async (filters = {}, options = {}) => {
     return buildMonthlySummaryFromEntries(entries);
 };
 
+const getMonthlyProjection = async (filters = {}, options = {}) => {
+    const entries = await resolveEntries(filters, options);
+    const settings = resolveProjectionSettings(filters, options);
+    return buildMonthlyProjectionFromEntries(entries, settings, options);
+};
+
 const getFinanceSummary = async (filters = {}, options = {}) => {
     const entries = await resolveEntries(filters, options);
     const statusSummary = buildStatusSummaryFromEntries(entries);
+    const projectionSettings = resolveProjectionSettings(filters, options);
+    const projections = await buildMonthlyProjectionFromEntries(entries, projectionSettings, options);
     return {
         statusSummary,
         monthlySummary: buildMonthlySummaryFromEntries(entries),
-        totals: buildTotalsFromStatus(statusSummary)
+        totals: buildTotalsFromStatus(statusSummary),
+        projections
     };
 };
 
 module.exports = {
     getStatusSummary,
     getMonthlySummary,
+    getMonthlyProjection,
     getFinanceSummary,
     constants: {
         FINANCE_TYPES: [...FINANCE_TYPES],
@@ -209,8 +578,10 @@ module.exports = {
         buildTotalsFromStatus,
         buildStatusSummaryFromEntries,
         buildMonthlySummaryFromEntries,
+        buildMonthlyProjectionFromEntries,
         createEmptyStatusSummary,
         buildDateFilter,
-        isValidISODate
+        isValidISODate,
+        resolveProjectionSettings
     }
 };

--- a/src/views/dashboard/index.ejs
+++ b/src/views/dashboard/index.ejs
@@ -90,6 +90,48 @@
     </div>
 
     <div class="row g-4 mt-1">
+        <div class="col-12">
+            <article class="card projection-card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="d-flex align-items-center justify-content-between flex-wrap gap-3 mb-3">
+                        <div>
+                            <h5 class="chart-title mb-1">Metas e projeções financeiras</h5>
+                            <p class="chart-subtitle mb-0 text-muted">Comparativo do saldo líquido projetado com as metas cadastradas.</p>
+                        </div>
+                        <div class="text-end small">
+                            <span class="badge rounded-pill bg-light text-muted" data-projection-highlight-badge>
+                                <i class="bi bi-bullseye me-1"></i>
+                                Aguardando atualização
+                            </span>
+                        </div>
+                    </div>
+                    <div class="projection-highlight border rounded-3 p-3 bg-light-subtle mb-3" data-projection-highlight>
+                        <div class="text-muted small">As projeções serão carregadas automaticamente.</div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th scope="col">Mês</th>
+                                    <th scope="col">Saldo projetado</th>
+                                    <th scope="col">Meta líquida</th>
+                                    <th scope="col">Diferença</th>
+                                    <th scope="col" class="text-center">Status</th>
+                                </tr>
+                            </thead>
+                            <tbody data-projection-rows>
+                                <tr>
+                                    <td colspan="5" class="text-center text-muted small">Carregando projeções...</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </article>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-1">
         <div class="col-xxl-8">
             <article class="card chart-card border-0 shadow-sm h-100">
                 <div class="card-body">

--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -1,6 +1,10 @@
 <%- include('../partials/header') %>
 
 <div class="row fade-in responsive-page-row gy-4">
+    <% const currencyFormatter = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }); %>
+    <% const projectionList = Array.isArray(financeProjections) ? financeProjections : []; %>
+    <% const highlightProjection = projectionHighlight; %>
+    <% const alertsList = Array.isArray(projectionAlerts) ? projectionAlerts : []; %>
     <div class="col-12">
         <div class="card card-soft responsive-panel">
             <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
@@ -26,6 +30,189 @@
                     <i class="bi bi-exclamation-triangle me-2"></i><%= error_msg %>
                 </div>
             <% } %>
+        </div>
+    </div>
+
+    <div class="col-12 col-xxl-8">
+        <div class="card card-soft responsive-panel">
+            <div class="card-body">
+                <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 mb-3">
+                    <div>
+                        <h3 class="fw-semibold mb-1">Metas e projeções</h3>
+                        <p class="text-muted mb-0">Acompanhe se o saldo projetado atende as metas mensais configuradas.</p>
+                    </div>
+                    <div class="text-lg-end">
+                        <span class="badge rounded-pill bg-light text-muted me-2">
+                            <i class="bi bi-calendar-week me-1"></i>
+                            <%= projectionList.length %> períodos monitorados
+                        </span>
+                        <span class="badge rounded-pill <%= goalSummary && goalSummary.alerts ? 'bg-warning-subtle text-warning' : 'bg-success-subtle text-success' %>">
+                            <i class="bi bi-bullseye me-1"></i>
+                            <%= goalSummary && goalSummary.alerts ? `${goalSummary.alerts} meta(s) em atenção` : 'Metas sob controle' %>
+                        </span>
+                    </div>
+                </div>
+
+                <% if (alertsList.length) { %>
+                    <div class="alert alert-warning border-0 d-flex align-items-center gap-2" role="alert">
+                        <i class="bi bi-exclamation-triangle-fill"></i>
+                        <span>
+                            <strong><%= alertsList.length %></strong>
+                            <%= alertsList.length === 1 ? 'meta' : 'metas' %> com projeção abaixo do objetivo.
+                        </span>
+                    </div>
+                <% } %>
+
+                <div class="projection-highlight border rounded-3 p-3 bg-light-subtle mb-3">
+                    <% if (highlightProjection) { %>
+                        <% const highlightGoal = highlightProjection.goal || {}; %>
+                        <% const highlightGap = (typeof highlightGoal.gapToGoal === 'number') ? highlightGoal.gapToGoal : null; %>
+                        <% const gapLabel = highlightGap !== null ? `${highlightGap >= 0 ? '+' : '-'}${currencyFormatter.format(Math.abs(highlightGap))}` : '—'; %>
+                        <% const gapClass = highlightGap !== null ? (highlightGap >= 0 ? 'text-success' : 'text-danger') : 'text-muted'; %>
+                        <% const statusClass = highlightGoal.achieved === true ? 'badge bg-success-subtle text-success' : highlightGoal.achieved === false ? 'badge bg-danger-subtle text-danger' : 'badge bg-secondary-subtle text-secondary'; %>
+                        <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+                            <div>
+                                <p class="text-muted small mb-1">Próxima meta monitorada</p>
+                                <h4 class="fw-semibold mb-0"><%= highlightProjection.label || highlightProjection.month %></h4>
+                            </div>
+                            <div class="text-end">
+                                <div class="fw-semibold"><%= currencyFormatter.format(Number(highlightProjection.projected?.net || 0)) %></div>
+                                <div class="text-muted small">
+                                    Meta: <span class="fw-semibold"><%= highlightGoal.targetNetAmount !== null && highlightGoal.targetNetAmount !== undefined ? currencyFormatter.format(Number(highlightGoal.targetNetAmount)) : '—' %></span>
+                                </div>
+                                <div class="text-muted small">
+                                    Diferença: <span class="fw-semibold <%= gapClass %>"><%= gapLabel %></span>
+                                </div>
+                                <span class="<%= statusClass %>">
+                                    <%= highlightGoal.achieved === true ? 'Meta atingida' : highlightGoal.achieved === false ? 'Meta em risco' : 'Meta registrada' %>
+                                </span>
+                            </div>
+                        </div>
+                    <% } else { %>
+                        <p class="text-muted small mb-0">Cadastre uma meta mensal para visualizar projeções detalhadas.</p>
+                    <% } %>
+                </div>
+
+                <div class="table-responsive table-modern responsive-table">
+                    <table class="table table-sm align-middle mb-0">
+                        <thead class="table-dark">
+                            <tr>
+                                <th>Mês</th>
+                                <th>Saldo projetado</th>
+                                <th>Meta líquida</th>
+                                <th>Diferença</th>
+                                <th class="text-center">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <% if (!projectionList.length) { %>
+                                <tr>
+                                    <td colspan="5" class="text-center text-muted small">Nenhuma projeção disponível.</td>
+                                </tr>
+                            <% } else { %>
+                                <% projectionList.forEach((item) => { %>
+                                    <% const goal = item.goal || {}; %>
+                                    <% const gapValue = (typeof goal.gapToGoal === 'number') ? goal.gapToGoal : null; %>
+                                    <% const gapLabel = gapValue !== null ? `${gapValue >= 0 ? '+' : '-'}${currencyFormatter.format(Math.abs(gapValue))}` : '—'; %>
+                                    <% const gapClass = gapValue !== null ? (gapValue >= 0 ? 'text-success' : 'text-danger') : 'text-muted'; %>
+                                    <% const rowClass = item.needsAttention ? 'table-warning' : (item.isCurrent ? 'table-active' : ''); %>
+                                    <% const statusLabel = goal.achieved === true ? 'Meta atingida' : goal.achieved === false ? 'Meta em risco' : goal.targetNetAmount !== null && goal.targetNetAmount !== undefined ? 'Meta registrada' : 'Sem meta'; %>
+                                    <% const statusClass = goal.achieved === true ? 'badge bg-success-subtle text-success' : goal.achieved === false ? 'badge bg-danger-subtle text-danger' : goal.targetNetAmount !== null && goal.targetNetAmount !== undefined ? 'badge bg-secondary-subtle text-secondary' : 'badge bg-light text-muted'; %>
+                                    <tr class="<%= rowClass %>">
+                                        <td><%= item.label || item.month %></td>
+                                        <td><%= currencyFormatter.format(Number(item.projected?.net || 0)) %></td>
+                                        <td><%= goal.targetNetAmount !== null && goal.targetNetAmount !== undefined ? currencyFormatter.format(Number(goal.targetNetAmount)) : '—' %></td>
+                                        <td class="<%= gapClass %>"><%= gapLabel %></td>
+                                        <td class="text-center"><span class="<%= statusClass %>"><%= statusLabel %></span></td>
+                                    </tr>
+                                <% }) %>
+                            <% } %>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-12 col-xxl-4">
+        <div class="card card-soft responsive-panel h-100">
+            <div class="card-body">
+                <h4 class="fw-semibold mb-3">Configurar metas mensais</h4>
+                <form action="/finance/goals" method="POST" class="row g-3">
+                    <div class="col-12">
+                        <label class="form-label">Mês da meta</label>
+                        <input type="month" class="form-control" name="month" value="<%= highlightProjection ? highlightProjection.month : '' %>" required />
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Saldo líquido desejado (R$)</label>
+                        <input type="number" step="0.01" min="0" class="form-control" name="targetNetAmount" placeholder="Ex.: 15000" required />
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label">Notas (opcional)</label>
+                        <textarea class="form-control" name="notes" rows="2" maxlength="255" placeholder="Reforços ou observações"></textarea>
+                    </div>
+                    <div class="col-12 d-flex justify-content-end gap-2">
+                        <button type="reset" class="btn btn-outline-secondary btn-sm">Limpar</button>
+                        <button type="submit" class="btn btn-gradient btn-sm">Salvar meta</button>
+                    </div>
+                </form>
+
+                <hr class="my-4" />
+
+                <h5 class="fw-semibold mb-3">Metas cadastradas</h5>
+                <% if (!financeGoals.length) { %>
+                    <p class="text-muted small mb-0">Nenhuma meta cadastrada até o momento.</p>
+                <% } else { %>
+                    <div class="list-group list-group-flush">
+                        <% financeGoals.forEach((goal) => { %>
+                            <div class="list-group-item px-0">
+                                <div class="d-flex flex-column gap-2">
+                                    <div class="d-flex justify-content-between align-items-start gap-3">
+                                        <div>
+                                            <h6 class="fw-semibold mb-1"><%= goal.monthLabel %></h6>
+                                            <p class="text-muted small mb-1">Meta: <span class="fw-semibold"><%= goal.formattedAmount %></span></p>
+                                            <% if (goal.notes) { %>
+                                                <p class="text-muted small mb-0"><i class="bi bi-chat-left-text me-1"></i><%= goal.notes %></p>
+                                            <% } %>
+                                        </div>
+                                        <div class="d-flex gap-2">
+                                            <button class="btn btn-outline-primary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#goalEdit<%= goal.id %>" aria-expanded="false" aria-controls="goalEdit<%= goal.id %>">
+                                                <i class="bi bi-pencil"></i>
+                                            </button>
+                                            <form action="/finance/goals/<%= goal.id %>?_method=DELETE" method="POST" class="d-inline">
+                                                <button class="btn btn-outline-danger btn-sm" type="submit">
+                                                    <i class="bi bi-trash"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                    <div class="collapse" id="goalEdit<%= goal.id %>">
+                                        <form action="/finance/goals" method="POST" class="row g-3 mt-2">
+                                            <input type="hidden" name="goalId" value="<%= goal.id %>" />
+                                            <div class="col-12">
+                                                <label class="form-label">Mês</label>
+                                                <input type="month" class="form-control" name="month" value="<%= goal.monthKey %>" required />
+                                            </div>
+                                            <div class="col-12">
+                                                <label class="form-label">Meta líquida (R$)</label>
+                                                <input type="number" step="0.01" min="0" class="form-control" name="targetNetAmount" value="<%= goal.targetNetAmountInput %>" required />
+                                            </div>
+                                            <div class="col-12">
+                                                <label class="form-label">Notas</label>
+                                                <textarea class="form-control" name="notes" rows="2" maxlength="255"><%= goal.notes %></textarea>
+                                            </div>
+                                            <div class="col-12 d-flex justify-content-end gap-2">
+                                                <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="collapse" data-bs-target="#goalEdit<%= goal.id %>">Cancelar</button>
+                                                <button type="submit" class="btn btn-gradient btn-sm">Atualizar meta</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        <% }) %>
+                    </div>
+                <% } %>
+            </div>
         </div>
     </div>
 

--- a/tests/integration/routes.smoke.test.js
+++ b/tests/integration/routes.smoke.test.js
@@ -9,6 +9,9 @@ jest.mock('../../database/models', () => {
         FinanceEntry: {
             findAll: jest.fn()
         },
+        FinanceGoal: {
+            findAll: jest.fn()
+        },
         Notification: {
             findAll: jest.fn()
         },
@@ -21,7 +24,7 @@ jest.mock('../../database/models', () => {
 });
 
 const request = require('supertest');
-const { FinanceEntry, Notification } = require('../../database/models');
+const { FinanceEntry, FinanceGoal, Notification } = require('../../database/models');
 const { createRouterTestApp } = require('../utils/createRouterTestApp');
 const { authenticateTestUser } = require('../utils/authTestUtils');
 
@@ -35,6 +38,7 @@ describe('Smoke tests das rotas principais', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        FinanceGoal.findAll.mockResolvedValue([]);
         app = createRouterTestApp({
             routes: [
                 ['/', authRoutes],
@@ -82,8 +86,11 @@ describe('Smoke tests das rotas principais', () => {
         const response = await agent.get('/finance');
 
         expect(FinanceEntry.findAll).toHaveBeenCalledTimes(1);
+        expect(FinanceGoal.findAll).toHaveBeenCalledTimes(2);
         expect(response.status).toBe(200);
         expect(response.text).toContain('Gerenciar finanças estratégicas');
+        expect(response.text).toContain('Metas e projeções');
+        expect(response.text).toContain('Configurar metas mensais');
         expect(response.text).toContain('Lançamentos recentes');
         expect(response.text).toContain('Mensalidade corporativa');
     });

--- a/tests/unit/views/manageFinance.test.js
+++ b/tests/unit/views/manageFinance.test.js
@@ -29,6 +29,11 @@ const buildViewContext = () => ({
             recurringInterval: 'Mensal'
         }
     ],
+    financeProjections: [],
+    projectionHighlight: null,
+    projectionAlerts: [],
+    financeGoals: [],
+    goalSummary: { total: 0, alerts: 0 },
     success_msg: null,
     error_msg: null,
     error: null,


### PR DESCRIPTION
## Summary
- add FinanceGoals table and model to persist monthly targets
- extend finance reporting, controllers, and routes to compute projections against saved goals
- update dashboard and finance views with projection widgets and goal management UI, and cover behavior with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f9a275c0832f996c6ba5ac4f7e2e