### PR TITLE
Remove application loader overlay

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -357,21 +357,6 @@ body {
     font-weight: 600;
 }
 
-.app-loader {
-    position: fixed;
-    inset: 0;
-    background: rgba(16, 24, 40, 0.85);
-    z-index: 1080;
-    backdrop-filter: blur(4px);
-    transition: opacity 0.4s ease, visibility 0.4s ease;
-}
-
-.app-loader.is-hidden {
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-}
-
 .app-footer {
     background: linear-gradient(135deg, var(--brand-primary-dark) 0%, #1a1c2d 100%);
     margin-top: auto;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,5 +1,4 @@
 (function () {
-    const loader = document.getElementById('appLoader');
     const THEME_STORAGE_KEY = 'app-theme';
     const themeRoot = document.getElementById('appShell');
     const themeToggle = document.getElementById('themeToggle');
@@ -97,52 +96,6 @@
         } else if (typeof prefersDark.addListener === 'function') {
             prefersDark.addListener(handleSystemPreference);
         }
-    }
-
-    const hideLoader = () => {
-        if (!loader || loader.classList.contains('is-hidden')) {
-            return;
-        }
-
-        loader.classList.add('is-hidden');
-        loader.setAttribute('aria-hidden', 'true');
-
-        const removeOnTransitionEnd = () => {
-            loader.removeEventListener('transitionend', removeOnTransitionEnd);
-            if (loader.parentElement) {
-                loader.parentElement.removeChild(loader);
-            }
-        };
-
-        loader.addEventListener('transitionend', removeOnTransitionEnd);
-    };
-
-    if (loader) {
-        let loaderTimeoutId = window.setTimeout(hideLoader, 1500);
-
-        const requestHideLoader = () => {
-            if (loaderTimeoutId) {
-                window.clearTimeout(loaderTimeoutId);
-                loaderTimeoutId = null;
-            }
-            window.setTimeout(hideLoader, 60);
-        };
-
-        document.addEventListener(
-            'DOMContentLoaded',
-            () => {
-                requestHideLoader();
-            },
-            { once: true }
-        );
-
-        window.addEventListener(
-            'load',
-            () => {
-                requestHideLoader();
-            },
-            { once: true }
-        );
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -116,13 +116,6 @@
     );
 %>
 
-<div id="appLoader" class="app-loader d-flex align-items-center justify-content-center">
-    <div class="text-center">
-        <div class="spinner-border text-light" role="status"></div>
-        <p class="mt-3 text-white-50 small">Carregando experiência personalizada...</p>
-    </div>
-</div>
-
 <div id="appShell" class="app-shell app-body theme-light" data-theme="light">
     <header class="app-header">
         <nav class="navbar navbar-expand-lg navbar-glass shadow-sm sticky-top">


### PR DESCRIPTION
## Summary
- remove the loader overlay markup from the shared header template
- delete the obsolete loader styling and client-side logic so pages render immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2e1c83d0832f8d289e8e6c595313