### PR TITLE
feat: add email verification to authentication flow

### DIFF
--- a/database/migrations/20240920-add-email-verification-fields.js
+++ b/database/migrations/20240920-add-email-verification-fields.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('Users', 'emailVerifiedAt', {
+            type: Sequelize.DATE,
+            allowNull: true
+        });
+
+        await queryInterface.addColumn('Users', 'emailVerificationTokenHash', {
+            type: Sequelize.STRING(128),
+            allowNull: true
+        });
+
+        await queryInterface.addColumn('Users', 'emailVerificationTokenExpiresAt', {
+            type: Sequelize.DATE,
+            allowNull: true
+        });
+
+        await queryInterface.addIndex('Users', ['emailVerificationTokenHash'], {
+            name: 'users_email_verification_token_hash_idx'
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('Users', 'users_email_verification_token_hash_idx');
+        await queryInterface.removeColumn('Users', 'emailVerificationTokenExpiresAt');
+        await queryInterface.removeColumn('Users', 'emailVerificationTokenHash');
+        await queryInterface.removeColumn('Users', 'emailVerifiedAt');
+    }
+};

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -135,6 +135,24 @@ module.exports = (sequelize, DataTypes) => {
                     msg: 'Crédito não pode ser negativo.'
                 }
             }
+        },
+        emailVerifiedAt: {
+            type: DataTypes.DATE,
+            allowNull: true
+        },
+        emailVerificationTokenHash: {
+            type: DataTypes.STRING(128),
+            allowNull: true,
+            validate: {
+                len: {
+                    args: [10, 128],
+                    msg: 'Hash de verificação de e-mail inválido.'
+                }
+            }
+        },
+        emailVerificationTokenExpiresAt: {
+            type: DataTypes.DATE,
+            allowNull: true
         }
     }, {
         tableName: 'Users',

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -1,9 +1,176 @@
 // src/controllers/authController.js
+const crypto = require('crypto');
+
 const { User, Sequelize } = require('../../database/models');
 const argon2 = require('argon2');
 const { USER_ROLES } = require('../constants/roles');
+const { sendEmail } = require('../utils/email');
 
 const FRIENDLY_DB_ERROR_MESSAGE = 'Estamos atualizando o sistema. Execute as migrações do banco de dados e tente novamente.';
+const DEFAULT_EMAIL_VERIFICATION_TTL_HOURS = 24;
+const MIN_EMAIL_VERIFICATION_TTL_HOURS = 1;
+
+const escapeHtml = (value = '') => String(value).replace(/[&<>"']/g, (match) => {
+    switch (match) {
+        case '&':
+            return '&amp;';
+        case '<':
+            return '&lt;';
+        case '>':
+            return '&gt;';
+        case '"':
+            return '&quot;';
+        case '\'':
+            return '&#39;';
+        default:
+            return match;
+    }
+});
+
+const parsePositiveInt = (value, fallback) => {
+    if (value === undefined || value === null || value === '') {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const resolveVerificationTtlMs = () => {
+    const configuredHours = parsePositiveInt(
+        process.env.EMAIL_VERIFICATION_TTL_HOURS,
+        DEFAULT_EMAIL_VERIFICATION_TTL_HOURS
+    );
+    const safeHours = Math.max(configuredHours, MIN_EMAIL_VERIFICATION_TTL_HOURS);
+    return safeHours * 60 * 60 * 1000;
+};
+
+const EMAIL_VERIFICATION_TOKEN_TTL_MS = resolveVerificationTtlMs();
+
+const createEmailVerificationToken = () => {
+    const token = crypto.randomBytes(40).toString('hex');
+    const hash = crypto.createHash('sha256').update(token).digest('hex');
+    const expiresAt = new Date(Date.now() + EMAIL_VERIFICATION_TOKEN_TTL_MS);
+
+    return { token, hash, expiresAt };
+};
+
+const resolveAppBaseUrl = (req) => {
+    const envBaseUrl = process.env.APP_BASE_URL || process.env.APP_URL || process.env.PUBLIC_APP_URL;
+    if (envBaseUrl) {
+        try {
+            const normalized = new URL(envBaseUrl);
+            const trailingSlashlessPath = normalized.pathname.replace(/\/$/, '');
+            return `${normalized.origin}${trailingSlashlessPath}`;
+        } catch (error) {
+            console.warn('APP_BASE_URL inválida, utilizando URL da requisição.', error);
+        }
+    }
+
+    if (!req) {
+        return null;
+    }
+
+    const host = typeof req.get === 'function' ? req.get('host') : null;
+    if (!host) {
+        return null;
+    }
+
+    const protocol = req.protocol || 'http';
+    return `${protocol}://${host}`;
+};
+
+const buildVerificationUrl = (req, token) => {
+    const relativePath = `/verify-email?token=${encodeURIComponent(token)}`;
+    const baseUrl = resolveAppBaseUrl(req);
+
+    if (!baseUrl) {
+        return relativePath;
+    }
+
+    try {
+        return new URL(relativePath, `${baseUrl.replace(/\/$/, '')}/`).toString();
+    } catch (error) {
+        console.warn('Falha ao construir URL absoluta de verificação. Usando caminho relativo.', error);
+        return relativePath;
+    }
+};
+
+const formatExpiry = (expiresAt) => {
+    if (!(expiresAt instanceof Date) || Number.isNaN(expiresAt.getTime())) {
+        return null;
+    }
+
+    try {
+        return new Intl.DateTimeFormat('pt-BR', {
+            dateStyle: 'short',
+            timeStyle: 'short'
+        }).format(expiresAt);
+    } catch (error) {
+        return expiresAt.toISOString();
+    }
+};
+
+const getDisplayName = (user) => {
+    if (user && typeof user.getFirstName === 'function') {
+        const firstName = user.getFirstName();
+        if (firstName) {
+            return firstName;
+        }
+    }
+
+    if (user && user.name) {
+        const segments = String(user.name).trim().split(/\s+/);
+        if (segments.length) {
+            return segments[0];
+        }
+    }
+
+    return 'usuário';
+};
+
+const sendVerificationEmail = async ({ user, req, token, expiresAt, isResend = false }) => {
+    if (!user || !user.email) {
+        throw new Error('Usuário inválido para envio de verificação.');
+    }
+
+    const verificationUrl = buildVerificationUrl(req, token);
+    const displayName = escapeHtml(getDisplayName(user));
+    const formattedExpiry = formatExpiry(expiresAt);
+
+    const subject = isResend
+        ? 'Reenvio: confirme seu e-mail para acessar a plataforma'
+        : 'Confirme seu e-mail para acessar a plataforma';
+
+    const textLines = [
+        `Olá ${displayName},`,
+        '',
+        'Precisamos confirmar seu endereço de e-mail para liberar o acesso à plataforma.',
+        `Clique no link a seguir para validar sua conta: ${verificationUrl}`
+    ];
+
+    if (formattedExpiry) {
+        textLines.push('', `O link é válido até ${formattedExpiry}.`);
+    }
+
+    textLines.push('', 'Se você não solicitou este acesso, ignore esta mensagem.');
+
+    const html = `
+        <p>Olá ${displayName},</p>
+        <p>Precisamos confirmar seu endereço de e-mail para liberar o acesso à plataforma.</p>
+        <p><a href="${verificationUrl}">Clique aqui para validar sua conta</a>.</p>
+        ${formattedExpiry ? `<p>O link é válido até <strong>${escapeHtml(formattedExpiry)}</strong>.</p>` : ''}
+        <p>Se você não solicitou este acesso, ignore esta mensagem.</p>
+    `;
+
+    await sendEmail(user.email, subject, {
+        html,
+        text: textLines.join('\n'),
+        headers: {
+            'X-Transactional-Email': 'verification'
+        }
+    });
+};
 
 const isSequelizeDatabaseError = (error) => {
     if (!error) {
@@ -63,6 +230,39 @@ module.exports = {
                 req.flash('error_msg', 'Senha incorreta.');
                 return res.redirect('/login');
             }
+
+            if (!user.emailVerifiedAt) {
+                try {
+                    const { token, hash, expiresAt } = createEmailVerificationToken();
+                    user.emailVerificationTokenHash = hash;
+                    user.emailVerificationTokenExpiresAt = expiresAt;
+                    await user.save({
+                        fields: ['emailVerificationTokenHash', 'emailVerificationTokenExpiresAt']
+                    });
+
+                    await sendVerificationEmail({
+                        user,
+                        req,
+                        token,
+                        expiresAt,
+                        isResend: true
+                    });
+
+                    req.flash(
+                        'error_msg',
+                        'É necessário confirmar seu e-mail antes de acessar a plataforma. Enviamos um novo link de verificação para o seu e-mail.'
+                    );
+                } catch (emailError) {
+                    console.error('Erro ao reenviar verificação de e-mail durante o login:', emailError);
+                    req.flash(
+                        'error_msg',
+                        'Não foi possível reenviar o e-mail de verificação. Tente novamente em instantes.'
+                    );
+                }
+
+                return res.redirect('/login');
+            }
+
             req.session.user = {
                 id: user.id,
                 name: user.name,
@@ -116,8 +316,10 @@ module.exports = {
                 profileBuffer = req.file.buffer;
             }
 
+            const { token, hash, expiresAt } = createEmailVerificationToken();
+
             try {
-                await User.create({
+                const createdUser = await User.create({
                     name,
                     email,
                     password, // Criptografado via hook no model
@@ -125,8 +327,34 @@ module.exports = {
                     address,
                     dateOfBirth,
                     role: USER_ROLES.CLIENT,
-                    profileImage: profileBuffer
+                    profileImage: profileBuffer,
+                    emailVerificationTokenHash: hash,
+                    emailVerificationTokenExpiresAt: expiresAt,
+                    emailVerifiedAt: null
                 });
+
+                try {
+                    await sendVerificationEmail({
+                        user: createdUser,
+                        req,
+                        token,
+                        expiresAt,
+                        isResend: false
+                    });
+
+                    req.flash(
+                        'success_msg',
+                        'Cadastro realizado! Enviamos um e-mail de verificação para ativar sua conta.'
+                    );
+                } catch (emailError) {
+                    console.error('Erro ao enviar e-mail de verificação durante o cadastro:', emailError);
+                    req.flash(
+                        'error_msg',
+                        'Cadastro realizado, mas não foi possível enviar o e-mail de verificação. Tente novamente em alguns instantes.'
+                    );
+                }
+
+                return res.redirect('/login');
             } catch (error) {
                 return handleDatabaseError(
                     error,
@@ -136,14 +364,103 @@ module.exports = {
                     'Erro ao criar usuário durante o cadastro.'
                 );
             }
-
-            req.flash('success_msg', 'Cadastro realizado com sucesso! Faça login.');
-            return res.redirect('/login');
         } catch (err) {
             console.error('Erro no registro:', err);
             req.flash('error_msg', 'Erro ao cadastrar usuário.');
             return res.redirect('/register');
         }
+    },
+
+    verifyEmail: async (req, res) => {
+        const token = (req.query.token || '').trim();
+
+        if (!token) {
+            req.flash('error_msg', 'Token de verificação inválido.');
+            return res.redirect('/login');
+        }
+
+        const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+        let user;
+        try {
+            user = await User.findOne({
+                where: {
+                    emailVerificationTokenHash: tokenHash
+                }
+            });
+        } catch (error) {
+            return handleDatabaseError(
+                error,
+                req,
+                res,
+                '/login',
+                'Erro ao buscar usuário para verificação de e-mail.'
+            );
+        }
+
+        if (!user) {
+            req.flash('error_msg', 'Token de verificação inválido ou já utilizado.');
+            return res.redirect('/login');
+        }
+
+        if (user.emailVerifiedAt) {
+            req.flash('success_msg', 'Seu e-mail já está confirmado. Faça login para continuar.');
+            return res.redirect('/login');
+        }
+
+        const now = new Date();
+        if (user.emailVerificationTokenExpiresAt && user.emailVerificationTokenExpiresAt < now) {
+            try {
+                const { token: newToken, hash: newHash, expiresAt: newExpiresAt } = createEmailVerificationToken();
+                user.emailVerificationTokenHash = newHash;
+                user.emailVerificationTokenExpiresAt = newExpiresAt;
+                await user.save({
+                    fields: ['emailVerificationTokenHash', 'emailVerificationTokenExpiresAt']
+                });
+
+                await sendVerificationEmail({
+                    user,
+                    req,
+                    token: newToken,
+                    expiresAt: newExpiresAt,
+                    isResend: true
+                });
+
+                req.flash(
+                    'error_msg',
+                    'O link de verificação expirou. Enviamos um novo e-mail com um link atualizado.'
+                );
+            } catch (emailError) {
+                console.error('Erro ao reenviar verificação de e-mail após expiração:', emailError);
+                req.flash(
+                    'error_msg',
+                    'O link de verificação expirou e não foi possível gerar um novo no momento. Tente novamente mais tarde.'
+                );
+            }
+
+            return res.redirect('/login');
+        }
+
+        try {
+            user.emailVerifiedAt = now;
+            user.emailVerificationTokenHash = null;
+            user.emailVerificationTokenExpiresAt = null;
+            await user.save({
+                fields: ['emailVerifiedAt', 'emailVerificationTokenHash', 'emailVerificationTokenExpiresAt']
+            });
+
+            req.flash('success_msg', 'E-mail confirmado com sucesso! Faça login para continuar.');
+        } catch (error) {
+            return handleDatabaseError(
+                error,
+                req,
+                res,
+                '/login',
+                'Erro ao confirmar e-mail do usuário.'
+            );
+        }
+
+        return res.redirect('/login');
     },
 
     // Efetua logout

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -27,6 +27,8 @@ router.post(
     authController.register        // se passou, cria usuário
 );
 
+router.get('/verify-email', authController.verifyEmail);
+
 // Rota de logout
 router.get('/logout', authController.logout);
 

--- a/tests/integration/authController.emailVerification.test.js
+++ b/tests/integration/authController.emailVerification.test.js
@@ -1,0 +1,165 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const crypto = require('crypto');
+const argon2 = require('argon2');
+
+jest.mock('../../database/models', () => {
+    const { Op } = require('sequelize');
+
+    return {
+        User: {
+            findOne: jest.fn(),
+            create: jest.fn()
+        },
+        Sequelize: { Op },
+        sequelize: { close: jest.fn() }
+    };
+});
+
+jest.mock('../../src/utils/email', () => ({
+    sendEmail: jest.fn()
+}));
+
+const request = require('supertest');
+const { User, sequelize } = require('../../database/models');
+const { sendEmail } = require('../../src/utils/email');
+const { createTestApp } = require('../utils/createTestApp');
+
+const buildMockUser = (overrides = {}) => ({
+    id: overrides.id ?? 1,
+    name: overrides.name ?? 'Usuário Teste',
+    email: overrides.email ?? 'user@example.com',
+    role: overrides.role ?? 'client',
+    active: overrides.active ?? true,
+    emailVerifiedAt: overrides.emailVerifiedAt ?? null,
+    emailVerificationTokenHash: overrides.emailVerificationTokenHash ?? null,
+    emailVerificationTokenExpiresAt: overrides.emailVerificationTokenExpiresAt ?? null,
+    password: overrides.password ?? 'hashed',
+    getFirstName: jest.fn(() => 'Usuário'),
+    save: jest.fn(async function save() {
+        return this;
+    }),
+    ...overrides
+});
+
+describe('AuthController - verificação de e-mail', () => {
+    let app;
+    let agent;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        app = createTestApp();
+        agent = request.agent(app);
+    });
+
+    afterAll(async () => {
+        if (sequelize && typeof sequelize.close === 'function') {
+            await sequelize.close();
+        }
+    });
+
+    it('envia e-mail de verificação após cadastro bem-sucedido', async () => {
+        User.findOne.mockResolvedValueOnce(null);
+
+        User.create.mockImplementationOnce(async (payload) => {
+            expect(payload.emailVerificationTokenHash).toEqual(expect.stringMatching(/^[a-f0-9]{64}$/));
+            expect(payload.emailVerificationTokenExpiresAt).toBeInstanceOf(Date);
+            return buildMockUser(payload);
+        });
+
+        const response = await agent
+            .post('/register')
+            .field('name', 'Usuário Teste')
+            .field('email', 'novo@example.com')
+            .field('password', 'Senha@123')
+            .field('phone', '11999998888');
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/login');
+        expect(User.create).toHaveBeenCalledTimes(1);
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+
+        const [to, subject, payload] = sendEmail.mock.calls[0];
+        expect(to).toBe('novo@example.com');
+        expect(subject).toContain('Confirme seu e-mail');
+        expect(payload.html).toContain('/verify-email?token=');
+
+        const flash = await agent.get('/__test/flash');
+        expect(flash.status).toBe(200);
+        expect(flash.body.success.join(' ')).toContain('Enviamos um e-mail de verificação');
+    });
+
+    it('bloqueia login até o e-mail ser confirmado e reenviando o link', async () => {
+        const hashedPassword = await argon2.hash('Senha@123');
+        const mockUser = buildMockUser({ password: hashedPassword });
+
+        User.findOne.mockResolvedValueOnce(mockUser);
+
+        const response = await agent
+            .post('/login')
+            .type('form')
+            .send({ email: mockUser.email, password: 'Senha@123' });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/login');
+        expect(mockUser.save).toHaveBeenCalledTimes(1);
+        expect(mockUser.emailVerificationTokenHash).toEqual(expect.stringMatching(/^[a-f0-9]{64}$/));
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+
+        const flash = await agent.get('/__test/flash');
+        expect(flash.status).toBe(200);
+        expect(flash.body.error.join(' ')).toContain('confirmar seu e-mail');
+    });
+
+    it('confirma o e-mail com token válido', async () => {
+        const token = 'token-valido';
+        const hash = crypto.createHash('sha256').update(token).digest('hex');
+        const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+        const mockUser = buildMockUser({
+            emailVerificationTokenHash: hash,
+            emailVerificationTokenExpiresAt: expiresAt
+        });
+
+        User.findOne.mockImplementationOnce(async ({ where }) => {
+            expect(where.emailVerificationTokenHash).toBe(hash);
+            return mockUser;
+        });
+
+        const response = await agent.get(`/verify-email?token=${token}`);
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/login');
+        expect(mockUser.save).toHaveBeenCalledTimes(1);
+        expect(mockUser.emailVerifiedAt).toBeInstanceOf(Date);
+        expect(mockUser.emailVerificationTokenHash).toBeNull();
+        expect(mockUser.emailVerificationTokenExpiresAt).toBeNull();
+        expect(sendEmail).not.toHaveBeenCalled();
+
+        const flash = await agent.get('/__test/flash');
+        expect(flash.body.success.join(' ')).toContain('E-mail confirmado com sucesso');
+    });
+
+    it('gera novo link quando token expirou', async () => {
+        const token = 'token-expirado';
+        const hash = crypto.createHash('sha256').update(token).digest('hex');
+        const expiredAt = new Date(Date.now() - 60 * 60 * 1000);
+        const mockUser = buildMockUser({
+            emailVerificationTokenHash: hash,
+            emailVerificationTokenExpiresAt: expiredAt
+        });
+
+        User.findOne.mockResolvedValueOnce(mockUser);
+
+        const response = await agent.get(`/verify-email?token=${token}`);
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/login');
+        expect(mockUser.save).toHaveBeenCalledTimes(1);
+        expect(sendEmail).toHaveBeenCalledTimes(1);
+
+        const flash = await agent.get('/__test/flash');
+        expect(flash.body.error.join(' ')).toContain('link de verificação expirou');
+    });
+});


### PR DESCRIPTION
## Summary
- add email verification fields to users and create supporting migration
- send verification emails on registration, require verification on login, and expose a verify-email endpoint
- add integration tests covering registration, login gating, and verification scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf7704168832f83b491cd94c69257