### PR TITLE
Adjust page container stacking context

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -184,7 +184,6 @@ body {
 
 .page-container {
     position: relative;
-    z-index: 1;
 }
 
 .bg-gradient-primary {


### PR DESCRIPTION
## Summary
- remove the z-index from `.page-container` to prevent it from creating an unnecessary stacking context

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2e1b2294832fa9df6291dcb5a748