### PR TITLE
fix: ensure notification service uses shared logger

### DIFF
--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -10,6 +10,7 @@ const {
     sequelize
 } = require('../../database/models');
 const crypto = require('node:crypto');
+const logger = require('../utils/logger');
 const { sendEmail } = require('../utils/email');
 const { buildEmailContent, buildRoleLabel } = require('../utils/placeholderUtils');
 const { parseRole, sortRolesByHierarchy, USER_ROLES } = require('../constants/roles');


### PR DESCRIPTION
## Summary
- import the shared logger into the notification service so its logging helpers reference the correct instance

## Testing
- npm run test:unit *(fails: existing syntax and mock scope issues in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9bd38304832f8f1f8ae873cf0b2f