### PR TITLE
Update support migrations to camelCase tables

### DIFF
--- a/database/migrations/20240921-create-support-tickets.js
+++ b/database/migrations/20240921-create-support-tickets.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const TABLE_NAME = 'SupportTickets';
-const STATUS_ENUM_NAME = 'enum_SupportTickets_status';
+const TABLE_NAME = 'supportTickets';
+const STATUS_ENUM_NAME = 'enum_supportTickets_status';
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {

--- a/database/migrations/20240922-create-support-messages.js
+++ b/database/migrations/20240922-create-support-messages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const TABLE_NAME = 'SupportMessages';
+const TABLE_NAME = 'supportMessages';
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
@@ -14,7 +14,7 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false,
                 references: {
-                    model: 'SupportTickets',
+                    model: 'supportTickets',
                     key: 'id'
                 },
                 onUpdate: 'CASCADE',

--- a/database/migrations/20240923-create-support-attachments.js
+++ b/database/migrations/20240923-create-support-attachments.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const TABLE_NAME = 'SupportAttachments';
+const TABLE_NAME = 'supportAttachments';
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
@@ -14,7 +14,7 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false,
                 references: {
-                    model: 'SupportTickets',
+                    model: 'supportTickets',
                     key: 'id'
                 },
                 onUpdate: 'CASCADE',
@@ -24,7 +24,7 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false,
                 references: {
-                    model: 'SupportMessages',
+                    model: 'supportMessages',
                     key: 'id'
                 },
                 onUpdate: 'CASCADE',

--- a/database/migrations/20240924-rename-support-tables.js
+++ b/database/migrations/20240924-rename-support-tables.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const PASCAL_TICKET_TABLE = 'SupportTickets';
+const CAMEL_TICKET_TABLE = 'supportTickets';
+const PASCAL_MESSAGE_TABLE = 'SupportMessages';
+const CAMEL_MESSAGE_TABLE = 'supportMessages';
+const PASCAL_ATTACHMENT_TABLE = 'SupportAttachments';
+const CAMEL_ATTACHMENT_TABLE = 'supportAttachments';
+const PASCAL_STATUS_ENUM = 'enum_SupportTickets_status';
+const CAMEL_STATUS_ENUM = 'enum_supportTickets_status';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        const tableExists = async (tableName) => {
+            try {
+                await queryInterface.describeTable(tableName, { transaction });
+                return true;
+            } catch (error) {
+                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
+                    error?.original?.code === 'SQLITE_ERROR' ||
+                    /does not exist/i.test(error?.message ?? '')) {
+                    return false;
+                }
+                throw error;
+            }
+        };
+
+        try {
+            const dialect = queryInterface.sequelize.getDialect();
+
+            if (await tableExists(PASCAL_TICKET_TABLE)) {
+                await queryInterface.renameTable(PASCAL_TICKET_TABLE, CAMEL_TICKET_TABLE, { transaction });
+                if (dialect === 'postgres') {
+                    await queryInterface.sequelize.query(
+                        `ALTER TYPE "${PASCAL_STATUS_ENUM}" RENAME TO "${CAMEL_STATUS_ENUM}";`,
+                        { transaction }
+                    );
+                }
+            }
+
+            if (await tableExists(PASCAL_MESSAGE_TABLE)) {
+                await queryInterface.renameTable(PASCAL_MESSAGE_TABLE, CAMEL_MESSAGE_TABLE, { transaction });
+            }
+
+            if (await tableExists(PASCAL_ATTACHMENT_TABLE)) {
+                await queryInterface.renameTable(PASCAL_ATTACHMENT_TABLE, CAMEL_ATTACHMENT_TABLE, { transaction });
+            }
+
+            if (await tableExists(CAMEL_MESSAGE_TABLE)) {
+                await queryInterface.changeColumn(
+                    CAMEL_MESSAGE_TABLE,
+                    'ticketId',
+                    {
+                        type: Sequelize.INTEGER,
+                        allowNull: false,
+                        references: {
+                            model: CAMEL_TICKET_TABLE,
+                            key: 'id'
+                        },
+                        onUpdate: 'CASCADE',
+                        onDelete: 'CASCADE'
+                    },
+                    { transaction }
+                );
+            }
+
+            if (await tableExists(CAMEL_ATTACHMENT_TABLE)) {
+                await queryInterface.changeColumn(
+                    CAMEL_ATTACHMENT_TABLE,
+                    'ticketId',
+                    {
+                        type: Sequelize.INTEGER,
+                        allowNull: false,
+                        references: {
+                            model: CAMEL_TICKET_TABLE,
+                            key: 'id'
+                        },
+                        onUpdate: 'CASCADE',
+                        onDelete: 'CASCADE'
+                    },
+                    { transaction }
+                );
+
+                await queryInterface.changeColumn(
+                    CAMEL_ATTACHMENT_TABLE,
+                    'messageId',
+                    {
+                        type: Sequelize.INTEGER,
+                        allowNull: false,
+                        references: {
+                            model: CAMEL_MESSAGE_TABLE,
+                            key: 'id'
+                        },
+                        onUpdate: 'CASCADE',
+                        onDelete: 'CASCADE'
+                    },
+                    { transaction }
+                );
+            }
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        const tableExists = async (tableName) => {
+            try {
+                await queryInterface.describeTable(tableName, { transaction });
+                return true;
+            } catch (error) {
+                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
+                    error?.original?.code === 'SQLITE_ERROR' ||
+                    /does not exist/i.test(error?.message ?? '')) {
+                    return false;
+                }
+                throw error;
+            }
+        };
+
+        try {
+            const dialect = queryInterface.sequelize.getDialect();
+
+            if (await tableExists(CAMEL_ATTACHMENT_TABLE)) {
+                await queryInterface.renameTable(CAMEL_ATTACHMENT_TABLE, PASCAL_ATTACHMENT_TABLE, { transaction });
+            }
+
+            if (await tableExists(CAMEL_MESSAGE_TABLE)) {
+                await queryInterface.renameTable(CAMEL_MESSAGE_TABLE, PASCAL_MESSAGE_TABLE, { transaction });
+            }
+
+            if (await tableExists(CAMEL_TICKET_TABLE)) {
+                await queryInterface.renameTable(CAMEL_TICKET_TABLE, PASCAL_TICKET_TABLE, { transaction });
+                if (dialect === 'postgres') {
+                    await queryInterface.sequelize.query(
+                        `ALTER TYPE "${CAMEL_STATUS_ENUM}" RENAME TO "${PASCAL_STATUS_ENUM}";`,
+                        { transaction }
+                    );
+                }
+            }
+
+            if (await tableExists(PASCAL_MESSAGE_TABLE)) {
+                await queryInterface.changeColumn(
+                    PASCAL_MESSAGE_TABLE,
+                    'ticketId',
+                    {
+                        type: Sequelize.INTEGER,
+                        allowNull: false,
+                        references: {
+                            model: PASCAL_TICKET_TABLE,
+                            key: 'id'
+                        },
+                        onUpdate: 'CASCADE',
+                        onDelete: 'CASCADE'
+                    },
+                    { transaction }
+                );
+            }
+
+            if (await tableExists(PASCAL_ATTACHMENT_TABLE)) {
+                await queryInterface.changeColumn(
+                    PASCAL_ATTACHMENT_TABLE,
+                    'ticketId',
+                    {
+                        type: Sequelize.INTEGER,
+                        allowNull: false,
+                        references: {
+                            model: PASCAL_TICKET_TABLE,
+                            key: 'id'
+                        },
+                        onUpdate: 'CASCADE',
+                        onDelete: 'CASCADE'
+                    },
+                    { transaction }
+                );
+
+                await queryInterface.changeColumn(
+                    PASCAL_ATTACHMENT_TABLE,
+                    'messageId',
+                    {
+                        type: Sequelize.INTEGER,
+                        allowNull: false,
+                        references: {
+                            model: PASCAL_MESSAGE_TABLE,
+                            key: 'id'
+                        },
+                        onUpdate: 'CASCADE',
+                        onDelete: 'CASCADE'
+                    },
+                    { transaction }
+                );
+            }
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- update support-related migrations to create camelCase table names and references
- add a follow-up migration that safely renames existing PascalCase tables and adjusts the enum plus foreign keys

## Testing
- NODE_ENV=test npx sequelize-cli db:migrate *(fails: SQLITE_ERROR: no such table: Users)*

------
https://chatgpt.com/codex/tasks/task_e_68cb36e3d004832fba9a6eb298da144b