### PR TITLE
Fix finance category handling on entry create/update

### DIFF
--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -1079,8 +1079,7 @@ module.exports = {
                 dueDate,
                 financeCategoryId,
                 recurring: (recurring === 'true'),
-                recurringInterval: normalizeRecurringInterval(recurringInterval),
-                financeCategoryId: finalCategoryId
+                recurringInterval: normalizeRecurringInterval(recurringInterval)
             };
 
             let entry;
@@ -1161,7 +1160,6 @@ module.exports = {
             entry.financeCategoryId = financeCategoryId;
             entry.recurring = (recurring === 'true');
             entry.recurringInterval = normalizeRecurringInterval(recurringInterval);
-            entry.financeCategoryId = finalCategoryId;
 
             if (transaction) {
                 await entry.save({ transaction });


### PR DESCRIPTION
## Summary
- keep the normalized finance category id when creating entries instead of overwriting it
- avoid reassigning the finance category during updates so the normalized value is preserved

## Testing
- npm run test:unit -- --runTestsByPath tests/unit/controllers/financeController.test.js

------
https://chatgpt.com/codex/tasks/task_e_68caabd01dac832fa576c0f2340239a6