### PR TITLE
feat: add support ticket workflow

### DIFF
--- a/database/migrations/20240922-create-support-attachments.js
+++ b/database/migrations/20240922-create-support-attachments.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const TABLE_NAME = 'SupportAttachments';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.createTable(TABLE_NAME, {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            ticketId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'SupportTickets',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            },
+            messageId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'SupportMessages',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            },
+            uploadedById: {
+                type: Sequelize.INTEGER,
+                allowNull: true,
+                references: {
+                    model: 'Users',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'SET NULL'
+            },
+            fileName: {
+                type: Sequelize.STRING(255),
+                allowNull: false
+            },
+            storageKey: {
+                type: Sequelize.STRING(255),
+                allowNull: false
+            },
+            checksum: {
+                type: Sequelize.STRING(128),
+                allowNull: true
+            },
+            contentType: {
+                type: Sequelize.STRING(120),
+                allowNull: true
+            },
+            fileSize: {
+                type: Sequelize.BIGINT,
+                allowNull: true
+            },
+            createdAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            },
+            updatedAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            }
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_attachments_ticket_idx',
+            fields: ['ticketId']
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_attachments_message_idx',
+            fields: ['messageId']
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_attachments_uploader_idx',
+            fields: ['uploadedById']
+        });
+    },
+
+    down: async (queryInterface) => {
+        await queryInterface.removeIndex(TABLE_NAME, 'support_attachments_uploader_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'support_attachments_message_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'support_attachments_ticket_idx');
+        await queryInterface.dropTable(TABLE_NAME);
+    }
+};

--- a/database/migrations/20240922-create-support-messages.js
+++ b/database/migrations/20240922-create-support-messages.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const TABLE_NAME = 'SupportMessages';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.createTable(TABLE_NAME, {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            ticketId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'SupportTickets',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            },
+            senderId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'Users',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            },
+            body: {
+                type: Sequelize.TEXT,
+                allowNull: false
+            },
+            isFromAgent: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: false
+            },
+            createdAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            },
+            updatedAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            }
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_messages_ticket_idx',
+            fields: ['ticketId']
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_messages_sender_idx',
+            fields: ['senderId']
+        });
+    },
+
+    down: async (queryInterface) => {
+        await queryInterface.removeIndex(TABLE_NAME, 'support_messages_sender_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'support_messages_ticket_idx');
+        await queryInterface.dropTable(TABLE_NAME);
+    }
+};

--- a/database/migrations/20240922-create-support-tickets.js
+++ b/database/migrations/20240922-create-support-tickets.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const TABLE_NAME = 'SupportTickets';
+const STATUS_ENUM_NAME = 'enum_SupportTickets_status';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.createTable(TABLE_NAME, {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true
+            },
+            subject: {
+                type: Sequelize.STRING(180),
+                allowNull: false
+            },
+            status: {
+                type: Sequelize.ENUM('pending', 'in_progress', 'resolved'),
+                allowNull: false,
+                defaultValue: 'pending'
+            },
+            creatorId: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'Users',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            },
+            assignedToId: {
+                type: Sequelize.INTEGER,
+                allowNull: true,
+                references: {
+                    model: 'Users',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'SET NULL'
+            },
+            resolvedAt: {
+                type: Sequelize.DATE,
+                allowNull: true
+            },
+            firstResponseAt: {
+                type: Sequelize.DATE,
+                allowNull: true
+            },
+            lastMessageAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            },
+            createdAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            },
+            updatedAt: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+            }
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_tickets_status_idx',
+            fields: ['status']
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_tickets_creator_idx',
+            fields: ['creatorId']
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'support_tickets_assignee_idx',
+            fields: ['assignedToId']
+        });
+    },
+
+    down: async (queryInterface) => {
+        await queryInterface.removeIndex(TABLE_NAME, 'support_tickets_assignee_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'support_tickets_creator_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'support_tickets_status_idx');
+        await queryInterface.dropTable(TABLE_NAME);
+
+        if (queryInterface.sequelize.getDialect() === 'postgres') {
+            await queryInterface.sequelize.query(`DROP TYPE IF EXISTS "${STATUS_ENUM_NAME}";`);
+        }
+    }
+};

--- a/database/models/index.js
+++ b/database/models/index.js
@@ -59,7 +59,19 @@ Object.keys(db).forEach(modelName => {
 });
 
 // --- Início das associações manuais ---
