### PR TITLE
Fix budget overview loading in finance list

### DIFF
--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -747,21 +747,28 @@ module.exports = {
                 }
             })();
 
-            const [entries, summary, goals, categories] = await Promise.all([
+            const [entries, summary, goals, categories, budgetOverview] = await Promise.all([
                 entriesPromise,
                 summaryPromise,
                 goalsPromise,
-                categoriesPromise
+                categoriesPromise,
+                budgetOverviewPromise
             ]);
 
-            const rawBudgetSummaries = Array.isArray(budgetOverview?.summaries)
-                ? budgetOverview.summaries
+            const normalizedBudgetOverview = (
+                budgetOverview && typeof budgetOverview === 'object'
+                    ? budgetOverview
+                    : {}
+            );
+
+            const rawBudgetSummaries = Array.isArray(normalizedBudgetOverview?.summaries)
+                ? normalizedBudgetOverview.summaries
                 : [];
-            const categoryConsumption = Array.isArray(budgetOverview?.categoryConsumption)
-                ? budgetOverview.categoryConsumption
+            const categoryConsumption = Array.isArray(normalizedBudgetOverview?.categoryConsumption)
+                ? normalizedBudgetOverview.categoryConsumption
                 : [];
-            const budgetMonths = Array.isArray(budgetOverview?.months)
-                ? budgetOverview.months
+            const budgetMonths = Array.isArray(normalizedBudgetOverview?.months)
+                ? normalizedBudgetOverview.months
                 : [];
 
             const statusPalette = buildStatusPalette();


### PR DESCRIPTION
## Summary
- include the budget overview request in the listFinanceEntries Promise.all aggregation
- guard budget overview dependent calculations against undefined results

## Testing
- npm run test:integration -- tests/integration/routes.smoke.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cab1a39a30832f83a64836ad19f3c3