### PR TITLE
Enhance finance import with category resolution

### DIFF
--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -534,7 +534,8 @@ module.exports = {
                 throw new Error('Nenhum lançamento válido foi encontrado no arquivo.');
             }
 
-            const preview = await buildImportPreview(parseResult.entries);
+            const currentUserId = req.user?.id ?? req.session?.user?.id ?? null;
+            const preview = await buildImportPreview(parseResult.entries, { ownerId: currentUserId });
             const payload = {
                 fileName: req.file.originalname,
                 uploadedAt: new Date().toISOString(),
@@ -575,11 +576,14 @@ module.exports = {
                 throw new Error('Nenhum lançamento selecionado para importação.');
             }
 
+            const currentUserId = req.user?.id ?? req.session?.user?.id ?? null;
+            const categoryResolver = await financeImportService.createFinanceCategoryResolver({ ownerId: currentUserId });
+
             const preparedEntries = [];
             const skippedEntries = [];
             const invalidEntries = [];
 
-            entriesArray.forEach((entry) => {
+            for (const entry of entriesArray) {
                 const includeFlag = entry.include ?? entry.selected ?? entry.import ?? entry.shouldImport;
                 const shouldImport = includeFlag === true
                     || includeFlag === 'true'
@@ -588,16 +592,16 @@ module.exports = {
 
                 if (!shouldImport) {
                     skippedEntries.push(entry);
-                    return;
+                    continue;
                 }
 
                 try {
-                    const prepared = financeImportService.prepareEntryForPersistence(entry);
+                    const prepared = await financeImportService.prepareEntryForPersistence(entry, { categoryResolver });
                     preparedEntries.push(prepared);
                 } catch (error) {
                     invalidEntries.push({ entry, message: error.message });
                 }
-            });
+            }
 
             if (!preparedEntries.length) {
                 const baseMessage = invalidEntries.length

--- a/src/services/financeImportService.js
+++ b/src/services/financeImportService.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const path = require('path');
 const { Op } = require('sequelize');
 
-const { FinanceEntry } = require('../../database/models');
+const { FinanceEntry, FinanceCategory } = require('../../database/models');
 
 const stripDiacritics = (value) => {
     return value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
@@ -193,9 +193,125 @@ const splitCsvLine = (line, delimiter) => {
     return values;
 };
 
+const fallbackSlugify = (value) => {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    const stringValue = sanitizeDescription(value);
+    if (!stringValue) {
+        return null;
+    }
+
+    const normalized = stripDiacritics(stringValue)
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+
+    return normalized || null;
+};
+
+const normalizeCategorySlug = (value) => {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    const source = sanitizeDescription(value);
+    if (!source) {
+        return null;
+    }
+
+    if (FinanceCategory && typeof FinanceCategory.normalizeSlug === 'function') {
+        try {
+            return FinanceCategory.normalizeSlug(source);
+        } catch (error) {
+            return fallbackSlugify(source);
+        }
+    }
+
+    return fallbackSlugify(source);
+};
+
+const extractCategorySlugFromInput = (input) => {
+    if (!input || typeof input !== 'object') {
+        return null;
+    }
+
+    const candidates = [
+        input.financeCategorySlug,
+        input.categorySlug,
+        input.categoryKey,
+        input.category,
+        input.financeCategory,
+        input.categoryName,
+        input.metadata?.originalCategory,
+        input.metadata?.category,
+        input.metadata?.categoryName
+    ];
+
+    for (const candidate of candidates) {
+        const slug = normalizeCategorySlug(candidate);
+        if (slug) {
+            return slug;
+        }
+    }
+
+    return null;
+};
+
+const buildCategoryResolver = async ({ ownerId, FinanceCategoryModel = FinanceCategory } = {}) => {
+    if (!FinanceCategoryModel || !ownerId) {
+        return {
+            resolveSlug: async () => null,
+            isAllowedId: () => false
+        };
+    }
+
+    const categories = await FinanceCategoryModel.scope('all').findAll({
+        where: { ownerId },
+        attributes: ['id', 'name', 'slug']
+    });
+
+    const slugMap = new Map();
+    const allowedIds = new Set();
+
+    categories.forEach((record) => {
+        const plain = typeof record.get === 'function' ? record.get({ plain: true }) : record;
+        const slug = normalizeCategorySlug(plain.slug || plain.name);
+        if (slug && !slugMap.has(slug)) {
+            slugMap.set(slug, plain.id);
+        }
+        if (plain.id !== undefined && plain.id !== null) {
+            allowedIds.add(Number(plain.id));
+        }
+    });
+
+    return {
+        resolveSlug: async (slug) => {
+            if (!slug) {
+                return null;
+            }
+            return slugMap.get(slug) || null;
+        },
+        isAllowedId: (id) => {
+            if (id === undefined || id === null) {
+                return true;
+            }
+            const numeric = Number(id);
+            if (!Number.isInteger(numeric)) {
+                return false;
+            }
+            return allowedIds.has(numeric);
+        }
+    };
+};
+
 const aliasMap = {
     description: ['description', 'descricao', 'descrição', 'historico', 'histórico', 'memo', 'name', 'history'],
-    type: ['type', 'tipo', 'natureza', 'categoria', 'transactiontype', 'trntype'],
+    type: ['type', 'tipo', 'natureza', 'transactiontype', 'trntype'],
+    category: ['category', 'categoria', 'financecategory'],
     value: ['value', 'valor', 'amount', 'quantia', 'montante'],
     dueDate: ['duedate', 'data', 'date', 'datavencimento', 'vencimento', 'posteddate', 'dtposted'],
     paymentDate: ['paymentdate', 'datapagamento', 'payment_date', 'data_pagamento', 'dtpayment'],
@@ -264,8 +380,10 @@ const parseCsvContent = (content) => {
                 ? normalizeDate(values[headerIndexes.paymentDate], 'data de pagamento')
                 : null;
             const typeRaw = headerIndexes.type !== undefined ? values[headerIndexes.type] : null;
+            const categoryRaw = headerIndexes.category !== undefined ? values[headerIndexes.category] : null;
             const statusRaw = headerIndexes.status !== undefined ? values[headerIndexes.status] : null;
             const type = inferType(typeRaw, numericAmount);
+            const categorySlug = normalizeCategorySlug(categoryRaw);
 
             entries.push({
                 description,
@@ -278,8 +396,11 @@ const parseCsvContent = (content) => {
                     source: 'csv',
                     line: lineIndex + 1,
                     originalType: typeRaw || null,
-                    rawAmount: amountRaw
-                }
+                    rawAmount: amountRaw,
+                    originalCategory: sanitizeDescription(categoryRaw) || null,
+                    categorySlug
+                },
+                financeCategorySlug: categorySlug || null
             });
         } catch (error) {
             warnings.push(`Linha ${lineIndex + 1}: ${error.message}`);
@@ -339,6 +460,8 @@ const parseOfxContent = (content) => {
             const descriptionRaw = extractTagValue(block, 'MEMO') || extractTagValue(block, 'NAME') || `Transação ${index + 1}`;
             const statusRaw = extractTagValue(block, 'STATUS');
             const paymentDateRaw = extractTagValue(block, 'DTAVAIL') || null;
+            const categoryRaw = extractTagValue(block, 'CATEGORY');
+            const categorySlug = normalizeCategorySlug(categoryRaw);
 
             entries.push({
                 description: sanitizeDescription(descriptionRaw),
@@ -351,8 +474,11 @@ const parseOfxContent = (content) => {
                     source: 'ofx',
                     index: index + 1,
                     originalType: typeRaw || null,
-                    rawAmount: amountRaw
-                }
+                    rawAmount: amountRaw,
+                    originalCategory: sanitizeDescription(categoryRaw) || null,
+                    categorySlug
+                },
+                financeCategorySlug: categorySlug || null
             });
         } catch (error) {
             warnings.push(`Transação ${index + 1}: ${error.message}`);
@@ -378,7 +504,7 @@ const parseFinanceFile = (buffer, { filename = '', mimetype = '' } = {}) => {
     return parseCsvContent(content);
 };
 
-const prepareEntryForPersistence = (input) => {
+const prepareEntryForPersistence = async (input, options = {}) => {
     if (!input) {
         throw new Error('Entrada inválida.');
     }
@@ -393,6 +519,32 @@ const prepareEntryForPersistence = (input) => {
     const dueDate = normalizeDate(input.dueDate, 'data de vencimento');
     const paymentDate = input.paymentDate ? normalizeDate(input.paymentDate, 'data de pagamento') : null;
     const status = normalizeStatus(input.status);
+    const categoryResolver = options.categoryResolver;
+
+    const rawCategoryId = input.financeCategoryId ?? input.categoryId ?? null;
+    const categorySlug = extractCategorySlugFromInput(input);
+
+    let financeCategoryId = null;
+
+    if (rawCategoryId !== null && rawCategoryId !== undefined) {
+        const numericId = Number(rawCategoryId);
+        if (!Number.isInteger(numericId)) {
+            throw new Error('Categoria informada é inválida.');
+        }
+        if (!categoryResolver || typeof categoryResolver.isAllowedId !== 'function' || !categoryResolver.isAllowedId(numericId)) {
+            throw new Error('Categoria informada não pertence ao usuário autenticado.');
+        }
+        financeCategoryId = numericId;
+    } else if (categorySlug) {
+        if (!categoryResolver || typeof categoryResolver.resolveSlug !== 'function') {
+            throw new Error('Categoria informada não pôde ser validada.');
+        }
+        const resolvedId = await categoryResolver.resolveSlug(categorySlug);
+        if (!resolvedId) {
+            throw new Error('Categoria informada não encontrada para o usuário autenticado.');
+        }
+        financeCategoryId = resolvedId;
+    }
 
     return {
         description,
@@ -401,6 +553,7 @@ const prepareEntryForPersistence = (input) => {
         dueDate,
         paymentDate,
         status,
+        financeCategoryId,
         hash: createEntryHash({ description, value: Math.abs(numericAmount), dueDate })
     };
 };
@@ -453,7 +606,9 @@ const buildInvalidPreviewEntry = (rawEntry, metadata, errorMessage) => {
         dueDate: normalizedDueDate,
         paymentDate: normalizedPaymentDate,
         status: normalizeStatus(rawEntry?.status),
+        financeCategoryId: null,
         metadata,
+        financeCategorySlug: metadata?.categorySlug || null,
         hash: null,
         conflict: true,
         include: false,
@@ -461,16 +616,29 @@ const buildInvalidPreviewEntry = (rawEntry, metadata, errorMessage) => {
     };
 };
 
-const buildImportPreview = async (rawEntries = []) => {
+const createFinanceCategoryResolver = async (options = {}) => buildCategoryResolver(options);
+
+const buildImportPreview = async (rawEntries = [], options = {}) => {
     const entriesArray = Array.isArray(rawEntries) ? rawEntries : [];
 
-    const previewEntries = entriesArray.map((rawEntry) => {
+    let categoryResolver = options.categoryResolver || null;
+    if (!categoryResolver) {
+        categoryResolver = await buildCategoryResolver({
+            ownerId: options.ownerId,
+            FinanceCategoryModel: options.FinanceCategoryModel || FinanceCategory
+        });
+    }
+
+    const previewEntries = await Promise.all(entriesArray.map(async (rawEntry) => {
         const metadata = cloneMetadata(rawEntry?.metadata);
+        metadata.originalCategory = metadata.originalCategory || sanitizeDescription(rawEntry?.category || rawEntry?.financeCategory || rawEntry?.financeCategorySlug) || null;
+        metadata.categorySlug = metadata.categorySlug || extractCategorySlugFromInput(rawEntry);
 
         try {
-            const prepared = prepareEntryForPersistence(rawEntry);
+            const prepared = await prepareEntryForPersistence(rawEntry, { categoryResolver });
             return {
                 ...prepared,
+                financeCategorySlug: metadata.categorySlug || null,
                 metadata,
                 conflict: false,
                 include: true,
@@ -479,7 +647,7 @@ const buildImportPreview = async (rawEntries = []) => {
         } catch (error) {
             return buildInvalidPreviewEntry(rawEntry, metadata, error.message);
         }
-    });
+    }));
 
     const validEntries = previewEntries.filter((entry) => entry.hash);
     const dueDates = [...new Set(validEntries.map((entry) => entry.dueDate).filter(Boolean))];
@@ -557,5 +725,6 @@ module.exports = {
     normalizeStatus,
     createEntryHash,
     prepareEntryForPersistence,
-    buildImportPreview
+    buildImportPreview,
+    createFinanceCategoryResolver
 };

--- a/tests/unit/financeImportService.test.js
+++ b/tests/unit/financeImportService.test.js
@@ -2,11 +2,11 @@ const financeImportService = require('../../src/services/financeImportService');
 
 describe('financeImportService', () => {
     describe('parseFinanceFile - CSV', () => {
-        it('normaliza valores, datas e metadados a partir de um CSV válido', () => {
+        it('normaliza valores, datas, categoria e metadados a partir de um CSV válido', () => {
             const csvContent = [
-                'Descrição;Valor;Data;Tipo;Status',
-                'Conta de Luz;-150,30;10/01/2024;Despesa;pending',
-                'Mensalidade Academia;2500;2024-01-15;Receita;paid'
+                'Descrição;Valor;Data;Tipo;Status;Categoria',
+                'Conta de Luz;-150,30;10/01/2024;Despesa;pending;Despesas Fixas',
+                'Mensalidade Academia;2500;2024-01-15;Receita;paid;Receitas Diversas'
             ].join('\n');
 
             const buffer = Buffer.from(csvContent, 'utf8');
@@ -26,10 +26,13 @@ describe('financeImportService', () => {
                 value: 150.3,
                 dueDate: '2024-01-10',
                 status: 'pending',
+                financeCategorySlug: 'despesas-fixas',
                 metadata: expect.objectContaining({
                     source: 'csv',
                     line: 2,
-                    originalType: 'Despesa'
+                    originalType: 'Despesa',
+                    originalCategory: 'Despesas Fixas',
+                    categorySlug: 'despesas-fixas'
                 })
             });
 
@@ -39,10 +42,13 @@ describe('financeImportService', () => {
                 value: 2500,
                 dueDate: '2024-01-15',
                 status: 'paid',
+                financeCategorySlug: 'receitas-diversas',
                 metadata: expect.objectContaining({
                     source: 'csv',
                     line: 3,
-                    originalType: 'Receita'
+                    originalType: 'Receita',
+                    originalCategory: 'Receitas Diversas',
+                    categorySlug: 'receitas-diversas'
                 })
             });
         });
@@ -58,12 +64,14 @@ describe('financeImportService', () => {
             <DTPOSTED>20240105120000[-03:EST]
             <TRNAMT>-89.45
             <MEMO>Supermercado Central
+            <CATEGORY>Alimentação
         </STMTTRN>
         <STMTTRN>
             <TRNTYPE>CREDIT
             <DTPOSTED>20240106
             <TRNAMT>1500.00
             <NAME>Pagamento Projeto
+            <CATEGORY>Receitas
         </STMTTRN>
     </BANKTRANLIST>
 </OFX>
@@ -82,27 +90,43 @@ describe('financeImportService', () => {
                 description: 'Supermercado Central',
                 type: 'payable',
                 value: 89.45,
-                dueDate: '2024-01-05'
+                dueDate: '2024-01-05',
+                financeCategorySlug: 'alimentacao',
+                metadata: expect.objectContaining({
+                    originalCategory: 'Alimentação',
+                    categorySlug: 'alimentacao'
+                })
             });
 
             expect(creditEntry).toMatchObject({
                 description: 'Pagamento Projeto',
                 type: 'receivable',
                 value: 1500,
-                dueDate: '2024-01-06'
+                dueDate: '2024-01-06',
+                financeCategorySlug: 'receitas',
+                metadata: expect.objectContaining({
+                    originalCategory: 'Receitas',
+                    categorySlug: 'receitas'
+                })
             });
         });
     });
 
     describe('prepareEntryForPersistence', () => {
-        it('padroniza descrição, valores, datas e hash de um lançamento', () => {
-            const prepared = financeImportService.prepareEntryForPersistence({
+        it('padroniza descrição, valores, datas, categoria e hash de um lançamento', async () => {
+            const resolver = {
+                resolveSlug: async () => 42,
+                isAllowedId: () => true
+            };
+
+            const prepared = await financeImportService.prepareEntryForPersistence({
                 description: '  Serviço de Consultoria  ',
                 value: '1.234,56',
                 dueDate: '12/02/2024',
                 status: 'paid',
-                type: 'receita'
-            });
+                type: 'receita',
+                financeCategorySlug: 'consultoria'
+            }, { categoryResolver: resolver });
 
             expect(prepared).toMatchObject({
                 description: 'Serviço de Consultoria',
@@ -110,11 +134,29 @@ describe('financeImportService', () => {
                 value: 1234.56,
                 dueDate: '2024-02-12',
                 status: 'paid',
-                paymentDate: null
+                paymentDate: null,
+                financeCategoryId: 42
             });
 
             expect(typeof prepared.hash).toBe('string');
             expect(prepared.hash).toHaveLength(64);
+        });
+
+        it('rejeita categoria que não pertence ao usuário autenticado', async () => {
+            const resolver = {
+                resolveSlug: async () => null,
+                isAllowedId: () => false
+            };
+
+            await expect(
+                financeImportService.prepareEntryForPersistence({
+                    description: 'Conta de Luz',
+                    value: '250,00',
+                    dueDate: '2024-01-10',
+                    type: 'despesa',
+                    financeCategorySlug: 'categoria-invalida'
+                }, { categoryResolver: resolver })
+            ).rejects.toThrow('Categoria informada não encontrada para o usuário autenticado.');
         });
     });
 


### PR DESCRIPTION
## Summary
- normalize imported finance categories and resolve them to user-owned FinanceCategory records while rejecting invalid mappings
- load the authenticated user context during finance import preview/commit to supply the category resolver and persist financeCategoryId
- extend finance import unit tests to cover category extraction and validation scenarios

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68ca8766d994832fa082532ebaaf3549