-const { User, Appointment, Room, Procedure, FinanceCategory, FinanceEntry, Budget, BudgetThresholdStatus } = db;
+const {
+    User,
+    Appointment,
+    Room,
+    Procedure,
+    FinanceCategory,
+    FinanceEntry,
+    Budget,
+    BudgetThresholdStatus,
+    SupportTicket,
+    SupportMessage,
+    SupportAttachment
+} = db;
 
 /**
  * Exemplo de associações:
@@ -118,6 +130,36 @@ if (Procedure && Appointment) {
 }
 
 // --- Fim das associações manuais ---
+
+if (SupportTicket && User) {
+    if (!(User.associations && User.associations.createdSupportTickets)) {
+        User.hasMany(SupportTicket, {
+            as: 'createdSupportTickets',
+            foreignKey: 'creatorId'
+        });
+    }
+
+    if (!(User.associations && User.associations.assignedSupportTickets)) {
+        User.hasMany(SupportTicket, {
+            as: 'assignedSupportTickets',
+            foreignKey: 'assignedToId'
+        });
+    }
+}
+
+if (SupportMessage && User && !(User.associations && User.associations.supportMessages)) {
+    User.hasMany(SupportMessage, {
+        as: 'supportMessages',
+        foreignKey: 'senderId'
+    });
+}
+
+if (SupportAttachment && User && !(User.associations && User.associations.uploadedSupportAttachments)) {
+    User.hasMany(SupportAttachment, {
+        as: 'uploadedSupportAttachments',
+        foreignKey: 'uploadedById'
+    });
+}
 
 if (Budget && User && !(Budget.associations && Budget.associations.user)) {
     Budget.belongsTo(User, {

--- a/database/models/supportAttachment.js
+++ b/database/models/supportAttachment.js
@@ -1,0 +1,80 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportAttachment = sequelize.define('SupportAttachment', {
+        ticketId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        messageId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        uploadedById: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
+        fileName: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+            validate: {
+                notEmpty: {
+                    msg: 'Nome do arquivo é obrigatório.'
+                }
+            }
+        },
+        storageKey: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+            validate: {
+                notEmpty: {
+                    msg: 'Chave de armazenamento é obrigatória.'
+                }
+            }
+        },
+        checksum: {
+            type: DataTypes.STRING(128),
+            allowNull: true
+        },
+        contentType: {
+            type: DataTypes.STRING(120),
+            allowNull: true
+        },
+        fileSize: {
+            type: DataTypes.BIGINT,
+            allowNull: true,
+            validate: {
+                min: {
+                    args: [0],
+                    msg: 'Tamanho do arquivo inválido.'
+                }
+            }
+        }
+    }, {
+        tableName: 'SupportAttachments',
+        indexes: [
+            { name: 'support_attachments_ticket_idx', fields: ['ticketId'] },
+            { name: 'support_attachments_message_idx', fields: ['messageId'] },
+            { name: 'support_attachments_uploader_idx', fields: ['uploadedById'] }
+        ]
+    });
+
+    SupportAttachment.associate = (models) => {
+        SupportAttachment.belongsTo(models.SupportTicket, {
+            as: 'ticket',
+            foreignKey: 'ticketId'
+        });
+
+        SupportAttachment.belongsTo(models.SupportMessage, {
+            as: 'message',
+            foreignKey: 'messageId'
+        });
+
+        SupportAttachment.belongsTo(models.User, {
+            as: 'uploader',
+            foreignKey: 'uploadedById'
+        });
+    };
+
+    return SupportAttachment;
+};

--- a/database/models/supportMessage.js
+++ b/database/models/supportMessage.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportMessage = sequelize.define('SupportMessage', {
+        ticketId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        senderId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        body: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+            validate: {
+                notEmpty: {
+                    msg: 'Mensagem não pode estar vazia.'
+                }
+            }
+        },
+        isFromAgent: {
+            type: DataTypes.BOOLEAN,
+            allowNull: false,
+            defaultValue: false
+        }
+    }, {
+        tableName: 'SupportMessages',
+        indexes: [
+            { name: 'support_messages_ticket_idx', fields: ['ticketId'] },
+            { name: 'support_messages_sender_idx', fields: ['senderId'] }
+        ]
+    });
+
+    SupportMessage.associate = (models) => {
+        SupportMessage.belongsTo(models.SupportTicket, {
+            as: 'ticket',
+            foreignKey: 'ticketId'
+        });
+
+        SupportMessage.belongsTo(models.User, {
+            as: 'sender',
+            foreignKey: 'senderId'
+        });
+
+        SupportMessage.hasMany(models.SupportAttachment, {
+            as: 'attachments',
+            foreignKey: 'messageId',
+            onDelete: 'CASCADE'
+        });
+    };
+
+    return SupportMessage;
+};

--- a/database/models/supportTicket.js
+++ b/database/models/supportTicket.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const { TICKET_STATUSES, TICKET_STATUS_VALUES } = require('../../src/constants/support');
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportTicket = sequelize.define('SupportTicket', {
+        subject: {
+            type: DataTypes.STRING(180),
+            allowNull: false,
+            validate: {
+                notEmpty: {
+                    msg: 'Assunto do chamado é obrigatório.'
+                },
+                len: {
+                    args: [4, 180],
+                    msg: 'Assunto deve ter entre 4 e 180 caracteres.'
+                }
+            }
+        },
+        status: {
+            type: DataTypes.ENUM(...TICKET_STATUS_VALUES),
+            defaultValue: TICKET_STATUSES.PENDING,
+            allowNull: false,
+            validate: {
+                isIn: {
+                    args: [TICKET_STATUS_VALUES],
+                    msg: 'Status do chamado inválido.'
+                }
+            }
+        },
+        creatorId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        assignedToId: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
+        resolvedAt: {
+            type: DataTypes.DATE,
+            allowNull: true
+        },
+        firstResponseAt: {
+            type: DataTypes.DATE,
+            allowNull: true
+        },
+        lastMessageAt: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW
+        }
+    }, {
+        tableName: 'SupportTickets',
+        indexes: [
+            { name: 'support_tickets_status_idx', fields: ['status'] },
+            { name: 'support_tickets_creator_idx', fields: ['creatorId'] },
+            { name: 'support_tickets_assignee_idx', fields: ['assignedToId'] }
+        ]
+    });
+
+    SupportTicket.STATUS = TICKET_STATUSES;
+    SupportTicket.STATUS_VALUES = TICKET_STATUS_VALUES;
+
+    SupportTicket.associate = (models) => {
+        SupportTicket.belongsTo(models.User, {
+            as: 'creator',
+            foreignKey: 'creatorId'
+        });
+
+        SupportTicket.belongsTo(models.User, {
+            as: 'assignee',
+            foreignKey: 'assignedToId'
+        });
+
+        SupportTicket.hasMany(models.SupportMessage, {
+            as: 'messages',
+            foreignKey: 'ticketId',
+            onDelete: 'CASCADE'
+        });
+    };
+
+    return SupportTicket;
+};

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ const notificationRoutes = require('./src/routes/notificationRoutes');
 const auditRoutes = require('./src/routes/auditRoutes');
 const campaignRoutes = require('./src/routes/campaignRoutes');
 const adminRoutes = require('./src/routes/adminRoutes');
+const supportRoutes = require('./src/routes/supportRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -257,6 +258,7 @@ app.use('/notifications', notificationRoutes);
 app.use('/campaigns', campaignRoutes);
 app.use('/audit', auditRoutes);
 app.use('/admin', adminRoutes);
+app.use('/support', supportRoutes);
 
 // Conexão DB
 Promise.all([sequelize.sync(), sessionStoreSyncPromise])

--- a/src/constants/support.js
+++ b/src/constants/support.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const sanitize = require('sanitize-html');
+const { USER_ROLES, roleAtLeast } = require('./roles');
+
+const TICKET_STATUSES = Object.freeze({
+    PENDING: 'pending',
+    IN_PROGRESS: 'in_progress',
+    RESOLVED: 'resolved'
+});
+
+const TICKET_STATUS_VALUES = Object.freeze(Object.values(TICKET_STATUSES));
+
+const SUPPORT_AGENT_MIN_ROLE = USER_ROLES.COLLABORATOR;
+
+const isSupportAgentRole = (role) => roleAtLeast(role, SUPPORT_AGENT_MIN_ROLE);
+
+const sanitizeSupportContent = (value) => {
+    if (!value) {
+        return '';
+    }
+
+    return sanitize(value, {
+        allowedTags: ['p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'code'],
+        allowedAttributes: {
+            code: ['class']
+        },
+        allowedSchemes: ['http', 'https', 'mailto']
+    }).trim();
+};
+
+module.exports = {
+    TICKET_STATUSES,
+    TICKET_STATUS_VALUES,
+    SUPPORT_AGENT_MIN_ROLE,
+    isSupportAgentRole,
+    sanitizeSupportContent
+};

--- a/src/controllers/supportController.js
+++ b/src/controllers/supportController.js
@@ -1,0 +1,220 @@
+'use strict';
+const {
+    SupportTicket,
+    SupportMessage,
+    SupportAttachment,
+    User
+} = require('../../database/models');
+const {
+    isSupportAgentRole,
+    TICKET_STATUSES
+} = require('../constants/support');
+const {
+    createTicket,
+    addMessage,
+    updateTicketStatus,
+    assignTicket,
+    normalizeAttachmentsInput
+} = require('../services/supportTicketService');
+
+const wantsJson = (req) => {
+    const accept = req.headers.accept || '';
+    return req.xhr || accept.includes('application/json') || accept.includes('text/json');
+};
+
+const parseAttachments = (raw) => {
+    if (!raw) {
+        return [];
+    }
+
+    if (typeof raw === 'string') {
+        try {
+            const parsed = JSON.parse(raw);
+            return normalizeAttachmentsInput(parsed);
+        } catch (error) {
+            return [];
+        }
+    }
+
+    return normalizeAttachmentsInput(raw);
+};
+
+const handleSuccess = (req, res, message, payload = {}) => {
+    if (wantsJson(req)) {
+        return res.json({ message, ...payload });
+    }
+
+    if (message) {
+        req.flash('success_msg', message);
+    }
+
+    return res.redirect('/support/tickets');
+};
+
+const handleError = (req, res, error) => {
+    const message = error && error.message ? error.message : 'Não foi possível concluir a operação.';
+
+    if (wantsJson(req)) {
+        return res.status(400).json({ message });
+    }
+
+    req.flash('error_msg', message);
+    return res.redirect('/support/tickets');
+};
+
+const listTickets = async (req, res) => {
+    try {
+        const user = req.user;
+        const agent = isSupportAgentRole(user?.role);
+
+        const where = agent
+            ? {}
+            : { creatorId: user.id };
+
+        const records = await SupportTicket.findAll({
+            where,
+            include: [
+                {
+                    model: User,
+                    as: 'creator',
+                    attributes: ['id', 'name', 'email', 'role']
+                },
+                {
+                    model: User,
+                    as: 'assignee',
+                    attributes: ['id', 'name', 'email', 'role']
+                },
+                {
+                    model: SupportMessage,
+                    as: 'messages',
+                    include: [
+                        {
+                            model: User,
+                            as: 'sender',
+                            attributes: ['id', 'name', 'role']
+                        },
+                        {
+                            model: SupportAttachment,
+                            as: 'attachments',
+                            attributes: ['id', 'fileName', 'storageKey', 'contentType', 'fileSize', 'createdAt']
+                        }
+                    ]
+                }
+            ],
+            order: [['updatedAt', 'DESC']]
+        });
+
+        const tickets = records.map((ticket) => {
+            const plain = ticket.get({ plain: true });
+            if (Array.isArray(plain.messages)) {
+                plain.messages.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+            }
+            return plain;
+        });
+
+        if (wantsJson(req)) {
+            return res.json({ tickets, isAgent: agent });
+        }
+
+        return res.render('support/tickets', {
+            tickets,
+            isAgent: agent,
+            statuses: TICKET_STATUSES
+        });
+    } catch (error) {
+        return handleError(req, res, error);
+    }
+};
+
+const createTicketController = async (req, res) => {
+    try {
+        const assignedToId = req.body.assignedToId ? Number.parseInt(req.body.assignedToId, 10) : null;
+
+        await createTicket({
+            subject: req.body.subject,
+            description: req.body.description,
+            creator: req.user,
+            attachments: parseAttachments(req.body.attachments),
+            assignedToId: Number.isFinite(assignedToId) ? assignedToId : null,
+            ipAddress: req.ip
+        });
+
+        return handleSuccess(req, res, 'Chamado criado com sucesso.');
+    } catch (error) {
+        return handleError(req, res, error);
+    }
+};
+
+const addMessageController = async (req, res) => {
+    try {
+        const ticketId = Number.parseInt(req.params.ticketId, 10);
+
+        if (!Number.isFinite(ticketId)) {
+            throw new Error('Chamado inválido.');
+        }
+
+        await addMessage({
+            ticketId,
+            sender: req.user,
+            body: req.body.body,
+            attachments: parseAttachments(req.body.attachments),
+            ipAddress: req.ip
+        });
+
+        return handleSuccess(req, res, 'Mensagem registrada com sucesso.');
+    } catch (error) {
+        return handleError(req, res, error);
+    }
+};
+
+const updateStatusController = async (req, res) => {
+    try {
+        const ticketId = Number.parseInt(req.params.ticketId, 10);
+
+        if (!Number.isFinite(ticketId)) {
+            throw new Error('Chamado inválido.');
+        }
+
+        await updateTicketStatus({
+            ticketId,
+            status: req.body.status,
+            actor: req.user,
+            ipAddress: req.ip
+        });
+
+        return handleSuccess(req, res, 'Status atualizado com sucesso.');
+    } catch (error) {
+        return handleError(req, res, error);
+    }
+};
+
+const assignTicketController = async (req, res) => {
+    try {
+        const ticketId = Number.parseInt(req.params.ticketId, 10);
+
+        if (!Number.isFinite(ticketId)) {
+            throw new Error('Chamado inválido.');
+        }
+
+        const assignedToId = req.body.assignedToId ? Number.parseInt(req.body.assignedToId, 10) : null;
+
+        await assignTicket({
+            ticketId,
+            assignedToId: Number.isFinite(assignedToId) ? assignedToId : null,
+            actor: req.user,
+            ipAddress: req.ip
+        });
+
+        return handleSuccess(req, res, 'Chamado atribuído com sucesso.');
+    } catch (error) {
+        return handleError(req, res, error);
+    }
+};
+
+module.exports = {
+    listTickets,
+    createTicket: createTicketController,
+    addMessage: addMessageController,
+    updateStatus: updateStatusController,
+    assignTicket: assignTicketController
+};

--- a/src/routes/supportRoutes.js
+++ b/src/routes/supportRoutes.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+const supportController = require('../controllers/supportController');
+const authMiddleware = require('../middlewares/authMiddleware');
+const authorize = require('../middlewares/authorize');
+const audit = require('../middlewares/audit');
+const { USER_ROLES } = require('../constants/roles');
+
+const SUPPORT_AGENT_ROLES = [
+    USER_ROLES.COLLABORATOR,
+    USER_ROLES.SPECIALIST,
+    USER_ROLES.MANAGER,
+    USER_ROLES.ADMIN
+];
+
+router.get(
+    '/tickets',
+    authMiddleware,
+    supportController.listTickets
+);
+
+router.post(
+    '/tickets',
+    authMiddleware,
+    audit('support.ticket.create', (req) => `support_ticket:create:user:${req.user?.id ?? 'unknown'}`),
+    supportController.createTicket
+);
+
+router.post(
+    '/tickets/:ticketId/messages',
+    authMiddleware,
+    audit('support.ticket.message', (req) => `support_ticket:${req.params.ticketId}:message`),
+    supportController.addMessage
+);
+
+router.post(
+    '/tickets/:ticketId/status',
+    authMiddleware,
+    audit('support.ticket.status', (req) => `support_ticket:${req.params.ticketId}:status`),
+    supportController.updateStatus
+);
+
+router.post(
+    '/tickets/:ticketId/assign',
+    authMiddleware,
+    authorize(SUPPORT_AGENT_ROLES),
+    audit('support.ticket.assign', (req) => `support_ticket:${req.params.ticketId}:assign`),
+    supportController.assignTicket
+);
+
+module.exports = router;

--- a/src/services/supportTicketService.js
+++ b/src/services/supportTicketService.js
@@ -1,0 +1,387 @@
+'use strict';
+
+const {
+    sequelize,
+    SupportTicket,
+    SupportMessage,
+    SupportAttachment,
+    User,
+    AuditLog
+} = require('../../database/models');
+const {
+    TICKET_STATUSES,
+    TICKET_STATUS_VALUES,
+    isSupportAgentRole,
+    sanitizeSupportContent
+} = require('../constants/support');
+
+const sanitizeSubject = (subject) => {
+    if (subject === undefined || subject === null) {
+        throw new Error('Assunto é obrigatório.');
+    }
+
+    const normalized = String(subject)
+        .replace(/[\u0000-\u001F\u007F]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    if (!normalized || normalized.length < 4) {
+        throw new Error('Assunto deve ter ao menos 4 caracteres.');
+    }
+
+    return normalized.slice(0, 180);
+};
+
+const normalizeAttachmentsInput = (attachments) => {
+    if (!attachments) {
+        return [];
+    }
+
+    const entries = Array.isArray(attachments) ? attachments : [attachments];
+    const normalized = [];
+    const seen = new Set();
+
+    for (const entry of entries) {
+        if (!entry || typeof entry !== 'object') {
+            continue;
+        }
+
+        const storageKey = typeof entry.storageKey === 'string'
+            ? entry.storageKey.trim()
+            : String(entry.storageKey || '').trim();
+        const fileName = typeof entry.fileName === 'string'
+            ? entry.fileName.trim()
+            : String(entry.fileName || '').trim();
+
+        if (!storageKey || !fileName) {
+            continue;
+        }
+
+        const fingerprint = `${storageKey}:${fileName}`;
+        if (seen.has(fingerprint)) {
+            continue;
+        }
+        seen.add(fingerprint);
+
+        const record = {
+            storageKey: storageKey.slice(0, 255),
+            fileName: fileName.slice(0, 255),
+            checksum: entry.checksum ? String(entry.checksum).slice(0, 128) : null,
+            contentType: entry.contentType ? String(entry.contentType).slice(0, 120) : null,
+            fileSize: null
+        };
+
+        if (entry.fileSize !== undefined && entry.fileSize !== null && entry.fileSize !== '') {
+            const parsed = Number.parseInt(entry.fileSize, 10);
+            if (Number.isFinite(parsed) && parsed >= 0) {
+                record.fileSize = parsed;
+            }
+        }
+
+        normalized.push(record);
+    }
+
+    return normalized;
+};
+
+const executeInTransaction = async (handler, externalTransaction = null) => {
+    if (externalTransaction) {
+        return handler(externalTransaction);
+    }
+
+    return sequelize.transaction(async (transaction) => handler(transaction));
+};
+
+const recordAudit = async ({ userId, action, resource, ip, transaction }) => {
+    if (!AuditLog || typeof AuditLog.create !== 'function') {
+        return null;
+    }
+
+    return AuditLog.create({
+        userId: userId || null,
+        action,
+        resource,
+        ip: ip || null
+    }, { transaction });
+};
+
+const fetchTicketForUpdate = async (ticketId, transaction) => {
+    const query = {
+        transaction
+    };
+
+    if (transaction && transaction.LOCK && transaction.LOCK.UPDATE) {
+        query.lock = transaction.LOCK.UPDATE;
+    }
+
+    const ticket = await SupportTicket.findByPk(ticketId, query);
+    if (!ticket) {
+        throw new Error('Chamado não encontrado.');
+    }
+
+    return ticket;
+};
+
+const ensureAgentUser = async (userId, transaction) => {
+    const user = await User.findByPk(userId, { transaction });
+    if (!user) {
+        throw new Error('Usuário não encontrado.');
+    }
+
+    if (!isSupportAgentRole(user.role)) {
+        throw new Error('Usuário selecionado não possui perfil de atendimento.');
+    }
+
+    return user;
+};
+
+const createTicket = async ({
+    subject,
+    description,
+    creator,
+    attachments = [],
+    assignedToId = null,
+    ipAddress = null,
+    transaction = null
+}) => {
+    if (!creator || !creator.id) {
+        throw new Error('Usuário criador inválido.');
+    }
+
+    const normalizedSubject = sanitizeSubject(subject);
+    const sanitizedBody = sanitizeSupportContent(description);
+
+    if (!sanitizedBody) {
+        throw new Error('Descrição do chamado é obrigatória.');
+    }
+
+    return executeInTransaction(async (trx) => {
+        let assigneeId = null;
+        if (assignedToId) {
+            const assignee = await ensureAgentUser(assignedToId, trx);
+            assigneeId = assignee.id;
+        }
+
+        const ticket = await SupportTicket.create({
+            subject: normalizedSubject,
+            creatorId: creator.id,
+            assignedToId: assigneeId,
+            status: TICKET_STATUSES.PENDING,
+            lastMessageAt: new Date()
+        }, { transaction: trx });
+
+        const isAgent = isSupportAgentRole(creator.role);
+        const message = await SupportMessage.create({
+            ticketId: ticket.id,
+            senderId: creator.id,
+            body: sanitizedBody,
+            isFromAgent: isAgent
+        }, { transaction: trx });
+
+        const normalizedAttachments = normalizeAttachmentsInput(attachments).map((entry) => ({
+            ...entry,
+            ticketId: ticket.id,
+            messageId: message.id,
+            uploadedById: creator.id
+        }));
+
+        if (normalizedAttachments.length) {
+            await SupportAttachment.bulkCreate(normalizedAttachments, { transaction: trx });
+        }
+
+        await ticket.update({
+            lastMessageAt: message.createdAt || new Date()
+        }, { transaction: trx });
+
+        await recordAudit({
+            userId: creator.id,
+            action: 'support.ticket.create',
+            resource: `support_ticket:${ticket.id}`,
+            ip: ipAddress,
+            transaction: trx
+        });
+
+        return { ticket, message };
+    }, transaction);
+};
+
+const addMessage = async ({
+    ticketId,
+    sender,
+    body,
+    attachments = [],
+    ipAddress = null,
+    transaction = null
+}) => {
+    if (!sender || !sender.id) {
+        throw new Error('Remetente inválido.');
+    }
+
+    const sanitizedBody = sanitizeSupportContent(body);
+    if (!sanitizedBody) {
+        throw new Error('Mensagem não pode estar vazia.');
+    }
+
+    return executeInTransaction(async (trx) => {
+        const ticket = await fetchTicketForUpdate(ticketId, trx);
+
+        const isAgent = isSupportAgentRole(sender.role);
+        const isCreator = ticket.creatorId === sender.id;
+        const isAssignedAgent = ticket.assignedToId && ticket.assignedToId === sender.id;
+
+        if (!isCreator && !isAgent && !isAssignedAgent) {
+            throw new Error('Você não possui permissão para responder este chamado.');
+        }
+
+        if (ticket.status === TICKET_STATUSES.RESOLVED && !isAgent) {
+            throw new Error('Chamado resolvido não pode receber novas mensagens do solicitante.');
+        }
+
+        const message = await SupportMessage.create({
+            ticketId: ticket.id,
+            senderId: sender.id,
+            body: sanitizedBody,
+            isFromAgent: isAgent
+        }, { transaction: trx });
+
+        const normalizedAttachments = normalizeAttachmentsInput(attachments).map((entry) => ({
+            ...entry,
+            ticketId: ticket.id,
+            messageId: message.id,
+            uploadedById: sender.id
+        }));
+
+        if (normalizedAttachments.length) {
+            await SupportAttachment.bulkCreate(normalizedAttachments, { transaction: trx });
+        }
+
+        const updatePayload = {
+            lastMessageAt: message.createdAt || new Date()
+        };
+
+        if (isAgent && ticket.status === TICKET_STATUSES.PENDING) {
+            updatePayload.status = TICKET_STATUSES.IN_PROGRESS;
+            updatePayload.firstResponseAt = ticket.firstResponseAt || (message.createdAt || new Date());
+        }
+
+        if (!isAgent && ticket.status === TICKET_STATUSES.RESOLVED) {
+            updatePayload.status = TICKET_STATUSES.IN_PROGRESS;
+            updatePayload.resolvedAt = null;
+        }
+
+        if (isAgent && sanitizedBody && ticket.status !== TICKET_STATUSES.RESOLVED) {
+            updatePayload.firstResponseAt = ticket.firstResponseAt || (message.createdAt || new Date());
+        }
+
+        await ticket.update(updatePayload, { transaction: trx });
+
+        await recordAudit({
+            userId: sender.id,
+            action: 'support.ticket.message',
+            resource: `support_ticket:${ticket.id}`,
+            ip: ipAddress,
+            transaction: trx
+        });
+
+        return { ticket, message };
+    }, transaction);
+};
+
+const updateTicketStatus = async ({
+    ticketId,
+    status,
+    actor,
+    ipAddress = null,
+    transaction = null
+}) => {
+    if (!actor || !actor.id) {
+        throw new Error('Usuário inválido.');
+    }
+
+    const normalizedStatus = typeof status === 'string' ? status.trim().toLowerCase() : status;
+
+    if (!TICKET_STATUS_VALUES.includes(normalizedStatus)) {
+        throw new Error('Status informado é inválido.');
+    }
+
+    return executeInTransaction(async (trx) => {
+        const ticket = await fetchTicketForUpdate(ticketId, trx);
+
+        const isAgent = isSupportAgentRole(actor.role);
+        const isCreator = ticket.creatorId === actor.id;
+
+        if (!isAgent && !isCreator) {
+            throw new Error('Você não possui permissão para alterar o status deste chamado.');
+        }
+
+        if (!isAgent && normalizedStatus !== TICKET_STATUSES.PENDING) {
+            throw new Error('Apenas a equipe de suporte pode alterar o status para este valor.');
+        }
+
+        const updatePayload = { status: normalizedStatus };
+
+        if (normalizedStatus === TICKET_STATUSES.RESOLVED) {
+            updatePayload.resolvedAt = new Date();
+        } else {
+            updatePayload.resolvedAt = null;
+        }
+
+        await ticket.update(updatePayload, { transaction: trx });
+
+        await recordAudit({
+            userId: actor.id,
+            action: 'support.ticket.status',
+            resource: `support_ticket:${ticket.id}`,
+            ip: ipAddress,
+            transaction: trx
+        });
+
+        return ticket;
+    }, transaction);
+};
+
+const assignTicket = async ({
+    ticketId,
+    assignedToId,
+    actor,
+    ipAddress = null,
+    transaction = null
+}) => {
+    if (!actor || !actor.id) {
+        throw new Error('Usuário inválido.');
+    }
+
+    if (!isSupportAgentRole(actor.role)) {
+        throw new Error('Apenas atendentes podem atribuir chamados.');
+    }
+
+    return executeInTransaction(async (trx) => {
+        const ticket = await fetchTicketForUpdate(ticketId, trx);
+
+        let assigneeId = null;
+        if (assignedToId) {
+            const user = await ensureAgentUser(assignedToId, trx);
+            assigneeId = user.id;
+        }
+
+        await ticket.update({ assignedToId: assigneeId }, { transaction: trx });
+
+        await recordAudit({
+            userId: actor.id,
+            action: 'support.ticket.assign',
+            resource: `support_ticket:${ticket.id}`,
+            ip: ipAddress,
+            transaction: trx
+        });
+
+        return ticket;
+    }, transaction);
+};
+
+module.exports = {
+    createTicket,
+    addMessage,
+    updateTicketStatus,
+    assignTicket,
+    normalizeAttachmentsInput
+};

--- a/src/views/support/tickets.ejs
+++ b/src/views/support/tickets.ejs
@@ -1,0 +1,223 @@
+<%- include('../partials/header') %>
+
+<div class="container py-5 support-wrapper">
+    <% if (success_msg) { %>
+        <div class="alert alert-success alert-auto" role="alert" data-auto-dismiss="6000">
+            <i class="bi bi-check-circle-fill me-2"></i><%= success_msg %>
+        </div>
+    <% } %>
+
+    <% if (error_msg) { %>
+        <div class="alert alert-danger alert-auto" role="alert" data-auto-dismiss="6000">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i><%= error_msg %>
+        </div>
+    <% } %>
+
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card card-soft shadow-sm h-100">
+                <div class="card-body">
+                    <span class="badge-soft badge-soft-primary mb-3"><i class="bi bi-life-preserver me-2"></i>Novo chamado</span>
+                    <h4 class="card-title mb-3">Precisa de ajuda?</h4>
+                    <p class="text-muted small mb-4">
+                        Descreva sua necessidade com detalhes para que nossa equipe retorne com a solução mais adequada.
+                        Anexos podem ser enviados após abrir o chamado pelo painel administrativo.
+                    </p>
+                    <form method="POST" action="/support/tickets" class="support-form">
+                        <div class="mb-3">
+                            <label for="support-subject" class="form-label">Assunto</label>
+                            <input type="text" class="form-control" id="support-subject" name="subject" maxlength="180" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="support-description" class="form-label">Descrição</label>
+                            <textarea class="form-control" id="support-description" name="description" rows="5" required></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-gradient w-100">Abrir chamado</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-8">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                    <h3 class="mb-1">Seus chamados</h3>
+                    <p class="text-muted small mb-0">
+                        Acompanhe o histórico de mensagens e atualizações em tempo real.
+                    </p>
+                </div>
+                <span class="badge bg-light text-dark"><i class="bi bi-people me-1"></i><%= isAgent ? 'Painel do atendente' : 'Painel do cliente' %></span>
+            </div>
+
+            <% if (!tickets || tickets.length === 0) { %>
+                <div class="card card-soft">
+                    <div class="card-body text-center py-5">
+                        <i class="bi bi-inbox display-5 text-muted"></i>
+                        <h5 class="mt-3">Nenhum chamado encontrado</h5>
+                        <p class="text-muted">Assim que você abrir um chamado ele aparecerá aqui.</p>
+                    </div>
+                </div>
+            <% } %>
+
+            <% const statusLabels = { pending: 'Pendente', in_progress: 'Em andamento', resolved: 'Resolvido' }; %>
+            <% const statusEntries = Object.entries(statuses || {}); %>
+
+            <% tickets && tickets.forEach((ticket) => { %>
+                <div class="card card-soft mb-4 shadow-sm">
+                    <div class="card-body">
+                        <div class="d-flex flex-wrap justify-content-between align-items-start mb-3 gap-2">
+                            <div>
+                                <h5 class="mb-1"><i class="bi bi-ticket-detailed me-2 text-primary"></i><%= ticket.subject %></h5>
+                                <div class="text-muted small">
+                                    Aberto por <strong><%= ticket.creator?.name || 'Usuário' %></strong>
+                                    em <%= new Date(ticket.createdAt).toLocaleString('pt-BR') %>
+                                </div>
+                                <% if (ticket.assignee) { %>
+                                    <div class="text-muted small">Atribuído para <strong><%= ticket.assignee.name %></strong></div>
+                                <% } %>
+                            </div>
+                            <div class="text-end">
+                                <span class="badge status-badge status-<%= ticket.status %>">
+                                    <i class="bi bi-activity me-1"></i><%= statusLabels[ticket.status] || ticket.status %>
+                                </span>
+                                <div class="text-muted small mt-1">Última atualização: <%= new Date(ticket.updatedAt).toLocaleString('pt-BR') %></div>
+                            </div>
+                        </div>
+
+                        <div class="timeline">
+                            <% (ticket.messages || []).forEach((message) => { %>
+                                <div class="timeline-item">
+                                    <div class="timeline-indicator <%= message.isFromAgent ? 'bg-primary' : 'bg-secondary' %>"></div>
+                                    <div class="timeline-content">
+                                        <div class="d-flex justify-content-between align-items-center mb-1">
+                                            <div class="fw-semibold"><%= message.sender?.name || 'Usuário' %></div>
+                                            <span class="text-muted small"><%= new Date(message.createdAt).toLocaleString('pt-BR') %></span>
+                                        </div>
+                                        <div class="timeline-body">
+                                            <%- message.body %>
+                                        </div>
+                                        <% if (message.attachments && message.attachments.length) { %>
+                                            <div class="attachment-list mt-2">
+                                                <% message.attachments.forEach((attachment) => { %>
+                                                    <div class="attachment-item">
+                                                        <i class="bi bi-paperclip me-2"></i>
+                                                        <span><%= attachment.fileName %></span>
+                                                        <% if (attachment.fileSize) { %>
+                                                            <span class="text-muted ms-2">(<%= (attachment.fileSize / 1024).toFixed(1) %> KB)</span>
+                                                        <% } %>
+                                                    </div>
+                                                <% }); %>
+                                            </div>
+                                        <% } %>
+                                    </div>
+                                </div>
+                            <% }); %>
+                        </div>
+
+                        <div class="row g-3 mt-4">
+                            <div class="col-md-8">
+                                <form method="POST" action="/support/tickets/<%= ticket.id %>/messages" class="reply-form">
+                                    <label class="form-label">Enviar nova mensagem</label>
+                                    <textarea class="form-control" name="body" rows="3" placeholder="Escreva sua atualização..." required></textarea>
+                                    <button type="submit" class="btn btn-soft mt-2">Enviar mensagem</button>
+                                </form>
+                            </div>
+                            <div class="col-md-4">
+                                <form method="POST" action="/support/tickets/<%= ticket.id %>/status" class="status-form">
+                                    <label class="form-label">Atualizar status</label>
+                                    <select class="form-select" name="status">
+                                        <% statusEntries.forEach(([key, value]) => { %>
+                                            <option value="<%= value %>" <%= ticket.status === value ? 'selected' : '' %>>
+                                                <%= statusLabels[value] || key %>
+                                            </option>
+                                        <% }); %>
+                                    </select>
+                                    <button type="submit" class="btn btn-outline-primary w-100 mt-2">Salvar</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <% }); %>
+        </div>
+    </div>
+</div>
+
+<%- include('../partials/footer') %>
+
+<style>
+    .support-wrapper .card-soft {
+        border: 1px solid rgba(30, 64, 175, 0.08);
+        border-radius: 18px;
+        backdrop-filter: blur(6px);
+    }
+
+    .support-wrapper .status-badge {
+        font-size: 0.85rem;
+        padding: 0.4rem 0.75rem;
+        border-radius: 999px;
+    }
+
+    .support-wrapper .status-pending {
+        background: rgba(255, 193, 7, 0.12);
+        color: #b8860b;
+    }
+
+    .support-wrapper .status-in_progress {
+        background: rgba(13, 110, 253, 0.12);
+        color: #0d6efd;
+    }
+
+    .support-wrapper .status-resolved {
+        background: rgba(25, 135, 84, 0.12);
+        color: #198754;
+    }
+
+    .support-wrapper .timeline {
+        border-left: 2px solid rgba(13, 110, 253, 0.15);
+        padding-left: 1.5rem;
+    }
+
+    .support-wrapper .timeline-item {
+        position: relative;
+        padding-bottom: 1.5rem;
+    }
+
+    .support-wrapper .timeline-indicator {
+        position: absolute;
+        left: -1.65rem;
+        top: 0.25rem;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+    }
+
+    .support-wrapper .timeline-content {
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 12px;
+        padding: 1rem;
+        border: 1px solid rgba(13, 110, 253, 0.08);
+    }
+
+    .support-wrapper .attachment-item {
+        padding: 0.45rem 0.65rem;
+        border-radius: 8px;
+        border: 1px dashed rgba(13, 110, 253, 0.2);
+        background: rgba(13, 110, 253, 0.05);
+        display: inline-flex;
+        align-items: center;
+        margin-right: 0.5rem;
+        margin-bottom: 0.5rem;
+        font-size: 0.85rem;
+    }
+
+    .support-wrapper .btn-soft {
+        background: rgba(13, 110, 253, 0.08);
+        color: #0d6efd;
+    }
+
+    .support-wrapper .btn-soft:hover {
+        background: rgba(13, 110, 253, 0.12);
+        color: #0b5ed7;
+    }
+</style>

--- a/tests/unit/support/supportTicketService.test.js
+++ b/tests/unit/support/supportTicketService.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const mockTransaction = { LOCK: { UPDATE: Symbol('update') } };
+
+const mockTicketInstance = (overrides = {}) => ({
+    id: overrides.id ?? 1,
+    creatorId: overrides.creatorId ?? 10,
+    assignedToId: overrides.assignedToId ?? null,
+    status: overrides.status ?? 'pending',
+    firstResponseAt: overrides.firstResponseAt ?? null,
+    resolvedAt: overrides.resolvedAt ?? null,
+    createdAt: overrides.createdAt ?? new Date('2024-09-20T10:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2024-09-20T10:00:00Z'),
+    get: jest.fn(function getPlain() {
+        return { ...this };
+    }),
+    update: jest.fn(async function update(values) {
+        Object.assign(this, values);
+        return this;
+    }),
+    ...overrides
+});
+
+const mockMessageInstance = (overrides = {}) => ({
+    id: overrides.id ?? 25,
+    ticketId: overrides.ticketId ?? 1,
+    senderId: overrides.senderId ?? 10,
+    body: overrides.body ?? '<p>Mensagem</p>',
+    isFromAgent: overrides.isFromAgent ?? false,
+    createdAt: overrides.createdAt ?? new Date('2024-09-20T11:00:00Z'),
+    ...overrides
+});
+
+const mockSequelizeTransaction = jest.fn(async (handler) => handler(mockTransaction));
+const mockTicketCreate = jest.fn();
+const mockTicketFindByPk = jest.fn();
+const mockMessageCreate = jest.fn();
+const mockAttachmentBulkCreate = jest.fn();
+const mockAuditCreate = jest.fn();
+const mockUserFindByPk = jest.fn();
+
+jest.mock('../../../database/models', () => ({
+    sequelize: { transaction: mockSequelizeTransaction },
+    SupportTicket: {
+        create: mockTicketCreate,
+        findByPk: mockTicketFindByPk
+    },
+    SupportMessage: {
+        create: mockMessageCreate
+    },
+    SupportAttachment: {
+        bulkCreate: mockAttachmentBulkCreate
+    },
+    User: {
+        findByPk: mockUserFindByPk
+    },
+    AuditLog: {
+        create: mockAuditCreate
+    }
+}));
+
+const {
+    createTicket,
+    addMessage,
+    updateTicketStatus,
+    assignTicket
+} = require('../../../src/services/supportTicketService');
+
+describe('supportTicketService', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('cria um chamado com mensagem inicial e anexos em transação', async () => {
+        const ticket = mockTicketInstance({ id: 5 });
+        const message = mockMessageInstance({ id: 44, ticketId: 5 });
+
+        mockTicketCreate.mockResolvedValueOnce(ticket);
+        mockMessageCreate.mockResolvedValueOnce(message);
+        mockAttachmentBulkCreate.mockResolvedValueOnce([]);
+
+        await createTicket({
+            subject: 'Erro no painel',
+            description: '<p>Detalhes do erro</p>',
+            creator: { id: 99, role: 'client' },
+            attachments: [
+                { fileName: 'evidencia.png', storageKey: 'abc/123', fileSize: 2048 }
+            ],
+            assignedToId: null,
+            ipAddress: '127.0.0.1'
+        });
+
+        expect(mockSequelizeTransaction).toHaveBeenCalledTimes(1);
+        expect(mockTicketCreate).toHaveBeenCalledWith(expect.objectContaining({
+            subject: 'Erro no painel',
+            creatorId: 99,
+            status: 'pending'
+        }), expect.objectContaining({ transaction: mockTransaction }));
+
+        expect(mockMessageCreate).toHaveBeenCalledWith(expect.objectContaining({
+            ticketId: 5,
+            senderId: 99,
+            isFromAgent: false
+        }), expect.objectContaining({ transaction: mockTransaction }));
+
+        expect(mockAttachmentBulkCreate).toHaveBeenCalledWith([
+            expect.objectContaining({
+                ticketId: 5,
+                messageId: 44,
+                uploadedById: 99,
+                fileName: 'evidencia.png'
+            })
+        ], expect.objectContaining({ transaction: mockTransaction }));
+
+        expect(ticket.update).toHaveBeenCalledWith(expect.objectContaining({
+            lastMessageAt: expect.any(Date)
+        }), expect.objectContaining({ transaction: mockTransaction }));
+
+        expect(mockAuditCreate).toHaveBeenCalledWith(expect.objectContaining({
+            action: 'support.ticket.create',
+            resource: 'support_ticket:5'
+        }), expect.objectContaining({ transaction: mockTransaction }));
+    });
+
+    it('impede resposta de usuário sem permissão', async () => {
+        const ticket = mockTicketInstance({ id: 12, creatorId: 1, status: 'pending' });
+
+        mockTicketFindByPk.mockResolvedValueOnce(ticket);
+
+        await expect(addMessage({
+            ticketId: 12,
+            sender: { id: 2, role: 'client' },
+            body: 'Atualização',
+            attachments: []
+        })).rejects.toThrow('Você não possui permissão para responder este chamado.');
+
+        expect(mockMessageCreate).not.toHaveBeenCalled();
+    });
+
+    it('transiciona o status para em andamento quando atendente responde', async () => {
+        const ticket = mockTicketInstance({ id: 9, creatorId: 1, status: 'pending', firstResponseAt: null });
+        const message = mockMessageInstance({ id: 101, ticketId: 9, senderId: 3 });
+
+        mockTicketFindByPk.mockResolvedValueOnce(ticket);
+        mockMessageCreate.mockResolvedValueOnce(message);
+
+        await addMessage({
+            ticketId: 9,
+            sender: { id: 3, role: 'manager' },
+            body: 'Mensagem do suporte',
+            attachments: []
+        });
+
+        expect(ticket.update).toHaveBeenCalledWith(expect.objectContaining({
+            status: 'in_progress',
+            firstResponseAt: expect.any(Date)
+        }), expect.objectContaining({ transaction: mockTransaction }));
+    });
+
+    it('não aceita status inválido', async () => {
+        await expect(updateTicketStatus({
+            ticketId: 1,
+            status: 'arquivado',
+            actor: { id: 1, role: 'manager' }
+        })).rejects.toThrow('Status informado é inválido.');
+    });
+
+    it('permite que atendente finalize chamado', async () => {
+        const ticket = mockTicketInstance({ id: 30, status: 'in_progress', creatorId: 5 });
+
+        mockTicketFindByPk.mockResolvedValueOnce(ticket);
+
+        await updateTicketStatus({
+            ticketId: 30,
+            status: 'resolved',
+            actor: { id: 8, role: 'manager' }
+        });
+
+        expect(ticket.update).toHaveBeenCalledWith(expect.objectContaining({
+            status: 'resolved',
+            resolvedAt: expect.any(Date)
+        }), expect.objectContaining({ transaction: mockTransaction }));
+    });
+
+    it('exige que atribuição seja feita para atendente válido', async () => {
+        const ticket = mockTicketInstance({ id: 50 });
+
+        mockTicketFindByPk.mockResolvedValue(ticket);
+        mockUserFindByPk.mockResolvedValueOnce({ id: 99, role: 'manager' });
+
+        await assignTicket({
+            ticketId: 50,
+            assignedToId: 99,
+            actor: { id: 77, role: 'manager' }
+        });
+
+        expect(ticket.update).toHaveBeenCalledWith({ assignedToId: 99 }, expect.objectContaining({ transaction: mockTransaction }));
+
+        mockUserFindByPk.mockResolvedValueOnce({ id: 55, role: 'client' });
+
+        await expect(assignTicket({
+            ticketId: 50,
+            assignedToId: 55,
+            actor: { id: 77, role: 'manager' }
+        })).rejects.toThrow('Usuário selecionado não possui perfil de atendimento.');
+    });
+});


### PR DESCRIPTION
## Summary
- add Sequelize migrations and models for support tickets, messages, and attachments with audit-friendly fields
- implement support ticket service, controller, routes, and UI to handle ticket lifecycle and communication
- add unit tests covering ticket status transitions, permissions, and attachment persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2b4c5dcc832f8336260cf3ff47af