### PR TITLE
feat: add finance budget endpoints with validation

### DIFF
--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -59,6 +59,25 @@ router.post(
     financeController.saveFinanceGoal
 );
 
+router.post(
+    '/budgets',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    audit('financeBudget.create', (req) => {
+        const categoryId = req.body?.financeCategoryId || 'unknown';
+        return `FinanceBudget:create:${categoryId}`;
+    }),
+    financeController.createBudget
+);
+
+router.put(
+    '/budgets/:id',
+    authMiddleware,
+    permissionMiddleware(USER_ROLES.ADMIN),
+    audit('financeBudget.update', (req) => `FinanceBudget:update:${req.params.id}`),
+    financeController.updateBudget
+);
+
 router.delete(
     '/goals/:id',
     authMiddleware,

--- a/src/services/financeBudgetService.js
+++ b/src/services/financeBudgetService.js
@@ -1,0 +1,107 @@
+const { UniqueConstraintError, ValidationError } = require('sequelize');
+const { Budget } = require('../../database/models');
+const { validateThresholdList, BUDGET_THRESHOLD_ERROR } = require('../utils/financeBudgetUtils');
+
+const buildBudgetPayload = ({
+    userId,
+    financeCategoryId,
+    monthlyLimit,
+    thresholds,
+    referenceMonth
+}) => ({
+    userId,
+    financeCategoryId,
+    monthlyLimit,
+    thresholds,
+    referenceMonth: referenceMonth || null
+});
+
+const createBudget = async (data = {}) => {
+    const normalizedThresholds = validateThresholdList(data.thresholds);
+    const payload = buildBudgetPayload({ ...data, thresholds: normalizedThresholds });
+
+    try {
+        const budget = await Budget.create(payload);
+        return budget;
+    } catch (error) {
+        if (error instanceof UniqueConstraintError) {
+            const conflictError = new Error('Já existe um orçamento configurado para esta categoria.');
+            conflictError.statusCode = 400;
+            conflictError.name = error.name;
+            throw conflictError;
+        }
+
+        if (error instanceof ValidationError) {
+            const validationMessage = error.errors?.[0]?.message || 'Dados inválidos para criação do orçamento.';
+            const validationError = new Error(validationMessage);
+            validationError.statusCode = 400;
+            validationError.name = error.name;
+            throw validationError;
+        }
+
+        throw error;
+    }
+};
+
+const updateBudget = async (budgetId, userId, data = {}) => {
+    const budget = await Budget.findByPk(budgetId);
+    if (!budget) {
+        return null;
+    }
+
+    if (budget.userId !== userId) {
+        const forbiddenError = new Error('Orçamento não pertence ao usuário autenticado.');
+        forbiddenError.statusCode = 403;
+        throw forbiddenError;
+    }
+
+    const updates = {};
+
+    if (data.financeCategoryId !== undefined) {
+        updates.financeCategoryId = data.financeCategoryId;
+    }
+
+    if (data.monthlyLimit !== undefined) {
+        updates.monthlyLimit = data.monthlyLimit;
+    }
+
+    if (data.referenceMonth !== undefined) {
+        updates.referenceMonth = data.referenceMonth || null;
+    }
+
+    if (data.thresholds !== undefined) {
+        updates.thresholds = validateThresholdList(data.thresholds);
+    }
+
+    try {
+        Object.assign(budget, updates);
+        await budget.save();
+        return budget;
+    } catch (error) {
+        if (error instanceof UniqueConstraintError) {
+            const conflictError = new Error('Já existe um orçamento configurado para esta categoria.');
+            conflictError.statusCode = 400;
+            conflictError.name = error.name;
+            throw conflictError;
+        }
+
+        if (error instanceof ValidationError) {
+            const validationMessage = error.errors?.[0]?.message || 'Dados inválidos para atualização do orçamento.';
+            const validationError = new Error(validationMessage);
+            validationError.statusCode = 400;
+            validationError.name = error.name;
+            throw validationError;
+        }
+
+        if (error.name === BUDGET_THRESHOLD_ERROR || error.statusCode === 400) {
+            throw error;
+        }
+
+        throw error;
+    }
+};
+
+module.exports = {
+    createBudget,
+    updateBudget
+};

--- a/src/utils/financeBudgetUtils.js
+++ b/src/utils/financeBudgetUtils.js
@@ -1,0 +1,68 @@
+const { Budget } = require('../../database/models');
+
+const BUDGET_THRESHOLD_ERROR = 'BudgetThresholdValidationError';
+
+const coerceThresholdInput = (value) => {
+    if (Array.isArray(value)) {
+        return value;
+    }
+
+    if (value === undefined || value === null) {
+        return [];
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return [];
+        }
+
+        try {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) {
+                return parsed;
+            }
+        } catch (error) {
+            // Ignore JSON parse errors and fallback to splitting by separators
+        }
+
+        return trimmed
+            .split(/[;,\s]+/)
+            .map((item) => item.trim())
+            .filter((item) => item.length);
+    }
+
+    return [value];
+};
+
+const buildValidationError = (message) => {
+    const error = new Error(message);
+    error.name = BUDGET_THRESHOLD_ERROR;
+    error.statusCode = 400;
+    return error;
+};
+
+const validateThresholdList = (value) => {
+    const coalesced = coerceThresholdInput(value);
+    const normalizer = Budget && typeof Budget.normalizeThresholds === 'function'
+        ? Budget.normalizeThresholds.bind(Budget)
+        : (list) => (Array.isArray(list) ? list : []);
+
+    const normalized = normalizer(coalesced);
+
+    if (!Array.isArray(normalized) || normalized.length === 0) {
+        throw buildValidationError('Informe ao menos um limite de alerta entre 0 e 1.');
+    }
+
+    const outOfRange = normalized.find((item) => item <= 0 || item >= 1);
+    if (outOfRange !== undefined) {
+        throw buildValidationError('Cada limite de alerta deve estar entre 0 e 1.');
+    }
+
+    return normalized;
+};
+
+module.exports = {
+    validateThresholdList,
+    BUDGET_THRESHOLD_ERROR
+};

