### PR TITLE
Refactor budget alert service import in notifications

### DIFF
--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -14,7 +14,8 @@ const { sendEmail } = require('../utils/email');
 const { buildEmailContent, buildRoleLabel } = require('../utils/placeholderUtils');
 const { parseRole, sortRolesByHierarchy, USER_ROLES } = require('../constants/roles');
 const { Op } = require('sequelize');
-const { processBudgetAlerts } = require('./budgetAlertService');
+const budgetAlertService = require('./budgetAlertService');
+const { processBudgetAlerts } = budgetAlertService;
 const ORGANIZATION_NAME = process.env.APP_NAME || 'Sistema de Gestão';
 const DEFAULT_APPOINTMENT_WINDOW_MINUTES = 60;
 


### PR DESCRIPTION
## Summary
- import the full budgetAlertService module in the notification service
- expose processBudgetAlerts from the imported module while keeping collectBudgetAlerts usage unchanged

## Testing
- npm run test:unit *(fails: existing syntax and mock issues in unrelated finance and notification tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9bd20adc832fba811ec026b6761f