### PR TITLE
Add real-time support chat via Socket.IO

### DIFF
--- a/database/models/index.js
+++ b/database/models/index.js
@@ -59,7 +59,19 @@ Object.keys(db).forEach(modelName => {
 });
 
 // --- Início das associações manuais ---
-const { User, Appointment, Room, Procedure, FinanceCategory, FinanceEntry, Budget, BudgetThresholdStatus } = db;
+const {
+    User,
+    Appointment,
+    Room,
+    Procedure,
+    FinanceCategory,
+    FinanceEntry,
+    Budget,
+    BudgetThresholdStatus,
+    SupportTicket,
+    SupportMessage,
+    SupportAttachment
+} = db;
 
 /**
  * Exemplo de associações:
@@ -167,6 +179,67 @@ if (FinanceEntry && FinanceCategory && !(FinanceEntry.associations && FinanceEnt
     FinanceEntry.belongsTo(FinanceCategory, {
         as: 'category',
         foreignKey: 'financeCategoryId'
+    });
+}
+
+if (SupportTicket && User && !(SupportTicket.associations && SupportTicket.associations.requester)) {
+    SupportTicket.belongsTo(User, {
+        as: 'requester',
+        foreignKey: 'userId'
+    });
+}
+
+if (SupportTicket && SupportMessage && !(SupportTicket.associations && SupportTicket.associations.messages)) {
+    SupportTicket.hasMany(SupportMessage, {
+        as: 'messages',
+        foreignKey: 'ticketId',
+        onDelete: 'CASCADE'
+    });
+}
+
+if (SupportTicket && SupportAttachment && !(SupportTicket.associations && SupportTicket.associations.attachments)) {
+    SupportTicket.hasMany(SupportAttachment, {
+        as: 'attachments',
+        foreignKey: 'ticketId',
+        onDelete: 'CASCADE'
+    });
+}
+
+if (SupportMessage && SupportTicket && !(SupportMessage.associations && SupportMessage.associations.ticket)) {
+    SupportMessage.belongsTo(SupportTicket, {
+        as: 'ticket',
+        foreignKey: 'ticketId',
+        onDelete: 'CASCADE'
+    });
+}
+
+if (SupportMessage && User && !(SupportMessage.associations && SupportMessage.associations.sender)) {
+    SupportMessage.belongsTo(User, {
+        as: 'sender',
+        foreignKey: 'senderId'
+    });
+}
+
+if (SupportMessage && SupportAttachment && !(SupportMessage.associations && SupportMessage.associations.attachment)) {
+    SupportMessage.belongsTo(SupportAttachment, {
+        as: 'attachment',
+        foreignKey: 'attachmentId'
+    });
+}
+
+if (SupportAttachment && SupportTicket && !(SupportAttachment.associations && SupportAttachment.associations.ticket)) {
+    SupportAttachment.belongsTo(SupportTicket, {
+        as: 'ticket',
+        foreignKey: 'ticketId',
+        onDelete: 'CASCADE'
+    });
+}
+
+if (SupportAttachment && SupportMessage && !(SupportAttachment.associations && SupportAttachment.associations.message)) {
+    SupportAttachment.hasOne(SupportMessage, {
+        as: 'message',
+        foreignKey: 'attachmentId',
+        constraints: false
     });
 }
 

--- a/database/models/supportAttachment.js
+++ b/database/models/supportAttachment.js
@@ -1,0 +1,60 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportAttachment = sequelize.define('SupportAttachment', {
+        ticketId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        originalName: {
+            type: DataTypes.STRING(255),
+            allowNull: false
+        },
+        storageKey: {
+            type: DataTypes.STRING(255),
+            allowNull: false
+        },
+        mimeType: {
+            type: DataTypes.STRING(120),
+            allowNull: false
+        },
+        size: {
+            type: DataTypes.INTEGER.UNSIGNED,
+            allowNull: false
+        },
+        checksum: {
+            type: DataTypes.STRING(64),
+            allowNull: false
+        }
+    }, {
+        tableName: 'supportAttachments',
+        indexes: [
+            {
+                name: 'supportAttachments_ticketId',
+                fields: ['ticketId']
+            }
+        ]
+    });
+
+    SupportAttachment.associate = (models) => {
+        const { SupportTicket, SupportMessage } = models;
+
+        if (SupportTicket) {
+            SupportAttachment.belongsTo(SupportTicket, {
+                as: 'ticket',
+                foreignKey: 'ticketId',
+                onDelete: 'CASCADE'
+            });
+        }
+
+        if (SupportMessage) {
+            SupportAttachment.hasOne(SupportMessage, {
+                as: 'message',
+                foreignKey: 'attachmentId',
+                constraints: false
+            });
+        }
+    };
+
+    return SupportAttachment;
+};

--- a/database/models/supportMessage.js
+++ b/database/models/supportMessage.js
@@ -1,0 +1,70 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportMessage = sequelize.define('SupportMessage', {
+        ticketId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        senderId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        },
+        senderRole: {
+            type: DataTypes.STRING(20),
+            allowNull: false
+        },
+        messageType: {
+            type: DataTypes.STRING(20),
+            allowNull: false,
+            defaultValue: 'text',
+            validate: {
+                isIn: [['text', 'file', 'system']]
+            }
+        },
+        content: {
+            type: DataTypes.TEXT,
+            allowNull: true
+        },
+        attachmentId: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        }
+    }, {
+        tableName: 'supportMessages',
+        indexes: [
+            {
+                name: 'supportMessages_ticketId_createdAt',
+                fields: ['ticketId', 'createdAt']
+            }
+        ]
+    });
+
+    SupportMessage.associate = (models) => {
+        const { SupportTicket, User, SupportAttachment } = models;
+
+        if (SupportTicket) {
+            SupportMessage.belongsTo(SupportTicket, {
+                as: 'ticket',
+                foreignKey: 'ticketId',
+                onDelete: 'CASCADE'
+            });
+        }
+
+        if (User) {
+            SupportMessage.belongsTo(User, {
+                as: 'sender',
+                foreignKey: 'senderId'
+            });
+        }
+
+        if (SupportAttachment) {
+            SupportMessage.belongsTo(SupportAttachment, {
+                as: 'attachment',
+                foreignKey: 'attachmentId'
+            });
+        }
+    };
+
+    return SupportMessage;
+};

--- a/database/models/supportTicket.js
+++ b/database/models/supportTicket.js
@@ -1,0 +1,66 @@
+'use strict';
+
+module.exports = (sequelize, DataTypes) => {
+    const SupportTicket = sequelize.define('SupportTicket', {
+        subject: {
+            type: DataTypes.STRING(150),
+            allowNull: false,
+            validate: {
+                len: [3, 150]
+            }
+        },
+        description: {
+            type: DataTypes.TEXT,
+            allowNull: false
+        },
+        status: {
+            type: DataTypes.STRING(20),
+            allowNull: false,
+            defaultValue: 'open',
+            validate: {
+                isIn: [['open', 'waiting', 'resolved', 'closed']]
+            }
+        },
+        userId: {
+            type: DataTypes.INTEGER,
+            allowNull: false
+        }
+    }, {
+        tableName: 'supportTickets',
+        indexes: [
+            {
+                name: 'supportTickets_userId_status',
+                fields: ['userId', 'status']
+            }
+        ]
+    });
+
+    SupportTicket.associate = (models) => {
+        const { User, SupportMessage, SupportAttachment } = models;
+
+        if (User) {
+            SupportTicket.belongsTo(User, {
+                as: 'requester',
+                foreignKey: 'userId'
+            });
+        }
+
+        if (SupportMessage) {
+            SupportTicket.hasMany(SupportMessage, {
+                as: 'messages',
+                foreignKey: 'ticketId',
+                onDelete: 'CASCADE'
+            });
+        }
+
+        if (SupportAttachment) {
+            SupportTicket.hasMany(SupportAttachment, {
+                as: 'attachments',
+                foreignKey: 'ticketId',
+                onDelete: 'CASCADE'
+            });
+        }
+    };
+
+    return SupportTicket;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,12 +31,14 @@
         "pg-hstore": "^2.3.4",
         "sanitize-html": "^2.13.0",
         "sequelize": "^6.28.0",
+        "socket.io": "^4.8.1",
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
         "@ngrok/ngrok": "^1.5.2",
         "jest": "^29.7.0",
         "nodemon": "^3.1.9",
+        "socket.io-client": "^4.8.1",
         "supertest": "^6.3.4"
       }
     },
@@ -1390,6 +1392,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.3.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
@@ -1452,6 +1460,15 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -1984,6 +2001,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.4",
@@ -2775,6 +2801,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -3278,6 +3317,106 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -7847,6 +7986,157 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -8769,11 +9059,41 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "helmet": "^8.0.0",
     "method-override": "^3.0.0",
     "multer": "^1.4.5-lts.1",
+    "socket.io": "^4.8.1",
     "node-cron": "^3.0.3",
     "nodemailer": "^6.10.0",
     "pdfkit": "^0.15.2",
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@ngrok/ngrok": "^1.5.2",
     "jest": "^29.7.0",
+    "socket.io-client": "^4.8.1",
     "nodemon": "^3.1.9",
     "supertest": "^6.3.4"
   },

--- a/public/js/support-chat.js
+++ b/public/js/support-chat.js
@@ -1,0 +1,376 @@
+const config = window.supportChatConfig || {};
+
+const elements = {
+    panel: document.querySelector('[data-chat-panel]'),
+    messageList: document.querySelector('[data-chat-messages]'),
+    emptyState: document.querySelector('[data-chat-empty]'),
+    agentStatus: document.querySelector('[data-agent-status]'),
+    form: document.querySelector('[data-chat-form]'),
+    messageInput: document.querySelector('#supportChatMessage'),
+    uploadButton: document.querySelector('[data-chat-upload] input[type="file"]'),
+    attachmentForm: document.querySelector('[data-attachment-form]'),
+    attachmentsContainer: document.querySelector('[data-support-attachments]'),
+    adminEntryButton: document.querySelector('[data-enter-as-admin]')
+};
+
+const state = {
+    ticketId: config.ticketId,
+    isAdmin: config?.user?.role === 'admin',
+    joined: false,
+    joining: false,
+    asAdmin: false,
+    attachments: Array.isArray(config.attachments) ? [...config.attachments] : [],
+    messages: Array.isArray(config.history) ? [...config.history] : [],
+    pendingFile: null
+};
+
+const socket = typeof io === 'function' ? io() : null;
+
+const formatTime = (value) => {
+    const date = value ? new Date(value) : new Date();
+    if (Number.isNaN(date.getTime())) {
+        return '';
+    }
+
+    return date.toLocaleTimeString('pt-BR', {
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+};
+
+const toggleEmptyState = () => {
+    if (!elements.emptyState || !elements.messageList) {
+        return;
+    }
+
+    if (!state.messages.length) {
+        elements.emptyState.classList.remove('d-none');
+    } else {
+        elements.emptyState.classList.add('d-none');
+    }
+};
+
+const renderMessage = (message) => {
+    if (!elements.messageList || !message) {
+        return;
+    }
+
+    const li = document.createElement('li');
+    li.className = 'support-chat__message-wrapper d-flex flex-column';
+
+    const bubble = document.createElement('div');
+    bubble.classList.add('support-chat__message');
+
+    if (message.messageType === 'system') {
+        bubble.classList.add('support-chat__message--system', 'bg-dark', 'bg-opacity-75', 'text-white');
+    } else if (config.user && message.senderId === config.user.id) {
+        bubble.classList.add('support-chat__message--self');
+    } else {
+        bubble.classList.add('support-chat__message--other');
+    }
+
+    const header = document.createElement('div');
+    header.className = 'd-flex align-items-center justify-content-between gap-2 mb-1';
+
+    const author = document.createElement('span');
+    author.className = 'fw-semibold small text-uppercase';
+    author.textContent = message.senderRole || 'suporte';
+
+    const timestamp = document.createElement('small');
+    timestamp.textContent = formatTime(message.createdAt);
+
+    header.append(author, timestamp);
+    bubble.append(header);
+
+    if (message.content) {
+        const body = document.createElement('p');
+        body.className = 'mb-2';
+        body.textContent = message.content;
+        bubble.append(body);
+    }
+
+    if (message.attachment) {
+        const attachmentLink = document.createElement('a');
+        attachmentLink.href = `/support/attachments/${message.attachment.id}/download`;
+        attachmentLink.className = 'd-inline-flex align-items-center gap-2 small fw-semibold';
+        attachmentLink.innerHTML = `<i class="bi bi-paperclip"></i> ${message.attachment.originalName}`;
+        bubble.append(attachmentLink);
+    }
+
+    li.append(bubble);
+    elements.messageList.append(li);
+    elements.messageList.scrollTop = elements.messageList.scrollHeight;
+};
+
+const renderMessages = () => {
+    if (!elements.messageList) {
+        return;
+    }
+
+    elements.messageList.innerHTML = '';
+    state.messages.forEach(renderMessage);
+    toggleEmptyState();
+};
+
+const renderAttachments = () => {
+    if (!elements.attachmentsContainer) {
+        return;
+    }
+
+    if (!state.attachments.length) {
+        elements.attachmentsContainer.innerHTML = '<p class="text-muted small mb-0">Nenhum anexo adicionado ainda.</p>';
+        return;
+    }
+
+    const list = document.createElement('ul');
+    list.className = 'list-unstyled mb-0 d-flex flex-column gap-2';
+
+    state.attachments.forEach((attachment) => {
+        const item = document.createElement('li');
+        item.className = 'attachment-item d-flex align-items-center gap-3';
+        item.dataset.attachmentId = attachment.id;
+
+        const sizeKb = ((attachment.size || 0) / 1024).toFixed(1);
+
+        item.innerHTML = `
+            <span class="attachment-icon bg-primary-subtle text-primary"><i class="bi bi-paperclip"></i></span>
+            <div class="flex-grow-1">
+                <a class="text-decoration-none fw-semibold" href="/support/attachments/${attachment.id}/download">
+                    ${attachment.originalName}
+                </a>
+                <small class="text-muted d-block">Tamanho: ${sizeKb} KB</small>
+            </div>
+        `;
+
+        list.append(item);
+    });
+
+    elements.attachmentsContainer.innerHTML = '';
+    elements.attachmentsContainer.append(list);
+};
+
+const setAgentStatus = (message, variant = 'success') => {
+    if (!elements.agentStatus) {
+        return;
+    }
+
+    elements.agentStatus.textContent = message;
+    elements.agentStatus.className = `badge rounded-pill bg-${variant}-subtle text-${variant}`;
+};
+
+const joinChat = (asAdmin = false) => {
+    if (!socket || state.joining || state.joined) {
+        return;
+    }
+
+    state.joining = true;
+    socket.emit('support:join', { ticketId: state.ticketId, asAdmin }, (response) => {
+        state.joining = false;
+
+        if (!response?.ok) {
+            alert('Não foi possível entrar no chat: ' + (response?.error || 'erro desconhecido'));
+            return;
+        }
+
+        state.joined = true;
+        state.asAdmin = Boolean(asAdmin);
+        state.messages = Array.isArray(response.history) ? response.history : [];
+        renderMessages();
+        setAgentStatus(state.asAdmin ? 'Administrador conectado' : 'Canal disponível', state.asAdmin ? 'primary' : 'success');
+
+        if (elements.adminEntryButton) {
+            elements.adminEntryButton.classList.add('d-none');
+        }
+    });
+};
+
+const sendMessage = async (content, attachmentFile) => {
+    if (!socket || !state.joined) {
+        alert('Conexão com o chat ainda não estabelecida.');
+        return;
+    }
+
+    let attachmentId = null;
+
+    if (attachmentFile) {
+        const formData = new FormData();
+        formData.append('file', attachmentFile);
+
+        const response = await fetch(`/support/tickets/${state.ticketId}/attachments`, {
+            method: 'POST',
+            body: formData
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({ message: 'Falha ao enviar anexo.' }));
+            throw new Error(errorData.message || 'Erro ao enviar anexo.');
+        }
+
+        const data = await response.json();
+        if (data?.attachment) {
+            attachmentId = data.attachment.id;
+            state.attachments.push(data.attachment);
+            renderAttachments();
+        }
+    }
+
+    return new Promise((resolve, reject) => {
+        socket.emit(
+            'support:message',
+            {
+                ticketId: state.ticketId,
+                content,
+                attachmentId,
+                messageType: attachmentId ? 'file' : 'text'
+            },
+            (ack) => {
+                if (!ack?.ok) {
+                    reject(new Error(ack?.error || 'Erro ao enviar mensagem.'));
+                    return;
+                }
+
+                resolve(ack.message);
+            }
+        );
+    });
+};
+
+const handleFormSubmit = async (event) => {
+    event.preventDefault();
+    if (!elements.messageInput) {
+        return;
+    }
+
+    const content = elements.messageInput.value.trim();
+    const file = state.pendingFile;
+
+    if (!content && !file) {
+        return;
+    }
+
+    try {
+        elements.form.classList.add('is-loading');
+        await sendMessage(content, file);
+        elements.messageInput.value = '';
+        if (elements.uploadButton) {
+            elements.uploadButton.value = '';
+        }
+        state.pendingFile = null;
+    } catch (error) {
+        alert(error.message || 'Erro ao enviar mensagem.');
+    } finally {
+        elements.form.classList.remove('is-loading');
+    }
+};
+
+const handleAttachmentSubmit = async (event) => {
+    event.preventDefault();
+    const input = event.currentTarget?.querySelector('input[type="file"]');
+    if (!input || !input.files?.length) {
+        return;
+    }
+
+    const file = input.files[0];
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+        event.currentTarget.classList.add('is-loading');
+        const response = await fetch(`/support/tickets/${state.ticketId}/attachments`, {
+            method: 'POST',
+            body: formData
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({ message: 'Falha ao enviar anexo.' }));
+            throw new Error(errorData.message || 'Erro ao anexar arquivo.');
+        }
+
+        const data = await response.json();
+        if (data?.attachment) {
+            state.attachments.push(data.attachment);
+            renderAttachments();
+        }
+        input.value = '';
+    } catch (error) {
+        alert(error.message || 'Erro ao anexar arquivo.');
+    } finally {
+        event.currentTarget.classList.remove('is-loading');
+    }
+};
+
+const bindEvents = () => {
+    if (elements.form) {
+        elements.form.addEventListener('submit', handleFormSubmit);
+    }
+
+    if (elements.uploadButton) {
+        elements.uploadButton.addEventListener('change', (event) => {
+            state.pendingFile = event.target.files?.[0] || null;
+        });
+    }
+
+    if (elements.attachmentForm) {
+        elements.attachmentForm.addEventListener('submit', handleAttachmentSubmit);
+    }
+
+    if (elements.adminEntryButton) {
+        if (state.isAdmin) {
+            elements.adminEntryButton.classList.remove('d-none');
+            elements.adminEntryButton.addEventListener('click', (event) => {
+                event.preventDefault();
+                joinChat(true);
+                fetch(`/support/tickets/${state.ticketId}/notify-admin-entry`, {
+                    method: 'POST'
+                }).catch(() => {
+                    // Notificar falha silenciosa para não interromper fluxo.
+                });
+            });
+        } else {
+            elements.adminEntryButton.classList.add('d-none');
+        }
+    }
+};
+
+const bindSocketEvents = () => {
+    if (!socket) {
+        return;
+    }
+
+    socket.on('connect', () => {
+        if (!state.isAdmin) {
+            joinChat(false);
+        }
+    });
+
+    socket.on('support:message', (message) => {
+        state.messages.push(message);
+        renderMessage(message);
+        toggleEmptyState();
+    });
+
+    socket.on('support:agent:online', () => {
+        setAgentStatus('Administrador conectado', 'primary');
+    });
+};
+
+const init = () => {
+    if (!state.ticketId || !socket) {
+        return;
+    }
+
+    renderMessages();
+    renderAttachments();
+    toggleEmptyState();
+    bindEvents();
+    bindSocketEvents();
+
+    if (state.isAdmin && !elements.adminEntryButton) {
+        joinChat(true);
+        fetch(`/support/tickets/${state.ticketId}/notify-admin-entry`, {
+            method: 'POST'
+        }).catch(() => {});
+    }
+};
+
+init();

--- a/src/controllers/supportController.js
+++ b/src/controllers/supportController.js
@@ -1,0 +1,166 @@
+const {
+    ensureTicketAccess,
+    ensureAdminRole,
+    createAttachment,
+    loadTicketHistory,
+    listTicketAttachments,
+    notifyAdminJoined,
+    getAttachmentById
+} = require('../services/supportChatService');
+const fileStorageService = require('../services/fileStorageService');
+
+const getRequestUser = (req) => {
+    if (req.user && req.user.active) {
+        return req.user;
+    }
+
+    if (req.session && req.session.user) {
+        return req.session.user;
+    }
+
+    return null;
+};
+
+const supportController = {
+    async renderChat(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                return res.redirect('/login');
+            }
+
+            const ticketId = Number.parseInt(req.params.ticketId, 10);
+            const { ticket } = await ensureTicketAccess(ticketId, user);
+            const [history, attachments] = await Promise.all([
+                loadTicketHistory(ticket.id),
+                listTicketAttachments(ticket.id)
+            ]);
+
+            res.render('support/chat', {
+                ticket: ticket.get({ plain: true }),
+                history,
+                attachments
+            });
+        } catch (error) {
+            const status = error?.status || 500;
+            if (status >= 500) {
+                console.error('Erro ao renderizar chat de suporte:', error);
+            }
+
+            req.flash('error_msg', error?.message || 'Não foi possível carregar o chat.');
+            res.redirect('/');
+        }
+    },
+
+    async uploadAttachment(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                return res.status(401).json({ message: 'Autenticação necessária.' });
+            }
+
+            const ticketId = Number.parseInt(req.params.ticketId, 10);
+            await ensureTicketAccess(ticketId, user);
+
+            if (!req.file) {
+                return res.status(400).json({ message: 'Arquivo obrigatório.' });
+            }
+
+            const attachment = await createAttachment({
+                ticketId,
+                file: req.file
+            });
+
+            return res.status(201).json({ attachment });
+        } catch (error) {
+            if (error.status) {
+                return res.status(error.status).json({ message: error.message });
+            }
+            console.error('Erro ao anexar arquivo ao ticket:', error);
+            return res.status(500).json({ message: 'Erro ao anexar arquivo.' });
+        }
+    },
+
+    async fetchHistory(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                return res.status(401).json({ message: 'Autenticação necessária.' });
+            }
+
+            const ticketId = Number.parseInt(req.params.ticketId, 10);
+            await ensureTicketAccess(ticketId, user);
+            const [history, attachments] = await Promise.all([
+                loadTicketHistory(ticketId),
+                listTicketAttachments(ticketId)
+            ]);
+
+            return res.json({ history, attachments });
+        } catch (error) {
+            if (error.status) {
+                return res.status(error.status).json({ message: error.message });
+            }
+            console.error('Erro ao recuperar histórico do chat:', error);
+            return res.status(500).json({ message: 'Erro ao carregar histórico.' });
+        }
+    },
+
+    async notifyAdminEntry(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                return res.status(401).json({ message: 'Autenticação necessária.' });
+            }
+
+            ensureAdminRole(user);
+            const ticketId = Number.parseInt(req.params.ticketId, 10);
+            const { ticket } = await ensureTicketAccess(ticketId, user);
+            await notifyAdminJoined({ ticket, adminUser: user });
+
+            return res.json({ ok: true });
+        } catch (error) {
+            if (error.status) {
+                return res.status(error.status).json({ message: error.message });
+            }
+            console.error('Erro ao notificar entrada do administrador:', error);
+            return res.status(500).json({ message: 'Erro ao notificar entrada.' });
+        }
+    },
+
+    async downloadAttachment(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                return res.redirect('/login');
+            }
+
+            const attachmentId = Number.parseInt(req.params.attachmentId, 10);
+            const attachment = await getAttachmentById(attachmentId);
+
+            if (!attachment) {
+                return res.status(404).send('Anexo não encontrado.');
+            }
+
+            await ensureTicketAccess(attachment.ticketId, user);
+
+            res.setHeader('Content-Type', attachment.mimeType);
+            res.setHeader('Content-Disposition', `attachment; filename="${attachment.originalName}"`);
+
+            const stream = fileStorageService.createReadStream(attachment.storageKey);
+            stream.on('error', (error) => {
+                console.error('Erro ao enviar anexo do suporte:', error);
+                if (!res.headersSent) {
+                    res.status(500).send('Erro ao enviar arquivo.');
+                }
+            });
+            stream.pipe(res);
+        } catch (error) {
+            console.error('Erro ao fazer download do anexo do suporte:', error);
+            if (!res.headersSent) {
+                res.status(500).send('Erro ao baixar anexo.');
+            }
+        }
+    }
+};
+
+module.exports = supportController;

--- a/src/routes/supportRoutes.js
+++ b/src/routes/supportRoutes.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const multer = require('multer');
+
+const supportController = require('../controllers/supportController');
+const authMiddleware = require('../middlewares/authMiddleware');
+const { constants: chatConstants } = require('../services/supportChatService');
+
+const router = express.Router();
+
+const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: {
+        fileSize: chatConstants.MAX_FILE_SIZE
+    }
+});
+
+router.get('/tickets/:ticketId/chat', authMiddleware, supportController.renderChat);
+router.get('/tickets/:ticketId/history', authMiddleware, supportController.fetchHistory);
+router.post(
+    '/tickets/:ticketId/attachments',
+    authMiddleware,
+    upload.single('file'),
+    supportController.uploadAttachment
+);
+router.post(
+    '/tickets/:ticketId/notify-admin-entry',
+    authMiddleware,
+    supportController.notifyAdminEntry
+);
+router.get(
+    '/attachments/:attachmentId/download',
+    authMiddleware,
+    supportController.downloadAttachment
+);
+
+module.exports = router;

--- a/src/services/supportChatService.js
+++ b/src/services/supportChatService.js
@@ -1,0 +1,414 @@
+const sanitizeHtml = require('sanitize-html');
+const {
+    SupportTicket,
+    SupportMessage,
+    SupportAttachment,
+    Notification
+} = require('../../database/models');
+const { USER_ROLES, getRoleLevel } = require('../constants/roles');
+const fileStorageService = require('./fileStorageService');
+const notificationService = require('./notificationService');
+
+const ALLOWED_MIME_TYPES = [
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'application/pdf'
+];
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const ROOM_PREFIX = 'support:ticket:';
+
+let ioInstance = null;
+
+const getRoomName = (ticketId) => `${ROOM_PREFIX}${ticketId}`;
+
+const sanitizeMessageContent = (value) => {
+    if (!value) {
+        return '';
+    }
+
+    return sanitizeHtml(String(value), {
+        allowedTags: [],
+        allowedAttributes: {},
+        textFilter: (text) => text.trim()
+    }).slice(0, 2000);
+};
+
+const normalizeUserFromSession = (session = {}) => {
+    if (!session || typeof session !== 'object') {
+        return null;
+    }
+
+    const user = session.user || session;
+
+    if (!user || !user.id || !user.active) {
+        return null;
+    }
+
+    return {
+        id: user.id,
+        name: user.name,
+        email: user.email || null,
+        role: user.role,
+        active: user.active
+    };
+};
+
+const ensureSessionUser = (socket) => {
+    const session = socket?.request?.session;
+    const user = normalizeUserFromSession(session);
+
+    if (!user) {
+        const error = new Error('UNAUTHORIZED');
+        error.status = 401;
+        throw error;
+    }
+
+    return user;
+};
+
+const ensureTicketAccess = async (ticketId, user) => {
+    if (!ticketId) {
+        const error = new Error('INVALID_TICKET');
+        error.status = 400;
+        throw error;
+    }
+
+    const ticket = await SupportTicket.findByPk(ticketId);
+
+    if (!ticket) {
+        const error = new Error('TICKET_NOT_FOUND');
+        error.status = 404;
+        throw error;
+    }
+
+    const isOwner = ticket.userId === user.id;
+    const isAdmin = getRoleLevel(user.role) >= getRoleLevel(USER_ROLES.ADMIN);
+
+    if (!isOwner && !isAdmin) {
+        const error = new Error('FORBIDDEN');
+        error.status = 403;
+        throw error;
+    }
+
+    return { ticket, isOwner, isAdmin };
+};
+
+const ensureAdminRole = (user) => {
+    if (getRoleLevel(user.role) < getRoleLevel(USER_ROLES.ADMIN)) {
+        const error = new Error('ADMIN_REQUIRED');
+        error.status = 403;
+        throw error;
+    }
+};
+
+const mapMessageToPayload = (message) => {
+    if (!message) {
+        return null;
+    }
+
+    const attachment = message.attachment
+        ? {
+            id: message.attachment.id,
+            originalName: message.attachment.originalName,
+            mimeType: message.attachment.mimeType,
+            size: message.attachment.size
+        }
+        : null;
+
+    return {
+        id: message.id,
+        ticketId: message.ticketId,
+        senderId: message.senderId,
+        senderRole: message.senderRole,
+        messageType: message.messageType,
+        content: message.content,
+        attachment,
+        createdAt: message.createdAt
+    };
+};
+
+const loadTicketHistory = async (ticketId) => {
+    const messages = await SupportMessage.findAll({
+        where: { ticketId },
+        include: [
+            {
+                model: SupportAttachment,
+                as: 'attachment',
+                required: false
+            }
+        ],
+        order: [['createdAt', 'ASC']]
+    });
+
+    return messages.map(mapMessageToPayload).filter(Boolean);
+};
+
+const listTicketAttachments = async (ticketId) => {
+    const attachments = await SupportAttachment.findAll({
+        where: { ticketId },
+        order: [['createdAt', 'ASC']],
+        attributes: ['id', 'ticketId', 'originalName', 'mimeType', 'size', 'createdAt']
+    });
+
+    return attachments.map((attachment) => attachment.get({ plain: true }));
+};
+
+const persistMessage = async ({
+    ticketId,
+    senderId,
+    senderRole,
+    messageType = 'text',
+    content = null,
+    attachmentId = null,
+    transaction
+}) => {
+    const payload = {
+        ticketId,
+        senderId,
+        senderRole,
+        messageType,
+        content: content ? sanitizeMessageContent(content) : null,
+        attachmentId: attachmentId || null
+    };
+
+    const created = await SupportMessage.create(payload, { transaction });
+
+    if (!created) {
+        throw new Error('FAILED_TO_PERSIST_MESSAGE');
+    }
+
+    const message = await SupportMessage.findByPk(created.id, {
+        include: [
+            {
+                model: SupportAttachment,
+                as: 'attachment',
+                required: false
+            }
+        ],
+        transaction
+    });
+
+    return mapMessageToPayload(message);
+};
+
+const validateAttachmentInput = (file) => {
+    if (!file || !file.buffer) {
+        const error = new Error('INVALID_ATTACHMENT');
+        error.status = 400;
+        throw error;
+    }
+
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+        const error = new Error('UNSUPPORTED_FILE_TYPE');
+        error.status = 415;
+        throw error;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+        const error = new Error('FILE_TOO_LARGE');
+        error.status = 413;
+        throw error;
+    }
+};
+
+const createAttachment = async ({ ticketId, file }) => {
+    validateAttachmentInput(file);
+
+    const stored = await fileStorageService.saveBuffer({
+        buffer: file.buffer,
+        originalName: file.originalname
+    });
+
+    const attachment = await SupportAttachment.create({
+        ticketId,
+        originalName: stored.sanitizedFileName,
+        storageKey: stored.storageKey,
+        mimeType: file.mimetype,
+        size: file.size,
+        checksum: stored.checksum
+    });
+
+    return {
+        id: attachment.id,
+        ticketId: attachment.ticketId,
+        originalName: attachment.originalName,
+        mimeType: attachment.mimeType,
+        size: attachment.size
+    };
+};
+
+const getAttachmentById = async (attachmentId) => {
+    if (!attachmentId) {
+        return null;
+    }
+
+    const attachment = await SupportAttachment.findByPk(attachmentId);
+    return attachment || null;
+};
+
+const notifyAdminJoined = async ({ ticket, adminUser }) => {
+    if (!ticket || !adminUser) {
+        return;
+    }
+
+    const systemContent = `Administrador ${adminUser.name || adminUser.email || 'Admin'} entrou no chat.`;
+    let systemMessage = null;
+
+    try {
+        systemMessage = await persistMessage({
+            ticketId: ticket.id,
+            senderId: adminUser.id,
+            senderRole: adminUser.role,
+            messageType: 'system',
+            content: systemContent
+        });
+
+        if (ioInstance) {
+            ioInstance.to(getRoomName(ticket.id)).emit('support:message', systemMessage);
+        }
+    } catch (error) {
+        console.error('Falha ao registrar mensagem de entrada do admin:', error);
+    }
+
+    try {
+        await Notification.create({
+            title: 'Atendimento em andamento',
+            message: `Um administrador entrou no chat do ticket #${ticket.id}.`,
+            type: 'support',
+            triggerDate: new Date(),
+            active: true,
+            repeatFrequency: 'none',
+            status: 'scheduled',
+            userId: ticket.userId,
+            sendToAll: false,
+            sent: false
+        });
+
+        await notificationService.processNotifications();
+    } catch (error) {
+        console.error('Falha ao acionar notificações do chat de suporte:', error);
+    }
+};
+
+const initializeSupportChat = ({ io, sessionMiddleware }) => {
+    if (!io) {
+        throw new Error('Socket.io instance é obrigatório.');
+    }
+
+    if (!sessionMiddleware || typeof sessionMiddleware !== 'function') {
+        throw new Error('Session middleware é obrigatório para autenticar sockets.');
+    }
+
+    io.use((socket, next) => sessionMiddleware(socket.request, {}, next));
+
+    io.use((socket, next) => {
+        try {
+            const user = ensureSessionUser(socket);
+            socket.data.user = user;
+            return next();
+        } catch (error) {
+            return next(error);
+        }
+    });
+
+    io.on('connection', (socket) => {
+        const joinedTickets = new Set();
+
+        socket.on('support:join', async ({ ticketId, asAdmin }, ack = () => {}) => {
+            try {
+                const user = socket.data.user;
+                const { ticket, isAdmin } = await ensureTicketAccess(ticketId, user);
+
+                if (asAdmin) {
+                    ensureAdminRole(user);
+                }
+
+                const roomName = getRoomName(ticketId);
+                socket.join(roomName);
+                joinedTickets.add(ticketId);
+
+                const history = await loadTicketHistory(ticketId);
+
+                ack({ ok: true, history });
+
+                if (asAdmin && isAdmin && io) {
+                    io.to(roomName).emit('support:agent:online', {
+                        ticketId,
+                        agentId: user.id,
+                        agentName: user.name
+                    });
+                }
+            } catch (error) {
+                ack({ ok: false, error: error.message || 'JOIN_FAILED' });
+            }
+        });
+
+        socket.on('support:message', async (payload, ack = () => {}) => {
+            try {
+                const user = socket.data.user;
+                const { ticketId, content, attachmentId, messageType } = payload || {};
+
+                if (!joinedTickets.has(ticketId)) {
+                    throw new Error('NOT_IN_ROOM');
+                }
+
+                const { ticket } = await ensureTicketAccess(ticketId, user);
+
+                let finalAttachmentId = null;
+                if (attachmentId) {
+                    const attachment = await SupportAttachment.findOne({
+                        where: {
+                            id: attachmentId,
+                            ticketId
+                        }
+                    });
+
+                    if (!attachment) {
+                        throw new Error('ATTACHMENT_NOT_FOUND');
+                    }
+
+                    finalAttachmentId = attachment.id;
+                }
+
+                const persisted = await persistMessage({
+                    ticketId,
+                    senderId: user.id,
+                    senderRole: user.role,
+                    messageType: messageType || (attachmentId ? 'file' : 'text'),
+                    content,
+                    attachmentId: finalAttachmentId
+                });
+
+                io.to(getRoomName(ticketId)).emit('support:message', persisted);
+
+                ack({ ok: true, message: persisted });
+            } catch (error) {
+                ack({ ok: false, error: error.message || 'SEND_FAILED' });
+            }
+        });
+    });
+
+    ioInstance = io;
+};
+
+const getIo = () => ioInstance;
+
+module.exports = {
+    initializeSupportChat,
+    ensureSessionUser,
+    ensureTicketAccess,
+    ensureAdminRole,
+    createAttachment,
+    getAttachmentById,
+    loadTicketHistory,
+    listTicketAttachments,
+    persistMessage,
+    notifyAdminJoined,
+    getIo,
+    constants: {
+        MAX_FILE_SIZE,
+        ALLOWED_MIME_TYPES
+    }
+};

--- a/src/views/support/chat.ejs
+++ b/src/views/support/chat.ejs
@@ -1,0 +1,229 @@
+<%- include('../partials/header') %>
+
+<section class="support-chat-wrapper">
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <aside class="card shadow-sm border-0 h-100 support-chat__sidebar">
+                <div class="card-body p-4 d-flex flex-column gap-3">
+                    <div>
+                        <span class="badge rounded-pill bg-primary-subtle text-primary mb-2">
+                            <i class="bi bi-life-preserver me-1"></i>Chamado #<%= ticket.id %>
+                        </span>
+                        <h1 class="h4 fw-semibold mb-1"><%= ticket.subject %></h1>
+                        <p class="text-muted small mb-0"><%= ticket.description %></p>
+                    </div>
+
+                    <div class="support-chat__status d-flex align-items-center gap-2">
+                        <span class="status-indicator"></span>
+                        <span class="text-uppercase small fw-semibold"><%= ticket.status %></span>
+                    </div>
+
+                    <div>
+                        <h2 class="h6 text-uppercase text-muted fw-semibold mb-3">Anexos do ticket</h2>
+                        <div class="support-chat__attachments" data-support-attachments>
+                            <% if (!attachments || !attachments.length) { %>
+                                <p class="text-muted small mb-0">Nenhum anexo adicionado ainda.</p>
+                            <% } else { %>
+                                <ul class="list-unstyled mb-0 d-flex flex-column gap-2">
+                                    <% attachments.forEach((attachment) => { %>
+                                        <li class="attachment-item d-flex align-items-center gap-3" data-attachment-id="<%= attachment.id %>">
+                                            <span class="attachment-icon bg-primary-subtle text-primary"><i class="bi bi-paperclip"></i></span>
+                                            <div class="flex-grow-1">
+                                                <a
+                                                    class="text-decoration-none fw-semibold"
+                                                    href="/support/attachments/<%= attachment.id %>/download"
+                                                >
+                                                    <%= attachment.originalName %>
+                                                </a>
+                                                <small class="text-muted d-block">Tamanho: <%= (((attachment.size || 0) / 1024).toFixed(1)) %> KB</small>
+                                            </div>
+                                        </li>
+                                    <% }); %>
+                                </ul>
+                            <% } %>
+                        </div>
+                        <form class="mt-3" data-attachment-form>
+                            <label class="form-label text-muted small text-uppercase fw-semibold">Adicionar anexo</label>
+                            <div class="input-group">
+                                <input type="file" class="form-control" name="file" accept="image/*,application/pdf" />
+                                <button class="btn btn-outline-primary" type="submit">
+                                    <i class="bi bi-upload"></i>
+                                </button>
+                            </div>
+                            <small class="text-muted d-block mt-2">Formatos aceitos: PNG, JPG, GIF ou PDF (até 10MB).</small>
+                        </form>
+                    </div>
+                </div>
+            </aside>
+        </div>
+
+        <div class="col-lg-8">
+            <section class="card shadow-sm border-0 h-100 support-chat__panel" data-chat-panel>
+                <div class="card-body d-flex flex-column p-0 h-100">
+                    <header class="support-chat__header px-4 py-3 border-bottom">
+                        <div>
+                            <p class="small text-muted mb-1">Converse em tempo real com nossa equipe de especialistas</p>
+                            <div class="d-flex align-items-center gap-2">
+                                <span class="fw-semibold">Assistente virtual</span>
+                                <span class="badge rounded-pill bg-success-subtle text-success" data-agent-status>
+                                    Aguardando atendente
+                                </span>
+                            </div>
+                        </div>
+                        <button class="btn btn-outline-secondary btn-sm d-none" data-enter-as-admin>
+                            <i class="bi bi-headset me-1"></i>Entrar como administrador
+                        </button>
+                    </header>
+
+                    <div class="support-chat__messages flex-grow-1 position-relative" data-chat-scroll-container>
+                        <div class="chat-empty-state text-center text-muted" data-chat-empty>
+                            <i class="bi bi-chat-dots display-5 d-block mb-3"></i>
+                            <p class="fw-semibold mb-1">Nenhuma mensagem por aqui ainda.</p>
+                            <p class="mb-0">Envie uma mensagem para iniciar a conversa.</p>
+                        </div>
+                        <ul class="list-unstyled p-4 m-0 d-flex flex-column gap-3" data-chat-messages></ul>
+                    </div>
+
+                    <footer class="support-chat__composer border-top px-4 py-3">
+                        <form class="d-flex flex-column flex-lg-row align-items-lg-center gap-3" data-chat-form>
+                            <div class="flex-grow-1 w-100">
+                                <label class="visually-hidden" for="supportChatMessage">Mensagem</label>
+                                <textarea
+                                    id="supportChatMessage"
+                                    class="form-control support-chat__input"
+                                    rows="2"
+                                    placeholder="Digite sua mensagem"
+                                    maxlength="2000"
+                                    required
+                                ></textarea>
+                            </div>
+                            <div class="d-flex gap-2 align-items-center">
+                                <label class="btn btn-light border mb-0" data-chat-upload>
+                                    <i class="bi bi-paperclip"></i>
+                                    <input type="file" name="chatAttachment" accept="image/*,application/pdf" hidden />
+                                </label>
+                                <button type="submit" class="btn btn-gradient">
+                                    <i class="bi bi-send-fill me-1"></i>Enviar
+                                </button>
+                            </div>
+                        </form>
+                    </footer>
+                </div>
+            </section>
+        </div>
+    </div>
+</section>
+
+<script>
+    window.supportChatConfig = {
+        ticketId: <%- JSON.stringify(ticket.id) %>,
+        history: <%- JSON.stringify(history || []) %>,
+        attachments: <%- JSON.stringify(attachments || []) %>,
+        user: <%- JSON.stringify(user ? { id: user.id, name: user.name, role: user.role } : null) %>
+    };
+</script>
+<script src="/socket.io/socket.io.js"></script>
+<script type="module" src="/js/support-chat.js"></script>
+
+<style>
+    .support-chat-wrapper {
+        min-height: 70vh;
+    }
+
+    .support-chat__panel {
+        background: linear-gradient(135deg, #ffffff 0%, #f7f9fc 100%);
+    }
+
+    .support-chat__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .support-chat__messages {
+        background: rgba(248, 249, 252, 0.8);
+        overflow-y: auto;
+    }
+
+    .support-chat__messages::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .support-chat__messages::-webkit-scrollbar-thumb {
+        background: rgba(0, 0, 0, 0.1);
+        border-radius: 999px;
+    }
+
+    .support-chat__message {
+        max-width: 80%;
+        border-radius: 1rem;
+        padding: 0.75rem 1rem;
+        position: relative;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+    }
+
+    .support-chat__message--self {
+        align-self: flex-end;
+        background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+        color: #fff;
+    }
+
+    .support-chat__message--other {
+        align-self: flex-start;
+        background: #ffffff;
+        color: #1f2937;
+    }
+
+    .support-chat__message--system {
+        align-self: center;
+        border-radius: 999px;
+        background: #111827;
+        color: #f8fafc;
+    }
+
+    .support-chat__message small {
+        opacity: 0.8;
+    }
+
+    .support-chat__input {
+        resize: none;
+        border-radius: 1rem;
+    }
+
+    .support-chat__sidebar .attachment-item {
+        background: #f8f9fc;
+        border-radius: 0.75rem;
+        padding: 0.75rem;
+    }
+
+    .support-chat__sidebar .attachment-icon {
+        width: 38px;
+        height: 38px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .support-chat__status .status-indicator {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #22c55e;
+        box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+    }
+
+    @media (max-width: 991px) {
+        .support-chat__message {
+            max-width: 100%;
+        }
+
+        .support-chat__header {
+            flex-direction: column;
+            align-items: flex-start;
+        }
+    }
+</style>
+
+<%- include('../partials/footer') %>

--- a/tests/integration/support/chat.test.js
+++ b/tests/integration/support/chat.test.js
@@ -1,0 +1,227 @@
+process.env.NODE_ENV = 'test';
+
+jest.mock('../../../database/models', () => {
+    const messages = [];
+
+    return {
+        SupportTicket: {
+            findByPk: jest.fn()
+        },
+        SupportMessage: {
+            findAll: jest.fn(),
+            create: jest.fn(async (payload) => {
+                const entry = {
+                    ...payload,
+                    id: messages.length + 1,
+                    createdAt: new Date()
+                };
+                messages.push(entry);
+                return entry;
+            }),
+            findByPk: jest.fn(async (id) => {
+                return messages.find((message) => message.id === id) || null;
+            })
+        },
+        SupportAttachment: {
+            create: jest.fn(async (payload) => ({
+                ...payload,
+                id: Date.now(),
+                createdAt: new Date()
+            })),
+            findAll: jest.fn(),
+            findOne: jest.fn(),
+            findByPk: jest.fn()
+        },
+        Notification: {
+            create: jest.fn(),
+            findAll: jest.fn().mockResolvedValue([]),
+            update: jest.fn()
+        },
+        sequelize: {
+            transaction: async (fn) => fn(),
+            getDialect: () => 'sqlite'
+        }
+    };
+});
+
+const express = require('express');
+const session = require('express-session');
+const http = require('http');
+const request = require('supertest');
+const { Server } = require('socket.io');
+const Client = require('socket.io-client');
+
+const supportChatService = require('../../../src/services/supportChatService');
+const models = require('../../../database/models');
+
+const TEST_TICKET = {
+    id: 101,
+    subject: 'Suporte estratégico',
+    description: 'Precisamos de suporte avançado.',
+    status: 'open',
+    userId: 1,
+    get() {
+        return { ...this };
+    }
+};
+
+describe('Support chat socket handshake', () => {
+    let app;
+    let server;
+    let io;
+    let port;
+    let sessionMiddleware;
+
+    const createClient = (cookies) => {
+        return Client(`http://127.0.0.1:${port}`, {
+            transports: ['websocket'],
+            extraHeaders: {
+                Cookie: cookies.map((cookie) => cookie.split(';')[0]).join('; ')
+            }
+        });
+    };
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+
+        models.SupportTicket.findByPk.mockResolvedValue(TEST_TICKET);
+        models.SupportMessage.findAll.mockResolvedValue([
+            {
+                id: 1,
+                ticketId: TEST_TICKET.id,
+                senderId: TEST_TICKET.userId,
+                senderRole: 'client',
+                messageType: 'text',
+                content: 'Mensagem inicial',
+                attachment: null,
+                createdAt: new Date()
+            }
+        ]);
+        models.SupportAttachment.findAll.mockResolvedValue([]);
+        models.SupportAttachment.findOne.mockResolvedValue(null);
+
+        app = express();
+        app.use(express.json());
+
+        sessionMiddleware = session({
+            secret: 'support-test',
+            resave: false,
+            saveUninitialized: false
+        });
+
+        app.use(sessionMiddleware);
+        app.post('/login', (req, res) => {
+            req.session.user = req.body;
+            res.json({ ok: true });
+        });
+
+        server = http.createServer(app);
+        io = new Server(server, { cors: false });
+        supportChatService.initializeSupportChat({ io, sessionMiddleware });
+
+        await new Promise((resolve) => {
+            server.listen(() => {
+                port = server.address().port;
+                resolve();
+            });
+        });
+    });
+
+    afterEach(async () => {
+        if (io) {
+            io.close();
+        }
+        if (server) {
+            await new Promise((resolve) => server.close(resolve));
+        }
+    });
+
+    it('permite que o solicitante do ticket realize o handshake e receba o histórico', async () => {
+        const agent = request.agent(app);
+        const loginResponse = await agent.post('/login').send({
+            id: TEST_TICKET.userId,
+            name: 'Cliente',
+            role: 'client',
+            active: true
+        });
+
+        const cookies = loginResponse.headers['set-cookie'];
+        expect(cookies).toBeDefined();
+
+        const client = createClient(cookies);
+
+        await new Promise((resolve) => client.on('connect', resolve));
+        const joinAck = await new Promise((resolve) => {
+            client.emit('support:join', { ticketId: TEST_TICKET.id, asAdmin: false }, resolve);
+        });
+
+        expect(joinAck.ok).toBe(true);
+        expect(Array.isArray(joinAck.history)).toBe(true);
+        expect(models.SupportMessage.findAll).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { ticketId: TEST_TICKET.id } })
+        );
+
+        client.close();
+    });
+
+    it('bloqueia usuários sem perfil admin de ingressarem como atendentes', async () => {
+        const agent = request.agent(app);
+        const loginResponse = await agent.post('/login').send({
+            id: TEST_TICKET.userId,
+            name: 'Cliente',
+            role: 'client',
+            active: true
+        });
+
+        const cookies = loginResponse.headers['set-cookie'];
+        const client = createClient(cookies);
+
+        await new Promise((resolve) => client.on('connect', resolve));
+        const joinAck = await new Promise((resolve) => {
+            client.emit('support:join', { ticketId: TEST_TICKET.id, asAdmin: true }, resolve);
+        });
+
+        expect(joinAck.ok).toBe(false);
+        expect(joinAck.error).toBe('ADMIN_REQUIRED');
+
+        client.close();
+    });
+
+    it('registra mensagens ao enviar texto para o chat', async () => {
+        const agent = request.agent(app);
+        const loginResponse = await agent.post('/login').send({
+            id: TEST_TICKET.userId,
+            name: 'Cliente',
+            role: 'client',
+            active: true
+        });
+
+        const cookies = loginResponse.headers['set-cookie'];
+        const client = createClient(cookies);
+
+        await new Promise((resolve) => client.on('connect', resolve));
+        await new Promise((resolve) => {
+            client.emit('support:join', { ticketId: TEST_TICKET.id, asAdmin: false }, resolve);
+        });
+
+        const messageAck = await new Promise((resolve) => {
+            client.emit('support:message', {
+                ticketId: TEST_TICKET.id,
+                content: 'Podem me ajudar?',
+                messageType: 'text'
+            }, resolve);
+        });
+
+        expect(messageAck.ok).toBe(true);
+        expect(models.SupportMessage.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ticketId: TEST_TICKET.id,
+                senderRole: 'client',
+                content: expect.any(String)
+            }),
+            { transaction: undefined }
+        );
+
+        client.close();
+    });
+});


### PR DESCRIPTION
## Summary
- integrate Socket.IO with shared Express sessions and expose support routes for chat access
- add support ticket, message and attachment models plus service logic for message persistence and admin notifications
- deliver a live chat UI with attachments handling and automated Socket.IO integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2b4c7004832fbc474512fbd458a6