### PR TITLE
chore: expose finance goal model in controller

### DIFF
--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -1,5 +1,5 @@
 const { Op } = require('sequelize');
-const { FinanceEntry, FinanceAttachment, sequelize } = require('../../database/models');
+const { FinanceEntry, FinanceAttachment, FinanceGoal, sequelize } = require('../../database/models');
 const PDFDocument = require('pdfkit');
 const ExcelJS = require('exceljs');
 const { pipeline } = require('stream/promises');


### PR DESCRIPTION
## Summary
- include the FinanceGoal model when requiring database models in the finance controller so routes and helpers can reuse it

## Testing
- npm run test:integration *(fails: ReferenceError: buildImportPreview is not defined; ReferenceError: wantsJsonResponse is not defined; SequelizeDatabaseError: SQLITE_ERROR: no such table: FinanceGoals)*
- npm run test *(fails: ReferenceError: buildImportPreview is not defined; ReferenceError: wantsJsonResponse is not defined; SequelizeDatabaseError: SQLITE_ERROR: no such table: FinanceGoals)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2a09465c832f8a85b28b220241ef