### PR TITLE
Fix finance import category normalization conflict

### DIFF
--- a/src/services/financeImportService.js
+++ b/src/services/financeImportService.js
@@ -564,11 +564,12 @@ const prepareEntryForPersistence = async (input, options = {}) => {
         financeCategoryId = resolvedId;
     }
 
-    const financeCategoryId = normalizeCategoryId(
+    const normalizedFallbackCategoryId = normalizeCategoryId(
         input.financeCategoryId
             ?? input.categoryId
             ?? input.category?.id
     );
+    const resolvedFinanceCategoryId = financeCategoryId ?? normalizedFallbackCategoryId;
     const categoryName = sanitizeCategoryName(
         input.categoryName
             ?? input.category?.name
@@ -582,7 +583,7 @@ const prepareEntryForPersistence = async (input, options = {}) => {
         dueDate,
         paymentDate,
         status,
-        financeCategoryId,
+        financeCategoryId: resolvedFinanceCategoryId,
         categoryName,
         hash: createEntryHash({ description, value: Math.abs(numericAmount), dueDate })
     };


### PR DESCRIPTION
## Summary
- reuse the previously resolved finance category id and only fall back to normalized inputs
- return the resolved finance category id to avoid duplicate declarations that broke the import service

## Testing
- `npm run test` *(fails: existing budget service, finance controller and notification worker unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9ec5b2e8832fb3289dc8ca816509