### PR TITLE
Align support schema migrations with models

### DIFF
--- a/database/migrations/20240921-create-support-tickets.js
+++ b/database/migrations/20240921-create-support-tickets.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const TABLE_NAME = 'SupportTickets';
-const STATUS_ENUM_NAME = 'enum_SupportTickets_status';
+const TABLE_NAME = 'supportTickets';
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
@@ -12,15 +11,19 @@ module.exports = {
                 autoIncrement: true
             },
             subject: {
-                type: Sequelize.STRING(180),
+                type: Sequelize.STRING(150),
+                allowNull: false
+            },
+            description: {
+                type: Sequelize.TEXT,
                 allowNull: false
             },
             status: {
-                type: Sequelize.ENUM('pending', 'in_progress', 'resolved'),
+                type: Sequelize.STRING(20),
                 allowNull: false,
-                defaultValue: 'pending'
+                defaultValue: 'open'
             },
-            creatorId: {
+            userId: {
                 type: Sequelize.INTEGER,
                 allowNull: false,
                 references: {
@@ -29,29 +32,6 @@ module.exports = {
                 },
                 onUpdate: 'CASCADE',
                 onDelete: 'CASCADE'
-            },
-            assignedToId: {
-                type: Sequelize.INTEGER,
-                allowNull: true,
-                references: {
-                    model: 'Users',
-                    key: 'id'
-                },
-                onUpdate: 'CASCADE',
-                onDelete: 'SET NULL'
-            },
-            resolvedAt: {
-                type: Sequelize.DATE,
-                allowNull: true
-            },
-            firstResponseAt: {
-                type: Sequelize.DATE,
-                allowNull: true
-            },
-            lastMessageAt: {
-                type: Sequelize.DATE,
-                allowNull: false,
-                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
             },
             createdAt: {
                 type: Sequelize.DATE,
@@ -66,29 +46,13 @@ module.exports = {
         });
 
         await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_tickets_status_idx',
-            fields: ['status']
-        });
-
-        await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_tickets_creator_idx',
-            fields: ['creatorId']
-        });
-
-        await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_tickets_assignee_idx',
-            fields: ['assignedToId']
+            name: 'supportTickets_userId_status',
+            fields: ['userId', 'status']
         });
     },
 
     down: async (queryInterface) => {
-        await queryInterface.removeIndex(TABLE_NAME, 'support_tickets_assignee_idx');
-        await queryInterface.removeIndex(TABLE_NAME, 'support_tickets_creator_idx');
-        await queryInterface.removeIndex(TABLE_NAME, 'support_tickets_status_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'supportTickets_userId_status');
         await queryInterface.dropTable(TABLE_NAME);
-
-        if (queryInterface.sequelize.getDialect() === 'postgres') {
-            await queryInterface.sequelize.query(`DROP TYPE IF EXISTS "${STATUS_ENUM_NAME}";`);
-        }
     }
 };

--- a/database/migrations/20240922-create-support-messages.js
+++ b/database/migrations/20240922-create-support-messages.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const TABLE_NAME = 'SupportMessages';
+const TABLE_NAME = 'supportMessages';
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
@@ -14,7 +14,7 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false,
                 references: {
-                    model: 'SupportTickets',
+                    model: 'supportTickets',
                     key: 'id'
                 },
                 onUpdate: 'CASCADE',
@@ -30,14 +30,22 @@ module.exports = {
                 onUpdate: 'CASCADE',
                 onDelete: 'CASCADE'
             },
-            body: {
-                type: Sequelize.TEXT,
+            senderRole: {
+                type: Sequelize.STRING(20),
                 allowNull: false
             },
-            isFromAgent: {
-                type: Sequelize.BOOLEAN,
+            messageType: {
+                type: Sequelize.STRING(20),
                 allowNull: false,
-                defaultValue: false
+                defaultValue: 'text'
+            },
+            content: {
+                type: Sequelize.TEXT,
+                allowNull: true
+            },
+            attachmentId: {
+                type: Sequelize.INTEGER,
+                allowNull: true
             },
             createdAt: {
                 type: Sequelize.DATE,
@@ -52,19 +60,25 @@ module.exports = {
         });
 
         await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_messages_ticket_idx',
-            fields: ['ticketId']
+            name: 'supportMessages_ticketId_createdAt',
+            fields: ['ticketId', 'createdAt']
         });
 
         await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_messages_sender_idx',
+            name: 'supportMessages_senderId_idx',
             fields: ['senderId']
+        });
+
+        await queryInterface.addIndex(TABLE_NAME, {
+            name: 'supportMessages_attachmentId_idx',
+            fields: ['attachmentId']
         });
     },
 
     down: async (queryInterface) => {
-        await queryInterface.removeIndex(TABLE_NAME, 'support_messages_sender_idx');
-        await queryInterface.removeIndex(TABLE_NAME, 'support_messages_ticket_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'supportMessages_attachmentId_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'supportMessages_senderId_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'supportMessages_ticketId_createdAt');
         await queryInterface.dropTable(TABLE_NAME);
     }
 };

