### PR TITLE
Add finance category reference to finance entry model

### DIFF
--- a/database/models/financeEntry.js
+++ b/database/models/financeEntry.js
@@ -55,6 +55,20 @@ module.exports = (sequelize, DataTypes) => {
                 }
             }
         },
+        financeCategoryId: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'FinanceCategories',
+                key: 'id'
+            },
+            onDelete: 'SET NULL',
+            validate: {
+                isInt: {
+                    msg: 'Categoria financeira inválida.'
+                }
+            }
+        },
         status: {
             type: DataTypes.STRING, // 'pending', 'paid', 'overdue'
             defaultValue: 'pending',


### PR DESCRIPTION
## Summary
- add the `financeCategoryId` attribute to the FinanceEntry model with integer type and validation
- declare the foreign-key reference to FinanceCategories and preserve the existing association

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca8765d6a4832fb69dca98d03b4cca