### PR TITLE
Fix finance reporting recurring interval constants import

### DIFF
--- a/src/services/financeReportingService.js
+++ b/src/services/financeReportingService.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const { FinanceEntry, FinanceGoal, Sequelize } = require('../../database/models');
+const {
+    FINANCE_RECURRING_INTERVALS,
+    FINANCE_RECURRING_INTERVAL_VALUES,
+    FINANCE_RECURRING_INTERVAL_LABEL_TO_VALUE
+} = require('../constants/financeRecurringIntervals');
 
 const { Op } = Sequelize;
 


### PR DESCRIPTION
## Summary
- import finance recurring interval constants into the finance reporting service so exported references are defined

## Testing
- `npm run test:health`


------
https://chatgpt.com/codex/tasks/task_e_68ca24f60b9c832fb3813068994bc7ae