--- a/database/migrations/20240923-create-support-attachments.js
+++ b/database/migrations/20240923-create-support-attachments.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const TABLE_NAME = 'SupportAttachments';
+const TABLE_NAME = 'supportAttachments';
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
@@ -14,17 +14,7 @@ module.exports = {
                 type: Sequelize.INTEGER,
                 allowNull: false,
                 references: {
-                    model: 'SupportTickets',
-                    key: 'id'
-                },
-                onUpdate: 'CASCADE',
-                onDelete: 'CASCADE'
-            },
-            messageId: {
-                type: Sequelize.INTEGER,
-                allowNull: false,
-                references: {
-                    model: 'SupportMessages',
+                    model: 'supportTickets',
                     key: 'id'
                 },
                 onUpdate: 'CASCADE',
@@ -40,7 +30,7 @@ module.exports = {
                 onUpdate: 'CASCADE',
                 onDelete: 'SET NULL'
             },
-            fileName: {
+            originalName: {
                 type: Sequelize.STRING(255),
                 allowNull: false
             },
@@ -49,16 +39,16 @@ module.exports = {
                 allowNull: false
             },
             checksum: {
-                type: Sequelize.STRING(128),
-                allowNull: true
+                type: Sequelize.STRING(64),
+                allowNull: false
             },
-            contentType: {
+            mimeType: {
                 type: Sequelize.STRING(120),
-                allowNull: true
+                allowNull: false
             },
-            fileSize: {
+            size: {
                 type: Sequelize.BIGINT,
-                allowNull: true
+                allowNull: false
             },
             createdAt: {
                 type: Sequelize.DATE,
@@ -73,25 +63,32 @@ module.exports = {
         });
 
         await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_attachments_ticket_idx',
+            name: 'supportAttachments_ticketId_idx',
             fields: ['ticketId']
         });
 
         await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_attachments_message_idx',
-            fields: ['messageId']
+            name: 'supportAttachments_uploaderId_idx',
+            fields: ['uploadedById']
         });
 
-        await queryInterface.addIndex(TABLE_NAME, {
-            name: 'support_attachments_uploader_idx',
-            fields: ['uploadedById']
+        await queryInterface.addConstraint('supportMessages', {
+            fields: ['attachmentId'],
+            type: 'foreign key',
+            name: 'supportMessages_attachmentId_fkey',
+            references: {
+                table: TABLE_NAME,
+                field: 'id'
+            },
+            onUpdate: 'CASCADE',
+            onDelete: 'SET NULL'
         });
     },
 
     down: async (queryInterface) => {
-        await queryInterface.removeIndex(TABLE_NAME, 'support_attachments_uploader_idx');
-        await queryInterface.removeIndex(TABLE_NAME, 'support_attachments_message_idx');
-        await queryInterface.removeIndex(TABLE_NAME, 'support_attachments_ticket_idx');
+        await queryInterface.removeConstraint('supportMessages', 'supportMessages_attachmentId_fkey');
+        await queryInterface.removeIndex(TABLE_NAME, 'supportAttachments_uploaderId_idx');
+        await queryInterface.removeIndex(TABLE_NAME, 'supportAttachments_ticketId_idx');
         await queryInterface.dropTable(TABLE_NAME);
     }
 };

--- a/database/models/supportAttachment.js
+++ b/database/models/supportAttachment.js
@@ -6,6 +6,10 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.INTEGER,
             allowNull: false
         },
+        uploadedById: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
         originalName: {
             type: DataTypes.STRING(255),
             allowNull: false
@@ -30,21 +34,27 @@ module.exports = (sequelize, DataTypes) => {
         tableName: 'supportAttachments',
         indexes: [
             {
-                name: 'supportAttachments_ticketId',
+                name: 'supportAttachments_ticketId_idx',
                 fields: ['ticketId']
             }
-
         ]
     });
 
     SupportAttachment.associate = (models) => {
-        const { SupportTicket, SupportMessage } = models;
+        const { SupportTicket, SupportMessage, User } = models;
 
         if (SupportTicket) {
             SupportAttachment.belongsTo(SupportTicket, {
                 as: 'ticket',
                 foreignKey: 'ticketId',
                 onDelete: 'CASCADE'
+            });
+        }
+
+        if (User) {
+            SupportAttachment.belongsTo(User, {
+                as: 'uploader',
+                foreignKey: 'uploadedById'
             });
         }
 


### PR DESCRIPTION
## Summary
- update support ticket migration to use the fields expected by the model, including description, userId and a composite index
- realign support message migration with senderRole/content based columns and add attachment index support
- refresh support attachment migration and model to use the new attachment metadata fields and uploader relationship

## Testing
- DB_DIALECT=sqlite DB_STORAGE=tmp/dev.sqlite npx sequelize-cli db:migrate
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb36e4ef9c832f8399375f197e8d61