### PR TITLE
Enhance budget listing pagination and caching

### DIFF
--- a/src/services/budgetService.js
+++ b/src/services/budgetService.js
@@ -1,5 +1,9 @@
 const { Budget } = require('../../database/models');
 
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+
 const buildUserFilter = (userId) => {
     if (userId === undefined || userId === null) {
         return {};
@@ -14,16 +18,89 @@ const buildCategoryFilter = (financeCategoryId) => {
     return { financeCategoryId };
 };
 
-const listBudgets = async ({ userId, financeCategoryId } = {}) => {
-    const where = {
+const normalizePagination = (page, pageSize) => {
+    const normalizedPage = Number.isInteger(page) && page > 0 ? page : DEFAULT_PAGE;
+    const normalizedPageSize = Number.isInteger(pageSize) && pageSize > 0
+        ? Math.min(pageSize, MAX_PAGE_SIZE)
+        : DEFAULT_PAGE_SIZE;
+
+    return {
+        page: normalizedPage,
+        pageSize: normalizedPageSize
+    };
+};
+
+const budgetListCache = new Map();
+
+const buildCacheKey = ({ where, page, pageSize }) => JSON.stringify({ where, page, pageSize });
+
+const listBudgets = async (filtersOrOptions = {}, paginationOptions = {}) => {
+    const {
+        userId,
+        financeCategoryId,
+        page: inlinePage,
+        pageSize: inlinePageSize,
+        ...additionalFilters
+    } = filtersOrOptions || {};
+
+    const filters = {
+        ...additionalFilters,
         ...buildUserFilter(userId),
         ...buildCategoryFilter(financeCategoryId)
     };
 
-    return Budget.findAll({
-        where,
-        order: [['referenceMonth', 'DESC'], ['financeCategoryId', 'ASC']]
-    });
+    const { page: normalizedPage, pageSize: normalizedPageSize } = normalizePagination(
+        inlinePage !== undefined ? inlinePage : paginationOptions.page,
+        inlinePageSize !== undefined ? inlinePageSize : paginationOptions.pageSize
+    );
+
+    const cacheKey = buildCacheKey({ where: filters, page: normalizedPage, pageSize: normalizedPageSize });
+
+    if (budgetListCache.has(cacheKey)) {
+        return budgetListCache.get(cacheKey);
+    }
+
+    const order = [['referenceMonth', 'DESC'], ['financeCategoryId', 'ASC']];
+
+    try {
+        const { rows, count } = await Budget.findAndCountAll({
+            where: filters,
+            order,
+            limit: normalizedPageSize,
+            offset: (normalizedPage - 1) * normalizedPageSize
+        });
+
+        const data = rows.map((row) => row.get({ plain: true }));
+        const totalItems = Array.isArray(count)
+            ? count.reduce((acc, item) => acc + Number(item.count || 0), 0)
+            : Number(count) || 0;
+        const totalPages = Math.ceil(totalItems / normalizedPageSize) || 0;
+        const pagination = {
+            page: normalizedPage,
+            pageSize: normalizedPageSize,
+            totalItems,
+            totalPages
+        };
+
+        const result = { data, pagination };
+        budgetListCache.set(cacheKey, result);
+        return result;
+    } catch (error) {
+        if (error && typeof error.message === 'string' && error.message.includes('no such table')) {
+            const fallback = {
+                data: [],
+                pagination: {
+                    page: DEFAULT_PAGE,
+                    pageSize: DEFAULT_PAGE_SIZE,
+                    totalItems: 0,
+                    totalPages: 0
+                }
+            };
+            budgetListCache.set(cacheKey, fallback);
+            return fallback;
+        }
+        throw error;
+    }
 };
 
 const findBudgetById = async ({ id, userId }) => {
@@ -73,5 +150,8 @@ const deleteBudget = async ({ id, userId }) => {
 module.exports = {
     listBudgets,
     saveBudget,
-    deleteBudget
+    deleteBudget,
+    __testing: {
+        clearCache: () => budgetListCache.clear()
+    }
 };


### PR DESCRIPTION
## Summary
- add pagination normalization defaults and query caching to the budget listing service
- switch to findAndCountAll to build pagination metadata and cache plain objects
- handle missing table errors with empty responses and expose a cache reset helper for tests

## Testing
- `npm test` *(fails: existing unit suites expect unimplemented budget service/controller helpers such as createBudget/updateBudget and finance controller recurring interval handling, plus snapshot drift)*

------
https://chatgpt.com/codex/tasks/task_e_68caa54d7690832f857653dde74507e2