### PR TITLE
Add support ticket workflow with attachments

### DIFF
--- a/database/models/index.js
+++ b/database/models/index.js
@@ -59,7 +59,18 @@ Object.keys(db).forEach(modelName => {
 });
 
 // --- Início das associações manuais ---
-const { User, Appointment, Room, Procedure, FinanceCategory, FinanceEntry, Budget, BudgetThresholdStatus } = db;
+const {
+    User,
+    Appointment,
+    Room,
+    Procedure,
+    FinanceCategory,
+    FinanceEntry,
+    Budget,
+    BudgetThresholdStatus,
+    SupportTicket,
+    SupportAttachment
+} = db;
 
 /**
  * Exemplo de associações:
@@ -118,6 +129,36 @@ if (Procedure && Appointment) {
 }
 
 // --- Fim das associações manuais ---
+
+if (User && SupportTicket && !(User.associations && User.associations.supportTickets)) {
+    User.hasMany(SupportTicket, {
+        as: 'supportTickets',
+        foreignKey: 'userId'
+    });
+}
+
+if (SupportTicket && User && !(SupportTicket.associations && SupportTicket.associations.requester)) {
+    SupportTicket.belongsTo(User, {
+        as: 'requester',
+        foreignKey: 'userId'
+    });
+}
+
+if (SupportTicket && SupportAttachment && !(SupportTicket.associations && SupportTicket.associations.attachments)) {
+    SupportTicket.hasMany(SupportAttachment, {
+        as: 'attachments',
+        foreignKey: 'ticketId',
+        onDelete: 'CASCADE',
+        hooks: true
+    });
+}
+
+if (SupportAttachment && SupportTicket && !(SupportAttachment.associations && SupportAttachment.associations.ticket)) {
+    SupportAttachment.belongsTo(SupportTicket, {
+        as: 'ticket',
+        foreignKey: 'ticketId'
+    });
+}
 
 if (Budget && User && !(Budget.associations && Budget.associations.user)) {
     Budget.belongsTo(User, {

--- a/database/models/supportAttachment.js
+++ b/database/models/supportAttachment.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const path = require('path');
+
+const MAX_FILENAME_LENGTH = 255;
+
+const sanitizeFileName = (name) => {
+    if (!name) {
+        return 'anexo';
+    }
+
+    const base = path.basename(String(name)).replace(/[^\w\d._-]+/g, '-');
+    const trimmed = base.replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+    if (!trimmed) {
+        return 'anexo';
+    }
+
+    return trimmed.slice(0, MAX_FILENAME_LENGTH);
+};
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportAttachment = sequelize.define('SupportAttachment', {
+        ticketId: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            references: {
+                model: 'SupportTickets',
+                key: 'id'
+            },
+            onDelete: 'CASCADE'
+        },
+        fileName: {
+            type: DataTypes.STRING(MAX_FILENAME_LENGTH),
+            allowNull: false,
+            set(value) {
+                this.setDataValue('fileName', sanitizeFileName(value));
+            }
+        },
+        mimeType: {
+            type: DataTypes.STRING(120),
+            allowNull: false
+        },
+        size: {
+            type: DataTypes.BIGINT,
+            allowNull: false,
+            validate: {
+                min: 0
+            }
+        },
+        checksum: {
+            type: DataTypes.STRING(128),
+            allowNull: false
+        },
+        data: {
+            type: DataTypes.BLOB('long'),
+            allowNull: false
+        }
+    }, {
+        tableName: 'SupportAttachments'
+    });
+
+    SupportAttachment.associate = (models) => {
+        SupportAttachment.belongsTo(models.SupportTicket, {
+            as: 'ticket',
+            foreignKey: 'ticketId'
+        });
+    };
+
+    return SupportAttachment;
+};

--- a/database/models/supportTicket.js
+++ b/database/models/supportTicket.js
@@ -1,0 +1,61 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportTicket = sequelize.define('SupportTicket', {
+        userId: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            references: {
+                model: 'Users',
+                key: 'id'
+            },
+            onDelete: 'CASCADE'
+        },
+        subject: {
+            type: DataTypes.STRING(150),
+            allowNull: false,
+            validate: {
+                len: {
+                    args: [3, 150],
+                    msg: 'Assunto deve ter entre 3 e 150 caracteres.'
+                }
+            }
+        },
+        description: {
+            type: DataTypes.TEXT,
+            allowNull: false
+        },
+        status: {
+            type: DataTypes.ENUM('open', 'in-progress', 'closed'),
+            allowNull: false,
+            defaultValue: 'open'
+        },
+        priority: {
+            type: DataTypes.ENUM('low', 'medium', 'high'),
+            allowNull: false,
+            defaultValue: 'medium'
+        },
+        firstResponseAt: {
+            type: DataTypes.DATE,
+            allowNull: true
+        }
+    }, {
+        tableName: 'SupportTickets'
+    });
+
+    SupportTicket.associate = (models) => {
+        SupportTicket.belongsTo(models.User, {
+            as: 'requester',
+            foreignKey: 'userId'
+        });
+
+        SupportTicket.hasMany(models.SupportAttachment, {
+            as: 'attachments',
+            foreignKey: 'ticketId',
+            onDelete: 'CASCADE',
+            hooks: true
+        });
+    };
+
+    return SupportTicket;
+};

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ const notificationRoutes = require('./src/routes/notificationRoutes');
 const auditRoutes = require('./src/routes/auditRoutes');
 const campaignRoutes = require('./src/routes/campaignRoutes');
 const adminRoutes = require('./src/routes/adminRoutes');
+const supportRoutes = require('./src/routes/supportRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -257,6 +258,7 @@ app.use('/notifications', notificationRoutes);
 app.use('/campaigns', campaignRoutes);
 app.use('/audit', auditRoutes);
 app.use('/admin', adminRoutes);
+app.use('/support', supportRoutes);
 
 // Conexão DB
 Promise.all([sequelize.sync(), sessionStoreSyncPromise])

--- a/src/controllers/supportController.js
+++ b/src/controllers/supportController.js
@@ -1,0 +1,205 @@
+const crypto = require('crypto');
+
+const { SupportTicket, SupportAttachment, User, sequelize } = require('../../database/models');
+const { USER_ROLES, roleAtLeast } = require('../constants/roles');
+
+const STATUS_LABELS = Object.freeze({
+    open: 'Aberto',
+    'in-progress': 'Em andamento',
+    closed: 'Resolvido'
+});
+
+const PRIORITY_LABELS = Object.freeze({
+    low: 'Baixa',
+    medium: 'Média',
+    high: 'Alta'
+});
+
+const PRIORITY_VALUES = new Set(Object.keys(PRIORITY_LABELS));
+
+const normalizePriority = (value) => {
+    if (!value) {
+        return 'medium';
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (PRIORITY_VALUES.has(normalized)) {
+        return normalized;
+    }
+
+    return 'medium';
+};
+
+const formatDateTime = (value) => {
+    if (!value) {
+        return '';
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (!Number.isFinite(date.getTime())) {
+        return '';
+    }
+
+    return date.toLocaleString('pt-BR', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+};
+
+const prepareTicketForView = (ticket) => {
+    const plain = ticket.get({ plain: true });
+    const attachments = Array.isArray(plain.attachments) ? plain.attachments : [];
+
+    return {
+        ...plain,
+        createdAtFormatted: formatDateTime(plain.createdAt),
+        updatedAtFormatted: formatDateTime(plain.updatedAt),
+        statusLabel: STATUS_LABELS[plain.status] || plain.status,
+        priorityLabel: PRIORITY_LABELS[plain.priority] || plain.priority,
+        attachmentCount: attachments.length,
+        attachments: attachments.map((attachment) => ({
+            ...attachment,
+            sizeFormatted: `${Math.max(1, Math.ceil(Number(attachment.size || 0) / 1024))} KB`
+        }))
+    };
+};
+
+module.exports = {
+    async listTickets(req, res) {
+        try {
+            const isAdmin = roleAtLeast(req.user.role, USER_ROLES.ADMIN);
+            const tickets = await SupportTicket.findAll({
+                where: isAdmin ? {} : { userId: req.user.id },
+                include: [
+                    {
+                        model: SupportAttachment,
+                        as: 'attachments',
+                        attributes: ['id', 'size']
+                    },
+                    {
+                        model: User,
+                        as: 'requester',
+                        attributes: ['id', 'name', 'email']
+                    }
+                ],
+                order: [['createdAt', 'DESC']]
+            });
+
+            const formattedTickets = tickets.map(prepareTicketForView);
+
+            res.render('support/listTickets', {
+                pageTitle: 'Central de suporte',
+                tickets: formattedTickets,
+                statusLabels: STATUS_LABELS,
+                priorityLabels: PRIORITY_LABELS,
+                isAdmin
+            });
+        } catch (error) {
+            console.error('Erro ao listar tickets de suporte:', error);
+            req.flash('error_msg', 'Não foi possível carregar seus chamados no momento.');
+            return res.redirect('/');
+        }
+    },
+
+    async showCreateForm(req, res) {
+        res.render('support/newTicket', {
+            pageTitle: 'Abrir chamado',
+            priorityLabels: PRIORITY_LABELS
+        });
+    },
+
+    async createTicket(req, res) {
+        const subject = typeof req.body.subject === 'string' ? req.body.subject.trim() : '';
+        const description = typeof req.body.description === 'string' ? req.body.description.trim() : '';
+        const priority = normalizePriority(req.body.priority);
+
+        if (!subject || !description) {
+            req.flash('error_msg', 'Informe um assunto e descreva o que está acontecendo.');
+            return res.redirect('/support/tickets/new');
+        }
+
+        const files = Array.isArray(req.files) ? req.files : [];
+        const transaction = await sequelize.transaction();
+
+        try {
+            const ticket = await SupportTicket.create({
+                userId: req.user.id,
+                subject,
+                description,
+                priority
+            }, { transaction });
+
+            if (files.length) {
+                const attachmentsPayload = files.map((file) => ({
+                    ticketId: ticket.id,
+                    fileName: file.originalname,
+                    mimeType: file.mimetype,
+                    size: file.size,
+                    checksum: crypto.createHash('sha256').update(file.buffer).digest('hex'),
+                    data: file.buffer
+                }));
+
+                await SupportAttachment.bulkCreate(attachmentsPayload, { transaction });
+            }
+
+            await transaction.commit();
+            req.flash('success_msg', 'Chamado aberto com sucesso! Nossa equipe retornará em breve.');
+            return res.redirect('/support/tickets');
+        } catch (error) {
+            await transaction.rollback();
+            console.error('Erro ao criar ticket de suporte:', error);
+            req.flash('error_msg', 'Não foi possível abrir o chamado. Tente novamente.');
+            return res.redirect('/support/tickets/new');
+        }
+    },
+
+    async viewTicket(req, res) {
+        const { id } = req.params;
+
+        try {
+            const ticket = await SupportTicket.findByPk(id, {
+                include: [
+                    {
+                        model: SupportAttachment,
+                        as: 'attachments',
+                        attributes: ['id', 'fileName', 'mimeType', 'size', 'createdAt']
+                    },
+                    {
+                        model: User,
+                        as: 'requester',
+                        attributes: ['id', 'name', 'email']
+                    }
+                ],
+                order: [[{ model: SupportAttachment, as: 'attachments' }, 'createdAt', 'ASC']]
+            });
+
+            if (!ticket) {
+                req.flash('error_msg', 'Chamado de suporte não encontrado.');
+                return res.redirect('/support/tickets');
+            }
+
+            const isAdmin = roleAtLeast(req.user.role, USER_ROLES.ADMIN);
+            if (!isAdmin && ticket.userId !== req.user.id) {
+                req.flash('error_msg', 'Você não tem permissão para visualizar este chamado.');
+                return res.redirect('/support/tickets');
+            }
+
+            const formattedTicket = prepareTicketForView(ticket);
+
+            res.render('support/ticketDetail', {
+                pageTitle: `Chamado #${ticket.id}`,
+                ticket: formattedTicket,
+                statusLabels: STATUS_LABELS,
+                priorityLabels: PRIORITY_LABELS,
+                isAdmin
+            });
+        } catch (error) {
+            console.error('Erro ao visualizar ticket de suporte:', error);
+            req.flash('error_msg', 'Não foi possível exibir os detalhes do chamado.');
+            return res.redirect('/support/tickets');
+        }
+    }
+};

--- a/src/middlewares/supportAttachmentUpload.js
+++ b/src/middlewares/supportAttachmentUpload.js
@@ -1,0 +1,71 @@
+const multer = require('multer');
+
+const MAX_SIZE = Number.parseInt(process.env.SUPPORT_ATTACHMENT_MAX_SIZE, 10) || (8 * 1024 * 1024);
+const MAX_FILES = Number.parseInt(process.env.SUPPORT_ATTACHMENT_MAX_FILES, 10) || 3;
+
+const ALLOWED_MIME_TYPES = new Set([
+    'application/pdf',
+    'image/png',
+    'image/jpeg',
+    'image/jpg',
+    'text/plain',
+    'application/zip',
+    'application/x-zip-compressed',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+]);
+
+const storage = multer.memoryStorage();
+
+const multerInstance = multer({
+    storage,
+    limits: {
+        fileSize: MAX_SIZE,
+        files: MAX_FILES
+    },
+    fileFilter: (req, file, cb) => {
+        if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+            cb(null, true);
+            return;
+        }
+
+        const error = new Error('Tipo de arquivo não suportado para anexos de suporte.');
+        error.code = 'UNSUPPORTED_FILE_TYPE';
+        cb(error);
+    }
+});
+
+const uploadSupportAttachments = (req, res, next) => {
+    const handler = multerInstance.array('attachments');
+    handler(req, res, (err) => {
+        if (!err) {
+            return next();
+        }
+
+        if (typeof req.flash === 'function') {
+            if (err.code === 'LIMIT_FILE_SIZE') {
+                req.flash('error_msg', 'Arquivo excede o tamanho máximo permitido (8MB).');
+                return res.redirect('/support/tickets/new');
+            }
+
+            if (err.code === 'LIMIT_FILE_COUNT') {
+                req.flash('error_msg', 'Limite de anexos atingido para o chamado.');
+                return res.redirect('/support/tickets/new');
+            }
+
+            if (err.code === 'UNSUPPORTED_FILE_TYPE') {
+                req.flash('error_msg', 'Tipo de arquivo não suportado para anexos.');
+                return res.redirect('/support/tickets/new');
+            }
+        }
+
+        next(err);
+    });
+};
+
+module.exports = {
+    uploadSupportAttachments,
+    multerInstance
+};

--- a/src/routes/supportRoutes.js
+++ b/src/routes/supportRoutes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+
+const supportController = require('../controllers/supportController');
+const authMiddleware = require('../middlewares/authMiddleware');
+const authorize = require('../middlewares/authorize');
+const { uploadSupportAttachments } = require('../middlewares/supportAttachmentUpload');
+const { USER_ROLES } = require('../constants/roles');
+
+const router = express.Router();
+
+router.use(authMiddleware);
+router.use(authorize([USER_ROLES.CLIENT]));
+
+router.get('/tickets', supportController.listTickets);
+router.get('/tickets/new', supportController.showCreateForm);
+router.post('/tickets', uploadSupportAttachments, supportController.createTicket);
+router.get('/tickets/:id', supportController.viewTicket);
+
+module.exports = router;

--- a/src/utils/navigation.js
+++ b/src/utils/navigation.js
@@ -16,6 +16,13 @@ const rawShortcuts = [
         groups: ['menu']
     },
     {
+        label: 'Suporte',
+        route: '/support/tickets',
+        icon: 'bi-life-preserver',
+        minimumRole: USER_ROLES.CLIENT,
+        groups: ['menu', 'quick']
+    },
+    {
         label: 'Painel',
         route: '/dashboard',
         icon: 'bi-graph-up-arrow',

--- a/src/views/support/listTickets.ejs
+++ b/src/views/support/listTickets.ejs
@@ -1,0 +1,105 @@
+<%- include('../partials/header') %>
+
+<% const safeTickets = Array.isArray(tickets) ? tickets : []; %>
+<% const statusBadgeClasses = {
+    open: 'bg-primary-subtle text-primary',
+    'in-progress': 'bg-warning-subtle text-warning',
+    closed: 'bg-success-subtle text-success'
+}; %>
+<% const priorityDotClasses = {
+    low: 'bg-success',
+    medium: 'bg-warning',
+    high: 'bg-danger'
+}; %>
+
+<section class="container py-4 py-lg-5">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+        <div>
+            <h1 class="display-6 fw-semibold text-gradient">Central de suporte</h1>
+            <p class="text-muted mb-0">Visualize seus chamados e acompanhe o status de atendimento em tempo real.</p>
+        </div>
+        <a href="/support/tickets/new" class="btn btn-gradient btn-lg shadow-sm">
+            <i class="bi bi-plus-circle me-2"></i>
+            Abrir chamado
+        </a>
+    </div>
+
+    <div class="card border-0 shadow-sm">
+        <div class="card-body p-0">
+            <% if (!safeTickets.length) { %>
+                <div class="p-5 text-center">
+                    <div class="mb-3">
+                        <i class="bi bi-life-preserver display-5 text-primary"></i>
+                    </div>
+                    <h2 class="h4 fw-semibold mb-2">Nenhum chamado por aqui</h2>
+                    <p class="text-muted mb-4">Inicie um atendimento com nossa equipe e acompanhe tudo por este painel.</p>
+                    <a href="/support/tickets/new" class="btn btn-outline-primary btn-lg">
+                        Começar novo chamado
+                    </a>
+                </div>
+            <% } else { %>
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead class="bg-body-tertiary text-muted small text-uppercase">
+                            <tr>
+                                <th class="ps-4">Chamado</th>
+                                <th>Prioridade</th>
+                                <th>Status</th>
+                                <th>Atualizado</th>
+                                <th class="text-center">Anexos</th>
+                                <% if (isAdmin) { %>
+                                    <th>Solicitante</th>
+                                <% } %>
+                                <th class="text-end pe-4">Ações</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <% safeTickets.forEach((ticket) => { %>
+                                <tr>
+                                    <td class="ps-4">
+                                        <div class="fw-semibold mb-1">#<%= ticket.id %> · <%= ticket.subject %></div>
+                                        <small class="text-muted">Aberto em <%= ticket.createdAtFormatted %></small>
+                                    </td>
+                                    <td>
+                                        <span class="badge rounded-pill bg-opacity-25 text-dark d-inline-flex align-items-center gap-2">
+                                            <span class="d-inline-flex rounded-circle <%= priorityDotClasses[ticket.priority] || 'bg-secondary' %>" style="width: 0.65rem; height: 0.65rem;"></span>
+                                            <%= ticket.priorityLabel %>
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <% const badgeClass = statusBadgeClasses[ticket.status] || 'bg-secondary-subtle text-secondary'; %>
+                                        <span class="badge rounded-pill <%= badgeClass %>"><%= ticket.statusLabel %></span>
+                                    </td>
+                                    <td><span class="text-muted"><%= ticket.updatedAtFormatted %></span></td>
+                                    <td class="text-center">
+                                        <span class="badge rounded-pill bg-dark-subtle text-dark fw-semibold">
+                                            <%= ticket.attachmentCount %>
+                                        </span>
+                                    </td>
+                                    <% if (isAdmin) { %>
+                                        <td>
+                                            <% if (ticket.requester) { %>
+                                                <div class="fw-semibold"><%= ticket.requester.name || 'Usuário' %></div>
+                                                <small class="text-muted"><%= ticket.requester.email %></small>
+                                            <% } else { %>
+                                                <span class="text-muted">Não informado</span>
+                                            <% } %>
+                                        </td>
+                                    <% } %>
+                                    <td class="text-end pe-4">
+                                        <a href="/support/tickets/<%= ticket.id %>" class="btn btn-outline-primary btn-sm">
+                                            <i class="bi bi-eye"></i>
+                                            Detalhes
+                                        </a>
+                                    </td>
+                                </tr>
+                            <% }); %>
+                        </tbody>
+                    </table>
+                </div>
+            <% } %>
+        </div>
+    </div>
+</section>
+
+<%- include('../partials/footer') %>

--- a/src/views/support/newTicket.ejs
+++ b/src/views/support/newTicket.ejs
@@ -1,0 +1,83 @@
+<%- include('../partials/header') %>
+
+<% const priorityLabelsSafe = priorityLabels || { low: 'Baixa', medium: 'Média', high: 'Alta' }; %>
+
+<section class="container py-4 py-lg-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-7">
+            <div class="mb-4 text-center text-lg-start">
+                <a href="/support/tickets" class="btn btn-link px-0 text-decoration-none">
+                    <i class="bi bi-arrow-left"></i>
+                    Voltar para meus chamados
+                </a>
+            </div>
+
+            <div class="card border-0 shadow-sm overflow-hidden">
+                <div class="card-body p-4 p-lg-5">
+                    <span class="badge bg-gradient bg-opacity-10 text-primary mb-3">Atendimento prioritário</span>
+                    <h1 class="h3 fw-semibold text-gradient mb-2">Abrir novo chamado</h1>
+                    <p class="text-muted mb-4">Conte-nos o que está acontecendo e anexe evidências para agilizar o diagnóstico da equipe.</p>
+
+                    <form action="/support/tickets" method="POST" enctype="multipart/form-data" class="needs-validation" novalidate>
+                        <div class="mb-3">
+                            <label for="subject" class="form-label fw-semibold">Assunto</label>
+                            <input type="text" class="form-control form-control-lg" id="subject" name="subject" placeholder="Ex.: Erro ao acessar relatórios" required>
+                            <div class="invalid-feedback">Informe um assunto claro para o chamado.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="priority" class="form-label fw-semibold">Prioridade</label>
+                            <select class="form-select form-select-lg" id="priority" name="priority">
+                                <% Object.entries(priorityLabelsSafe).forEach(([value, label]) => { %>
+                                    <option value="<%= value %>"><%= label %></option>
+                                <% }); %>
+                            </select>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="description" class="form-label fw-semibold">Descrição detalhada</label>
+                            <textarea class="form-control" id="description" name="description" rows="6" placeholder="Descreva o comportamento, o impacto no time e passos para reproduzir" required></textarea>
+                            <div class="invalid-feedback">Descreva o que está acontecendo para que possamos ajudar melhor.</div>
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="attachments" class="form-label fw-semibold">Anexos (opcional)</label>
+                            <div class="border border-dashed rounded-4 p-4 text-center bg-body-tertiary">
+                                <i class="bi bi-cloud-arrow-up display-5 text-primary"></i>
+                                <p class="mt-3 mb-2 fw-semibold">Arraste arquivos ou clique para selecionar</p>
+                                <p class="text-muted small mb-3">Formatos aceitos: PDF, imagens, documentos Office e ZIP. Limite de 3 arquivos de até 8MB cada.</p>
+                                <input class="form-control form-control-lg" type="file" id="attachments" name="attachments" multiple>
+                            </div>
+                        </div>
+
+                        <div class="d-grid gap-2 d-sm-flex justify-content-sm-end">
+                            <a href="/support/tickets" class="btn btn-outline-secondary btn-lg">Cancelar</a>
+                            <button type="submit" class="btn btn-gradient btn-lg">
+                                <i class="bi bi-send me-2"></i>
+                                Enviar chamado
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script>
+(function () {
+    'use strict';
+    const forms = document.querySelectorAll('.needs-validation');
+    Array.from(forms).forEach((form) => {
+        form.addEventListener('submit', (event) => {
+            if (!form.checkValidity()) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+            form.classList.add('was-validated');
+        }, false);
+    });
+})();
+</script>
+
+<%- include('../partials/footer') %>

--- a/src/views/support/ticketDetail.ejs
+++ b/src/views/support/ticketDetail.ejs
@@ -1,0 +1,94 @@
+<%- include('../partials/header') %>
+
+<% const ticketSafe = ticket || {}; %>
+<% const attachmentsSafe = Array.isArray(ticketSafe.attachments) ? ticketSafe.attachments : []; %>
+<% const statusBadgeClasses = {
+    open: 'bg-primary-subtle text-primary',
+    'in-progress': 'bg-warning-subtle text-warning',
+    closed: 'bg-success-subtle text-success'
+}; %>
+<% const priorityDotClasses = {
+    low: 'bg-success',
+    medium: 'bg-warning',
+    high: 'bg-danger'
+}; %>
+
+<section class="container py-4 py-lg-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-10 col-xl-9">
+            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+                <div>
+                    <a href="/support/tickets" class="btn btn-link px-0 text-decoration-none mb-2">
+                        <i class="bi bi-arrow-left"></i>
+                        Voltar para meus chamados
+                    </a>
+                    <h1 class="display-6 fw-semibold text-gradient mb-1">Chamado #<%= ticketSafe.id %></h1>
+                    <p class="text-muted mb-0">Aberto em <%= ticketSafe.createdAtFormatted %> · Última atualização <%= ticketSafe.updatedAtFormatted %></p>
+                </div>
+                <div class="d-flex flex-wrap gap-2">
+                    <% const badgeClass = statusBadgeClasses[ticketSafe.status] || 'bg-secondary-subtle text-secondary'; %>
+                    <span class="badge rounded-pill <%= badgeClass %> px-3 py-2 fw-semibold">
+                        <i class="bi bi-lightning-charge me-1"></i>
+                        <%= ticketSafe.statusLabel %>
+                    </span>
+                    <span class="badge rounded-pill bg-body-secondary text-dark px-3 py-2 d-inline-flex align-items-center gap-2">
+                        <span class="rounded-circle <%= priorityDotClasses[ticketSafe.priority] || 'bg-secondary' %>" style="width: 0.65rem; height: 0.65rem;"></span>
+                        <%= ticketSafe.priorityLabel %>
+                    </span>
+                </div>
+            </div>
+
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body p-4 p-lg-5">
+                    <h2 class="h4 fw-semibold mb-3">Detalhes do chamado</h2>
+                    <p class="lead text-body-secondary mb-4"><%= ticketSafe.subject %></p>
+                    <article class="prose">
+                        <% (ticketSafe.description || '').split(/\n+/).forEach((paragraph) => { %>
+                            <% if (paragraph.trim()) { %>
+                                <p class="text-body"><%= paragraph %></p>
+                            <% } %>
+                        <% }); %>
+                    </article>
+
+                    <% if (ticketSafe.requester && isAdmin) { %>
+                        <div class="mt-4 p-3 rounded-4 bg-body-tertiary">
+                            <h3 class="h6 text-uppercase text-muted mb-2">Solicitante</h3>
+                            <div class="fw-semibold"><%= ticketSafe.requester.name || 'Usuário' %></div>
+                            <div class="text-muted small"><%= ticketSafe.requester.email %></div>
+                        </div>
+                    <% } %>
+                </div>
+            </div>
+
+            <div class="card border-0 shadow-sm">
+                <div class="card-body p-4 p-lg-5">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h2 class="h4 fw-semibold mb-0">Anexos compartilhados</h2>
+                        <span class="badge bg-dark-subtle text-dark fw-semibold"><%= attachmentsSafe.length %></span>
+                    </div>
+
+                    <% if (!attachmentsSafe.length) { %>
+                        <div class="text-center text-muted py-4">
+                            <i class="bi bi-folder-x display-6 mb-3"></i>
+                            <p class="mb-0">Nenhum arquivo foi anexado a este chamado.</p>
+                        </div>
+                    <% } else { %>
+                        <ul class="list-group list-group-flush">
+                            <% attachmentsSafe.forEach((attachment) => { %>
+                                <li class="list-group-item d-flex justify-content-between align-items-center py-3">
+                                    <div>
+                                        <div class="fw-semibold"><%= attachment.fileName %></div>
+                                        <small class="text-muted"><%= attachment.mimeType %> · <%= attachment.sizeFormatted %></small>
+                                    </div>
+                                    <span class="badge bg-body-secondary text-muted"><%= attachment.createdAt ? new Date(attachment.createdAt).toLocaleString('pt-BR', { hour: '2-digit', minute: '2-digit', day: '2-digit', month: 'short' }) : '' %></span>
+                                </li>
+                            <% }); %>
+                        </ul>
+                    <% } %>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<%- include('../partials/footer') %>

--- a/tests/integration/support/supportRoutes.test.js
+++ b/tests/integration/support/supportRoutes.test.js
@@ -1,0 +1,178 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const path = require('path');
+const express = require('express');
+const session = require('express-session');
+const flash = require('connect-flash');
+const request = require('supertest');
+const { USER_ROLES, getRoleLevel } = require('../../../src/constants/roles');
+
+let mockCurrentUser = {
+    id: 1,
+    role: 'client',
+    active: true,
+    name: 'Cliente Teste',
+    email: 'cliente@example.com'
+};
+
+jest.mock('../../../src/middlewares/authMiddleware', () => jest.fn((req, res, next) => {
+    req.session = req.session || {};
+    req.user = { ...mockCurrentUser };
+    req.session.user = req.user;
+    next();
+}));
+
+jest.mock('../../../src/middlewares/authorize', () => jest.fn(() => (req, res, next) => next()));
+
+const supportRoutes = require('../../../src/routes/supportRoutes');
+const { SupportTicket, SupportAttachment, User, sequelize } = require('../../../database/models');
+
+const buildApp = () => {
+    const app = express();
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+    app.use(session({
+        secret: 'support-test-secret',
+        resave: false,
+        saveUninitialized: false
+    }));
+    app.use(flash());
+    app.use((req, res, next) => {
+        const sessionUser = req.session.user || null;
+        res.locals.appName = 'Sistema de Gestão Inteligente';
+        res.locals.pageTitle = 'Sistema de Gestão Inteligente';
+        res.locals.user = sessionUser;
+        res.locals.userRoleLevel = sessionUser ? getRoleLevel(sessionUser.role) : -1;
+        res.locals.roles = USER_ROLES;
+        res.locals.roleLabels = {};
+        res.locals.roleOptions = [];
+        res.locals.success_msg = null;
+        res.locals.error_msg = null;
+        res.locals.error = null;
+        res.locals.notifications = [];
+        res.locals.notificationError = null;
+        res.locals.userMenuItems = [];
+        res.locals.quickActions = [];
+        next();
+    });
+    app.set('view engine', 'ejs');
+    app.set('views', path.join(__dirname, '..', '..', '..', 'src', 'views'));
+    app.use('/support', supportRoutes);
+    return app;
+};
+
+describe('Fluxo de suporte - integração', () => {
+    let app;
+    let requester;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        await sequelize.sync({ force: true });
+        requester = await User.create({
+            name: 'Cliente Teste',
+            email: 'cliente@example.com',
+            password: 'senhaSegura123',
+            role: 'client'
+        });
+        mockCurrentUser = {
+            id: requester.id,
+            role: 'client',
+            active: true,
+            name: requester.name,
+            email: requester.email
+        };
+        app = buildApp();
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    it('permite criar tickets com anexos antes do atendimento iniciar', async () => {
+        const pdfBuffer = Buffer.from('%PDF suporte teste');
+
+        const response = await request(app)
+            .post('/support/tickets')
+            .field('subject', 'Erro ao gerar relatório gerencial')
+            .field('description', 'O relatório de performance fica carregando indefinidamente.')
+            .field('priority', 'high')
+            .attach('attachments', pdfBuffer, {
+                filename: 'relatorio.pdf',
+                contentType: 'application/pdf'
+            });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/support/tickets');
+
+        const tickets = await SupportTicket.findAll({
+            include: [{ model: SupportAttachment, as: 'attachments' }]
+        });
+
+        expect(tickets).toHaveLength(1);
+        const [ticket] = tickets;
+        expect(ticket.subject).toBe('Erro ao gerar relatório gerencial');
+        expect(ticket.priority).toBe('high');
+        expect(ticket.attachments).toHaveLength(1);
+        const [attachment] = ticket.attachments;
+        expect(attachment.fileName).toBe('relatorio.pdf');
+        expect(attachment.mimeType).toBe('application/pdf');
+        expect(Number(attachment.size)).toBe(pdfBuffer.length);
+        expect(Buffer.isBuffer(attachment.data)).toBe(true);
+    });
+
+    it('lista apenas os chamados do usuário autenticado', async () => {
+        const otherUser = await User.create({
+            name: 'Gestor',
+            email: 'gestor@example.com',
+            password: 'senhaGestor123',
+            role: 'manager'
+        });
+
+        await SupportTicket.create({
+            userId: requester.id,
+            subject: 'Painel não atualiza',
+            description: 'As métricas ficam congeladas.',
+            priority: 'medium'
+        });
+
+        await SupportTicket.create({
+            userId: otherUser.id,
+            subject: 'Configuração de alertas',
+            description: 'Dúvida sobre alertas automáticos.',
+            priority: 'low'
+        });
+
+        const response = await request(app).get('/support/tickets');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Painel não atualiza');
+        expect(response.text).not.toContain('Configuração de alertas');
+    });
+
+    it('exibe detalhes do chamado com anexos cadastrados', async () => {
+        const ticket = await SupportTicket.create({
+            userId: requester.id,
+            subject: 'Integração ERP',
+            description: 'Integração está retornando erro 500.',
+            priority: 'medium'
+        });
+
+        await SupportAttachment.create({
+            ticketId: ticket.id,
+            fileName: 'log-erro.txt',
+            mimeType: 'text/plain',
+            size: 42,
+            checksum: '123456',
+            data: Buffer.from('Stacktrace simulada')
+        });
+
+        const response = await request(app).get(`/support/tickets/${ticket.id}`);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Integração ERP');
+        expect(response.text).toContain('log-erro.txt');
+        expect(response.text).toContain('text/plain');
+    });
+});


### PR DESCRIPTION
## Summary
- add support ticket and attachment Sequelize models with associations
- implement support controller, protected routes, and navigation entry with upload middleware
- create modern support EJS views and integration tests covering ticket creation, listing, and details

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2b4ae830832f90a0fb7dfe428e63