### PR TITLE
Allow positive budget thresholds

### DIFF
--- a/database/models/budget.js
+++ b/database/models/budget.js
@@ -51,7 +51,7 @@ const normalizeMonthValue = (value) => {
     return normalized.toISOString().slice(0, 10);
 };
 
-const THRESHOLD_RANGE_ERROR = 'Limiares devem ser números entre 0 e 1, com até duas casas decimais.';
+const THRESHOLD_RANGE_ERROR = 'Limiares devem ser números maiores que zero, com até duas casas decimais.';
 
 /**
  * Normaliza a lista de limiares (thresholds).
@@ -71,10 +71,10 @@ const normalizeThresholds = (value) => {
             const numeric = Number.parseFloat(
                 typeof item === 'string' ? item.replace(',', '.') : item
             );
-            if (!Number.isFinite(numeric) || numeric <= 0 || numeric > 1) {
+            if (!Number.isFinite(numeric) || numeric <= 0) {
                 return null;
             }
-            return Number(numeric.toFixed(4));
+            return Number(numeric.toFixed(2));
         })
         .filter((item) => item !== null);
 
@@ -82,7 +82,7 @@ const normalizeThresholds = (value) => {
         return getConfiguredThresholdDefaults();
     }
 
-    if (normalized.some((n) => n <= 0 || n > 1)) {
+    if (normalized.some((n) => n <= 0)) {
         throw new Error(THRESHOLD_RANGE_ERROR);
     }
 
@@ -130,9 +130,9 @@ module.exports = (sequelize, DataTypes) => {
                 validate: {
                     isArrayOfPositiveNumbers(value) {
                         const list = normalizeThresholds(value);
-                        if (list.some((item) => item <= 0 || item > 1)) {
+                        if (list.some((item) => item <= 0)) {
                             throw new Error(
-                                'Percentuais de alerta devem estar entre 0 e 1 (ex.: 0.75).'
+                                'Limites de alerta devem ser números maiores que zero.'
                             );
                         }
                     },

--- a/src/controllers/budgetController.js
+++ b/src/controllers/budgetController.js
@@ -28,8 +28,8 @@ const parsePositiveNumber = (value, errorMessage) => {
 };
 
 const parseThresholds = (value) => {
-    const emptyThresholdsMessage = 'Informe ao menos um limite de alerta entre 0 e 1.';
-    const invalidThresholdMessage = 'Cada limite de alerta deve estar entre 0 e 1.';
+    const emptyThresholdsMessage = 'Informe ao menos um limite de alerta maior que zero.';
+    const invalidThresholdMessage = 'Cada limite de alerta deve ser um número maior que zero.';
 
     if (value === undefined || value === null || value === '') {
         throw new ValidationError(emptyThresholdsMessage);
@@ -47,12 +47,7 @@ const parseThresholds = (value) => {
                 return null;
             }
 
-            const numeric = Number(stringItem);
-            if (!Number.isFinite(numeric) || numeric <= 0 || numeric > 1) {
-                throw new ValidationError(invalidThresholdMessage);
-            }
-
-            return Number(numeric.toFixed(2));
+            return parsePositiveNumber(stringItem, invalidThresholdMessage);
         })
         .filter((item) => item !== null);
 

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -116,13 +116,13 @@ const ensureValidBudgetThresholds = (req, { required } = {}) => {
     const numeric = list
         .map((item) => {
             const value = Number.parseFloat(item);
-            return Number.isFinite(value) ? Number(value.toFixed(4)) : null;
+            return Number.isFinite(value) ? Number(value.toFixed(2)) : null;
         })
         .filter((item) => item !== null);
 
     if (!numeric.length) {
         if (required || (req.body && Object.prototype.hasOwnProperty.call(req.body, 'thresholds'))) {
-            const error = new Error('Informe ao menos um limite de alerta entre 0 e 1.');
+            const error = new Error('Informe ao menos um limite de alerta maior que zero.');
             error.__budgetValidation = true;
             error.statusCode = 400;
             throw error;
@@ -130,9 +130,9 @@ const ensureValidBudgetThresholds = (req, { required } = {}) => {
         return;
     }
 
-    const invalid = numeric.find((value) => value <= 0 || value >= 1);
+    const invalid = numeric.find((value) => value <= 0);
     if (invalid !== undefined) {
-        const error = new Error('Cada limite de alerta deve estar entre 0 e 1.');
+        const error = new Error('Cada limite de alerta deve ser um número maior que zero.');
         error.__budgetValidation = true;
         error.statusCode = 400;
         throw error;

--- a/src/services/__tests__/budgetModel.test.js
+++ b/src/services/__tests__/budgetModel.test.js
@@ -18,14 +18,14 @@ const buildBudgetPayload = (overrides = {}) => ({
     ...overrides
 });
 
-test('normalizeThresholds arredonda e valida intervalo permitido', () => {
-    const normalized = Budget.normalizeThresholds([0.123, '0.456', 1]);
-    assert.deepEqual(normalized, [0.12, 0.46, 1]);
+test('normalizeThresholds arredonda valores positivos e mantém absolutos', () => {
+    const normalized = Budget.normalizeThresholds([0.123, '0.456', 1, 2500.789]);
+    assert.deepEqual(normalized, [0.12, 0.46, 1, 2500.79]);
 });
 
-test('normalizeThresholds rejeita valores fora do intervalo 0-1', () => {
-    assert.throws(() => Budget.normalizeThresholds([0, 1.2]), /0 e 1/);
-    assert.throws(() => Budget.normalizeThresholds(['abc']), /números entre 0 e 1/);
+test('normalizeThresholds usa padrões quando não há valores positivos', () => {
+    const normalized = Budget.normalizeThresholds(['abc', 0, -1]);
+    assert.deepEqual(normalized, Budget.getThresholdDefaults());
 });
 
 test('Budget valida ordenação crescente e ausência de duplicidades', async () => {

--- a/src/utils/financeBudgetUtils.js
+++ b/src/utils/financeBudgetUtils.js
@@ -51,12 +51,12 @@ const validateThresholdList = (value) => {
     const normalized = normalizer(coalesced);
 
     if (!Array.isArray(normalized) || normalized.length === 0) {
-        throw buildValidationError('Informe ao menos um limite de alerta entre 0 e 1.');
+        throw buildValidationError('Informe ao menos um limite de alerta maior que zero.');
     }
 
-    const outOfRange = normalized.find((item) => item <= 0 || item >= 1);
+    const outOfRange = normalized.find((item) => item <= 0);
     if (outOfRange !== undefined) {
-        throw buildValidationError('Cada limite de alerta deve estar entre 0 e 1.');
+        throw buildValidationError('Cada limite de alerta deve ser um número maior que zero.');
     }
 
     return normalized;

--- a/tests/integration/financeController.budgets.test.js
+++ b/tests/integration/financeController.budgets.test.js
@@ -106,20 +106,20 @@ describe('FinanceController budgets endpoints', () => {
             });
 
         expect(response.status).toBe(400);
-        expect(response.body).toEqual({ message: 'Informe ao menos um limite de alerta entre 0 e 1.' });
+        expect(response.body).toEqual({ message: 'Informe ao menos um limite de alerta maior que zero.' });
     });
 
-    it('retorna 400 quando algum threshold está fora do intervalo permitido', async () => {
+    it('retorna 400 quando algum threshold não é positivo', async () => {
         const response = await request(app)
             .post('/finance/budgets')
             .send({
                 financeCategoryId: category.id,
                 monthlyLimit: '900.00',
-                thresholds: [0.5, 1.2]
+                thresholds: [0.5, 0]
             });
 
         expect(response.status).toBe(400);
-        expect(response.body).toEqual({ message: 'Cada limite de alerta deve estar entre 0 e 1.' });
+        expect(response.body).toEqual({ message: 'Cada limite de alerta deve ser um número maior que zero.' });
     });
 
     it('atualiza um orçamento existente com dados válidos', async () => {
@@ -160,9 +160,9 @@ describe('FinanceController budgets endpoints', () => {
 
         const response = await request(app)
             .put(`/finance/budgets/${initialBudget.id}`)
-            .send({ thresholds: [0.4, 1.5] });
+            .send({ thresholds: [0.4, -1.5] });
 
         expect(response.status).toBe(400);
-        expect(response.body).toEqual({ message: 'Cada limite de alerta deve estar entre 0 e 1.' });
+        expect(response.body).toEqual({ message: 'Cada limite de alerta deve ser um número maior que zero.' });
     });
 });

--- a/tests/unit/controllers/budgetController.test.js
+++ b/tests/unit/controllers/budgetController.test.js
@@ -91,6 +91,34 @@ describe('budgetController', () => {
             });
         });
 
+        it('normaliza thresholds fracionários e absolutos antes de salvar', async () => {
+            const budget = { id: 15, monthlyLimit: '1800.00' };
+            budgetService.saveBudget.mockResolvedValue(budget);
+
+            const req = {
+                user: { id: 25 },
+                body: {
+                    financeCategoryId: '6',
+                    monthlyLimit: '1800.00',
+                    thresholds: ['0.5', '200', ' 0.755 ', '200'],
+                    referenceMonth: '2024-11'
+                }
+            };
+            const res = buildResponse();
+
+            await budgetController.save(req, res);
+
+            expect(budgetService.saveBudget).toHaveBeenCalledWith({
+                id: null,
+                financeCategoryId: 6,
+                monthlyLimit: 1800,
+                thresholds: [0.5, 0.76, 200],
+                referenceMonth: '2024-11-01',
+                userId: 25
+            });
+            expect(res.status).toHaveBeenCalledWith(201);
+        });
+
         it('retorna 400 quando limite mensal inválido', async () => {
             const req = {
                 user: { id: 7 },


### PR DESCRIPTION
## Summary
- allow `parseThresholds` and route validation to accept any positive threshold values and reuse common rounding
- update budget model and utility normalization to round to two decimals and require only positivity
- refresh unit and integration tests to cover fractional and absolute thresholds with updated messages

## Testing
- npm run test:unit
- npx jest --runInBand tests/integration/financeController.budgets.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cad3fa0a50832f8c8dfea6e79e41b8