### PR TITLE
Ajusta normalização de limiares de orçamento

### DIFF
--- a/database/migrations/20240917-create-budgets.js
+++ b/database/migrations/20240917-create-budgets.js
@@ -35,7 +35,8 @@ module.exports = {
             thresholds: {
                 type: Sequelize.JSON,
                 allowNull: false,
-                defaultValue: []
+                defaultValue: [],
+                comment: 'Limiares de alerta normalizados entre 0 e 1 (com duas casas decimais).'
             },
             referenceMonth: {
                 type: Sequelize.DATEONLY,

--- a/database/models/budget.js
+++ b/database/models/budget.js
@@ -32,31 +32,37 @@ const normalizeMonthValue = (value) => {
     return normalized.toISOString().slice(0, 10);
 };
 
+const THRESHOLD_RANGE_ERROR = 'Limiares devem ser números entre 0 e 1, com até duas casas decimais.';
+
 const normalizeThresholds = (value) => {
     if (value === undefined || value === null) {
         return [];
     }
 
     const rawList = Array.isArray(value) ? value : [value];
-    const normalized = rawList
-        .map((item) => {
-            if (item === undefined || item === null || item === '') {
-                return null;
-            }
+    if (rawList.length === 0) {
+        return [];
+    }
 
-            const numeric = Number(item);
-            if (!Number.isFinite(numeric)) {
-                return null;
-            }
+    return rawList.map((item) => {
+        if (item === undefined || item === null || item === '') {
+            throw new Error(THRESHOLD_RANGE_ERROR);
+        }
 
-            return Number(numeric.toFixed(2));
-        })
-        .filter((item) => item !== null && item > 0);
+        const numeric = Number(item);
+        if (!Number.isFinite(numeric)) {
+            throw new Error(THRESHOLD_RANGE_ERROR);
+        }
 
-    const uniqueValues = Array.from(new Set(normalized));
-    uniqueValues.sort((a, b) => a - b);
+        const rounded = Math.round(numeric * 100) / 100;
+        const normalized = Number(rounded.toFixed(2));
 
-    return uniqueValues;
+        if (normalized <= 0 || normalized > 1) {
+            throw new Error(THRESHOLD_RANGE_ERROR);
+        }
+
+        return normalized;
+    });
 };
 
 module.exports = (sequelize, DataTypes) => {
@@ -87,8 +93,14 @@ module.exports = (sequelize, DataTypes) => {
             validate: {
                 isArrayOfPositiveNumbers(value) {
                     const list = normalizeThresholds(value);
-                    if (list.some((item) => item <= 0)) {
-                        throw new Error('Limiares devem ser maiores que zero.');
+                    if (list.some((item) => item <= 0 || item > 1)) {
+                        throw new Error(THRESHOLD_RANGE_ERROR);
+                    }
+
+                    for (let index = 1; index < list.length; index += 1) {
+                        if (list[index] <= list[index - 1]) {
+                            throw new Error('Limiares devem estar em ordem crescente e sem duplicidades.');
+                        }
                     }
                 }
             }

--- a/src/services/__tests__/budgetModel.test.js
+++ b/src/services/__tests__/budgetModel.test.js
@@ -1,0 +1,40 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const models = require('../../../database/models');
+
+const { Budget } = models;
+
+const buildBudgetPayload = (overrides = {}) => ({
+    monthlyLimit: 1000,
+    thresholds: [0.25, 0.5, 0.75],
+    referenceMonth: '2024-09-01',
+    userId: 1,
+    financeCategoryId: 1,
+    ...overrides
+});
+
+test('normalizeThresholds arredonda e valida intervalo permitido', () => {
+    const normalized = Budget.normalizeThresholds([0.123, '0.456', 1]);
+    assert.deepEqual(normalized, [0.12, 0.46, 1]);
+});
+
+test('normalizeThresholds rejeita valores fora do intervalo 0-1', () => {
+    assert.throws(() => Budget.normalizeThresholds([0, 1.2]), /0 e 1/);
+    assert.throws(() => Budget.normalizeThresholds(['abc']), /números entre 0 e 1/);
+});
+
+test('Budget valida ordenação crescente e ausência de duplicidades', async () => {
+    const budget = Budget.build(buildBudgetPayload({ thresholds: [0.25, 0.5, 0.75] }));
+    await assert.doesNotReject(() => budget.validate());
+
+    const unordered = Budget.build(buildBudgetPayload({ thresholds: [0.5, 0.25] }));
+    await assert.rejects(() => unordered.validate(), /ordem crescente/);
+
+    const duplicated = Budget.build(buildBudgetPayload({ thresholds: [0.3, 0.3] }));
+    await assert.rejects(() => duplicated.validate(), /duplicidades/);
+});


### PR DESCRIPTION
## Summary
- reforça a normalização de limiares de orçamento garantindo arredondamento, faixa entre 0 e 1 e erros claros para entradas inválidas
- endurece a validação do modelo para impedir limiares fora da faixa, duplicados ou fora de ordem
- documenta a coluna thresholds na migration inicial e adiciona testes unitários cobrindo normalização e validações

## Testing
- npm test *(falha conhecida: scripts/health-check.js encerra por redefinição duplicada em financeController.js)*
- node --test src/services/__tests__/budgetModel.test.js


------
https://chatgpt.com/codex/tasks/task_e_68ca8844ec74832fb955bd1d801b02f6