### PR TITLE
Implement finance import preview helper

### DIFF
--- a/src/services/financeReportingService.js
+++ b/src/services/financeReportingService.js
@@ -370,14 +370,25 @@ const fetchGoalsForMonths = async (monthKeys, options = {}) => {
         return key;
     });
 
-    return FinanceGoal.findAll({
-        attributes: ['id', 'month', 'targetNetAmount', 'notes'],
-        where: {
-            month: { [Op.in]: monthValues }
-        },
-        order: [['month', 'ASC']],
-        raw: true
-    });
+    if (!FinanceGoal || typeof FinanceGoal.findAll !== 'function') {
+        return [];
+    }
+
+    try {
+        return await FinanceGoal.findAll({
+            attributes: ['id', 'month', 'targetNetAmount', 'notes'],
+            where: {
+                month: { [Op.in]: monthValues }
+            },
+            order: [['month', 'ASC']],
+            raw: true
+        });
+    } catch (error) {
+        if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
+            console.warn('Não foi possível buscar metas financeiras para projeções:', error);
+        }
+        return [];
+    }
 };
 
 const buildGoalsMap = (goals) => {


### PR DESCRIPTION
## Summary
- add a buildImportPreview helper to normalize parsed import entries, compute hashes, and flag duplicates/conflicts
- update the finance controller to use the preview builder, expose formatting helpers to the view, and safely load finance goals
- guard finance reporting goal lookups against missing tables during projection calculations

## Testing
- npm run test:integration
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68ca2a0a30fc832f8d28d6c7a3741467