### PR TITLE
Make support migrations resilient to table naming

### DIFF
--- a/database/migrations/20240921-create-support-tickets.js
+++ b/database/migrations/20240921-create-support-tickets.js
@@ -1,15 +1,70 @@
 'use strict';
 
-const TABLE_NAME = 'supportTickets';
+const DEFAULT_TABLE_NAME = 'supportTickets';
+const CANDIDATE_TABLE_NAMES = Object.freeze(['supportTickets', 'SupportTickets']);
+const SUPPORT_TICKETS_USER_STATUS_INDEX = 'supportTickets_userId_status';
+
+const isTableMissingError = (error) => {
+    const driverCode = error?.original?.code;
+    const message = error?.message ?? '';
+
+    return driverCode === 'ER_NO_SUCH_TABLE' ||
+        driverCode === 'SQLITE_ERROR' ||
+        /does not exist/i.test(message) ||
+        /no such table/i.test(message) ||
+        /unknown table/i.test(message);
+};
+
+const tableExists = async (queryInterface, tableName) => {
+    try {
+        await queryInterface.describeTable(tableName);
+        return true;
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+const resolveExistingTableName = async (queryInterface, candidates) => {
+    for (const name of candidates) {
+        if (await tableExists(queryInterface, name)) {
+            return name;
+        }
+    }
+
+    return null;
+};
+
+const getIndexNames = async (queryInterface, tableName) => {
+    try {
+        const indexes = await queryInterface.showIndex(tableName);
+        return indexes.map((index) => index.name);
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+};
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
-        await queryInterface.createTable(TABLE_NAME, {
-            id: {
-                type: Sequelize.INTEGER,
-                primaryKey: true,
-                autoIncrement: true
-            },
+        const targetTableName = await resolveExistingTableName(
+            queryInterface,
+            CANDIDATE_TABLE_NAMES
+        ) ?? DEFAULT_TABLE_NAME;
+
+        if (!(await tableExists(queryInterface, targetTableName))) {
+            await queryInterface.createTable(targetTableName, {
+                id: {
+                    type: Sequelize.INTEGER,
+                    primaryKey: true,
+                    autoIncrement: true
+                },
             subject: {
                 type: Sequelize.STRING(150),
                 allowNull: false
@@ -44,15 +99,37 @@ module.exports = {
                 defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
             }
         });
+        }
 
-        await queryInterface.addIndex(TABLE_NAME, {
-            name: 'supportTickets_userId_status',
-            fields: ['userId', 'status']
-        });
+        const existingIndexes = await getIndexNames(queryInterface, targetTableName);
+        if (!existingIndexes.includes(SUPPORT_TICKETS_USER_STATUS_INDEX)) {
+            await queryInterface.addIndex(targetTableName, {
+                name: SUPPORT_TICKETS_USER_STATUS_INDEX,
+                fields: ['userId', 'status']
+            });
+        }
     },
 
     down: async (queryInterface) => {
-        await queryInterface.removeIndex(TABLE_NAME, 'supportTickets_userId_status');
-        await queryInterface.dropTable(TABLE_NAME);
+        const targetTableName = await resolveExistingTableName(
+            queryInterface,
+            CANDIDATE_TABLE_NAMES
+        );
+
+        if (!targetTableName) {
+            return;
+        }
+
+        const existingIndexes = await getIndexNames(queryInterface, targetTableName);
+        if (existingIndexes.includes(SUPPORT_TICKETS_USER_STATUS_INDEX)) {
+            await queryInterface.removeIndex(
+                targetTableName,
+                SUPPORT_TICKETS_USER_STATUS_INDEX
+            );
+        }
+
+        if (await tableExists(queryInterface, targetTableName)) {
+            await queryInterface.dropTable(targetTableName);
+        }
     }
 };

--- a/database/migrations/20240923-create-support-attachments.js
+++ b/database/migrations/20240923-create-support-attachments.js
@@ -1,20 +1,91 @@
 'use strict';
 
-const TABLE_NAME = 'supportAttachments';
+const DEFAULT_TABLE_NAME = 'supportAttachments';
+const ATTACHMENT_TABLE_CANDIDATES = Object.freeze(['supportAttachments', 'SupportAttachments']);
+const MESSAGE_TABLE_CANDIDATES = Object.freeze(['supportMessages', 'SupportMessages']);
+const TICKET_TABLE_CANDIDATES = Object.freeze(['supportTickets', 'SupportTickets']);
+const ATTACHMENT_TICKET_INDEX = 'supportAttachments_ticketId_idx';
+const ATTACHMENT_UPLOADER_INDEX = 'supportAttachments_uploaderId_idx';
+const MESSAGE_ATTACHMENT_CONSTRAINT = 'supportMessages_attachmentId_fkey';
+
+const isTableMissingError = (error) => {
+    const driverCode = error?.original?.code;
+    const message = error?.message ?? '';
+
+    return driverCode === 'ER_NO_SUCH_TABLE' ||
+        driverCode === 'SQLITE_ERROR' ||
+        /does not exist/i.test(message) ||
+        /no such table/i.test(message) ||
+        /unknown table/i.test(message);
+};
+
+const tableExists = async (queryInterface, tableName) => {
+    try {
+        await queryInterface.describeTable(tableName);
+        return true;
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+const resolveExistingTableName = async (queryInterface, candidates) => {
+    for (const name of candidates) {
+        if (await tableExists(queryInterface, name)) {
+            return name;
+        }
+    }
+
+    return null;
+};
+
+const getIndexNames = async (queryInterface, tableName) => {
+    try {
+        const indexes = await queryInterface.showIndex(tableName);
+        return indexes.map((index) => index.name);
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+};
+
+const hasConstraint = (constraints, targetName) => {
+    return constraints.some((constraint) => {
+        const constraintName = constraint?.constraintName ?? constraint?.constraint_name;
+        return constraintName === targetName;
+    });
+};
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
-        await queryInterface.createTable(TABLE_NAME, {
-            id: {
-                type: Sequelize.INTEGER,
-                primaryKey: true,
-                autoIncrement: true
-            },
-            ticketId: {
-                type: Sequelize.INTEGER,
-                allowNull: false,
-                references: {
-                    model: 'supportTickets',
+        const ticketTableName = await resolveExistingTableName(
+            queryInterface,
+            TICKET_TABLE_CANDIDATES
+        ) ?? TICKET_TABLE_CANDIDATES[0];
+
+        const targetTableName = await resolveExistingTableName(
+            queryInterface,
+            ATTACHMENT_TABLE_CANDIDATES
+        ) ?? DEFAULT_TABLE_NAME;
+
+        if (!(await tableExists(queryInterface, targetTableName))) {
+            await queryInterface.createTable(targetTableName, {
+                id: {
+                    type: Sequelize.INTEGER,
+                    primaryKey: true,
+                    autoIncrement: true
+                },
+                ticketId: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    references: {
+                    model: ticketTableName,
                     key: 'id'
                 },
                 onUpdate: 'CASCADE',
@@ -61,34 +132,97 @@ module.exports = {
                 defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
             }
         });
+        }
 
-        await queryInterface.addIndex(TABLE_NAME, {
-            name: 'supportAttachments_ticketId_idx',
-            fields: ['ticketId']
-        });
+        const existingIndexes = await getIndexNames(queryInterface, targetTableName);
 
-        await queryInterface.addIndex(TABLE_NAME, {
-            name: 'supportAttachments_uploaderId_idx',
-            fields: ['uploadedById']
-        });
+        if (!existingIndexes.includes(ATTACHMENT_TICKET_INDEX)) {
+            await queryInterface.addIndex(targetTableName, {
+                name: ATTACHMENT_TICKET_INDEX,
+                fields: ['ticketId']
+            });
+        }
 
-        await queryInterface.addConstraint('supportMessages', {
-            fields: ['attachmentId'],
-            type: 'foreign key',
-            name: 'supportMessages_attachmentId_fkey',
-            references: {
-                table: TABLE_NAME,
-                field: 'id'
-            },
-            onUpdate: 'CASCADE',
-            onDelete: 'SET NULL'
-        });
+        if (!existingIndexes.includes(ATTACHMENT_UPLOADER_INDEX)) {
+            await queryInterface.addIndex(targetTableName, {
+                name: ATTACHMENT_UPLOADER_INDEX,
+                fields: ['uploadedById']
+            });
+        }
+
+        const messageTableName = await resolveExistingTableName(
+            queryInterface,
+            MESSAGE_TABLE_CANDIDATES
+        );
+
+        if (messageTableName && await tableExists(queryInterface, messageTableName)) {
+            const constraints = await queryInterface.getForeignKeyReferencesForTable(messageTableName);
+
+            if (!hasConstraint(constraints, MESSAGE_ATTACHMENT_CONSTRAINT)) {
+                await queryInterface.addConstraint(messageTableName, {
+                    fields: ['attachmentId'],
+                    type: 'foreign key',
+                    name: MESSAGE_ATTACHMENT_CONSTRAINT,
+                    references: {
+                        table: targetTableName,
+                        field: 'id'
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'SET NULL'
+                });
+            }
+        }
     },
 
     down: async (queryInterface) => {
-        await queryInterface.removeConstraint('supportMessages', 'supportMessages_attachmentId_fkey');
-        await queryInterface.removeIndex(TABLE_NAME, 'supportAttachments_uploaderId_idx');
-        await queryInterface.removeIndex(TABLE_NAME, 'supportAttachments_ticketId_idx');
-        await queryInterface.dropTable(TABLE_NAME);
+        const targetTableName = await resolveExistingTableName(
+            queryInterface,
+            ATTACHMENT_TABLE_CANDIDATES
+        );
+
+        const messageTableName = await resolveExistingTableName(
+            queryInterface,
+            MESSAGE_TABLE_CANDIDATES
+        );
+
+        if (messageTableName && await tableExists(queryInterface, messageTableName)) {
+            try {
+                const constraints = await queryInterface.getForeignKeyReferencesForTable(messageTableName);
+                if (hasConstraint(constraints, MESSAGE_ATTACHMENT_CONSTRAINT)) {
+                    await queryInterface.removeConstraint(
+                        messageTableName,
+                        MESSAGE_ATTACHMENT_CONSTRAINT
+                    );
+                }
+            } catch (error) {
+                if (!isTableMissingError(error)) {
+                    throw error;
+                }
+            }
+        }
+
+        if (!targetTableName) {
+            return;
+        }
+
+        const existingIndexes = await getIndexNames(queryInterface, targetTableName);
+
+        if (existingIndexes.includes(ATTACHMENT_UPLOADER_INDEX)) {
+            await queryInterface.removeIndex(
+                targetTableName,
+                ATTACHMENT_UPLOADER_INDEX
+            );
+        }
+
+        if (existingIndexes.includes(ATTACHMENT_TICKET_INDEX)) {
+            await queryInterface.removeIndex(
+                targetTableName,
+                ATTACHMENT_TICKET_INDEX
+            );
+        }
+
+        if (await tableExists(queryInterface, targetTableName)) {
+            await queryInterface.dropTable(targetTableName);
+        }
     }
 };


### PR DESCRIPTION
## Summary
- add table name resolution helpers to support ticket, message and attachment migrations
- guard table/index/constraint creation and removal so migrations handle legacy casing differences

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb3b7ffd18832fbd7f83c26bf09284