--- a/tests/integration/financeController.budgets.test.js
+++ b/tests/integration/financeController.budgets.test.js
@@ -1,0 +1,168 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const express = require('express');
+const session = require('express-session');
+const flash = require('connect-flash');
+const request = require('supertest');
+
+jest.mock('../../src/middlewares/authMiddleware', () => jest.fn((req, res, next) => {
+    req.session = req.session || {};
+    const user = global.__TEST_FINANCE_USER__ || { id: 1, role: 'admin', active: true };
+    req.user = user;
+    req.session.user = user;
+    next();
+}));
+
+jest.mock('../../src/middlewares/permissionMiddleware', () => () => (req, res, next) => next());
+
+jest.mock('../../src/middlewares/audit', () => () => (req, res, next) => next());
+
+const financeRoutes = require('../../src/routes/financeRoutes');
+const { sequelize, User, FinanceCategory, Budget } = require('../../database/models');
+const { USER_ROLES } = require('../../src/constants/roles');
+
+const buildApp = () => {
+    const app = express();
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+    app.use(session({
+        secret: 'finance-budgets-secret',
+        resave: false,
+        saveUninitialized: false
+    }));
+    app.use(flash());
+    app.use('/finance', financeRoutes);
+    return app;
+};
+
+describe('FinanceController budgets endpoints', () => {
+    let app;
+    let user;
+    let category;
+
+    beforeEach(async () => {
+        await sequelize.sync({ force: true });
+        const uniqueSuffix = Date.now();
+        user = await User.create({
+            name: 'Admin Budget',
+            email: `admin-budget-${uniqueSuffix}@example.com`,
+            password: 'SenhaSegura123',
+            role: USER_ROLES.ADMIN,
+            active: true
+        });
+
+        category = await FinanceCategory.scope('all').create({
+            name: 'Marketing Digital',
+            slug: `marketing-${uniqueSuffix}`,
+            color: '#2563eb',
+            ownerId: user.id
+        });
+
+        global.__TEST_FINANCE_USER__ = { id: user.id, role: USER_ROLES.ADMIN, active: true };
+        app = buildApp();
+    });
+
+    afterEach(() => {
+        global.__TEST_FINANCE_USER__ = null;
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    it('cria um orçamento financeiro com thresholds válidos', async () => {
+        const response = await request(app)
+            .post('/finance/budgets')
+            .send({
+                financeCategoryId: category.id,
+                monthlyLimit: '1250.55',
+                thresholds: [0.5, 0.75, 0.9],
+                referenceMonth: '2024-09-01'
+            });
+
+        expect(response.status).toBe(201);
+        expect(response.body).toMatchObject({
+            financeCategoryId: category.id,
+            monthlyLimit: 1250.55,
+            referenceMonth: '2024-09-01'
+        });
+        expect(response.body.thresholds).toEqual([0.5, 0.75, 0.9]);
+
+        const budget = await Budget.findOne({ where: { userId: user.id, financeCategoryId: category.id } });
+        expect(budget).toBeTruthy();
+        expect(Number(budget.monthlyLimit)).toBeCloseTo(1250.55);
+        expect(budget.thresholds).toEqual([0.5, 0.75, 0.9]);
+    });
+
+    it('retorna 400 quando a lista de thresholds está vazia', async () => {
+        const response = await request(app)
+            .post('/finance/budgets')
+            .send({
+                financeCategoryId: category.id,
+                monthlyLimit: '800.00',
+                thresholds: []
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ message: 'Informe ao menos um limite de alerta entre 0 e 1.' });
+    });
+
+    it('retorna 400 quando algum threshold está fora do intervalo permitido', async () => {
+        const response = await request(app)
+            .post('/finance/budgets')
+            .send({
+                financeCategoryId: category.id,
+                monthlyLimit: '900.00',
+                thresholds: [0.5, 1.2]
+            });
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ message: 'Cada limite de alerta deve estar entre 0 e 1.' });
+    });
+
+    it('atualiza um orçamento existente com dados válidos', async () => {
+        const initialBudget = await Budget.create({
+            userId: user.id,
+            financeCategoryId: category.id,
+            monthlyLimit: 950.0,
+            thresholds: [0.5],
+            referenceMonth: '2024-08-01'
+        });
+
+        const response = await request(app)
+            .put(`/finance/budgets/${initialBudget.id}`)
+            .send({
+                monthlyLimit: '1800.10',
+                thresholds: [0.6, 0.85],
+                referenceMonth: '2024-10-01'
+            });
+
+        expect(response.status).toBe(200);
+        expect(response.body.thresholds).toEqual([0.6, 0.85]);
+        expect(response.body.monthlyLimit).toBe(1800.1);
+        expect(response.body.referenceMonth).toBe('2024-10-01');
+
+        await initialBudget.reload();
+        expect(Number(initialBudget.monthlyLimit)).toBeCloseTo(1800.1);
+        expect(initialBudget.thresholds).toEqual([0.6, 0.85]);
+        expect(initialBudget.referenceMonth).toBe('2024-10-01');
+    });
+
+    it('retorna 400 ao tentar atualizar com thresholds inválidos', async () => {
+        const initialBudget = await Budget.create({
+            userId: user.id,
+            financeCategoryId: category.id,
+            monthlyLimit: 600.0,
+            thresholds: [0.5]
+        });
+
+        const response = await request(app)
+            .put(`/finance/budgets/${initialBudget.id}`)
+            .send({ thresholds: [0.4, 1.5] });
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ message: 'Cada limite de alerta deve estar entre 0 e 1.' });
+    });
+});


### PR DESCRIPTION
## Summary
- add authenticated finance budget creation and update endpoints with audit logging
- share a threshold validation helper between controller and finance budget service using Budget.normalizeThresholds
- cover valid and invalid budget scenarios with new integration tests

## Testing
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68ca88459f64832f8033afa8aecf61d2