### PR TITLE
Refatore preparação da pré-visualização de importação financeira

### DIFF
--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -378,14 +378,15 @@ const prepareImportPreview = async (rawEntries = []) => {
     const normalizedEntries = [];
     const validationErrors = [];
 
-    rawEntries.forEach((entry, index) => {
+    for (const [index, entry] of rawEntries.entries()) {
         try {
-            const prepared = financeImportService.prepareEntryForPersistence(entry);
+            const prepared = await financeImportService.prepareEntryForPersistence(entry);
             normalizedEntries.push({ ...prepared, originalIndex: index });
         } catch (error) {
-            validationErrors.push({ index, message: error.message || 'Entrada inválida.' });
+            const message = error?.message || 'Entrada inválida.';
+            validationErrors.push({ index, message });
         }
-    });
+    }
 
     totals.total = normalizedEntries.length + validationErrors.length;
     totals.invalid = validationErrors.length;

--- a/tests/integration/financeImportFlow.test.js
+++ b/tests/integration/financeImportFlow.test.js
@@ -121,4 +121,29 @@ describe('Fluxo de importação financeira', () => {
             dueDate: '2024-01-15'
         });
     });
+
+    it('mantém os campos essenciais nas entradas da pré-visualização', async () => {
+        const csvPayload = [
+            'Descrição;Valor;Data;Tipo',
+            'Mensalidade Plataforma;75,00;2024-02-01;Receita'
+        ].join('\n');
+
+        const response = await request(app)
+            .post('/finance/import/preview')
+            .set('Accept', 'application/json')
+            .attach('importFile', Buffer.from(csvPayload, 'utf8'), 'import.csv');
+
+        expect(response.status).toBe(200);
+        const { preview } = response.body;
+        expect(preview.entries).toHaveLength(1);
+
+        const [entry] = preview.entries;
+        expect(entry).toMatchObject({
+            description: 'Mensalidade Plataforma',
+            value: 75,
+            dueDate: '2024-02-01'
+        });
+        expect(entry).toHaveProperty('type', 'receivable');
+        expect(entry).toHaveProperty('status');
+    });
 });


### PR DESCRIPTION
## Summary
- aguarda a normalização de cada lançamento na pré-visualização de importação financeira, preservando todos os campos retornados
- aprimora o tratamento de erros de validação ao montar a pré-visualização
- adiciona teste de integração garantindo que a pré-visualização mantenha descrição, valor e vencimento das entradas

## Testing
- npx jest --runInBand tests/integration/financeImportFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cad8534ae0832fac94a16ec8797b5e