### PR TITLE
Prevent blank profile names from triggering validation errors

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -339,8 +339,16 @@ module.exports = {
 
             const { name, phone, address, password, dateOfBirth } = req.body;
 
-            if (typeof name === 'string') {
-                user.name = name.trim();
+            const hasNameInPayload = Object.prototype.hasOwnProperty.call(req.body, 'name');
+            const trimmedName = typeof name === 'string' ? name.trim() : undefined;
+
+            if (hasNameInPayload) {
+                if (!trimmedName) {
+                    req.flash('error_msg', 'Nome é obrigatório.');
+                    return res.redirect('/users/profile');
+                }
+
+                user.name = trimmedName;
             }
 
             if (typeof phone === 'string') {

--- a/tests/integration/userProfileRoutes.test.js
+++ b/tests/integration/userProfileRoutes.test.js
@@ -162,6 +162,7 @@ describe('Rotas autenticadas de perfil de usuário', () => {
 
         expect(response.status).toBe(302);
         expect(response.headers.location).toBe('/users/profile');
+        expect(failingInstance.save).not.toHaveBeenCalled();
         await new Promise((resolve) => setImmediate(resolve));
         expect(AuditLog.create).not.toHaveBeenCalled();
 

--- a/tests/unit/userController.profile.test.js
+++ b/tests/unit/userController.profile.test.js
@@ -138,7 +138,7 @@ describe('userController.updateProfile', () => {
         await userController.updateProfile(req, res);
 
         expect(User.findByPk).toHaveBeenCalledWith(55);
-        expect(userInstance.save).toHaveBeenCalledTimes(1);
+        expect(userInstance.save).not.toHaveBeenCalled();
         expect(req.session.user.name).toBe('Cliente Padrão');
         expect(req.flash).toHaveBeenCalledWith('error_msg', 'Nome é obrigatório.');
         expect(res.redirect).toHaveBeenCalledWith('/users/profile');


### PR DESCRIPTION
## Summary
- validate profile updates locally to reject blank names before hitting the database
- update unit and integration coverage to expect no persistence when the name is missing

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca822fefe8832faf231357670f8077