### PR TITLE
Refine support ticket schema and associations

### DIFF
--- a/database/migrations/20240926-update-support-tickets-structure.js
+++ b/database/migrations/20240926-update-support-tickets-structure.js
@@ -1,0 +1,343 @@
+'use strict';
+
+const TICKET_TABLE_CANDIDATES = Object.freeze(['supportTickets', 'SupportTickets']);
+const USER_TABLE = 'Users';
+const OLD_STATUS_INDEX = 'supportTickets_userId_status';
+const NEW_STATUS_INDEX = 'supportTickets_creatorId_status';
+const ASSIGNEE_STATUS_INDEX = 'supportTickets_assignedTo_status';
+
+const isTableMissingError = (error) => {
+    const driverCode = error?.original?.code;
+    const message = error?.message ?? '';
+
+    return driverCode === 'ER_NO_SUCH_TABLE' ||
+        driverCode === 'SQLITE_ERROR' ||
+        /does not exist/i.test(message) ||
+        /no such table/i.test(message) ||
+        /unknown table/i.test(message);
+};
+
+const tableExists = async (queryInterface, tableName) => {
+    try {
+        await queryInterface.describeTable(tableName);
+        return true;
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+const resolveExistingTableName = async (queryInterface, candidates) => {
+    for (const name of candidates) {
+        if (await tableExists(queryInterface, name)) {
+            return name;
+        }
+    }
+
+    return null;
+};
+
+const columnExists = async (queryInterface, tableName, columnName) => {
+    try {
+        const description = await queryInterface.describeTable(tableName);
+        return Object.prototype.hasOwnProperty.call(description, columnName);
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+};
+
+const getIndexNames = async (queryInterface, tableName) => {
+    try {
+        const indexes = await queryInterface.showIndex(tableName);
+        return indexes.map((index) => index.name);
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+};
+
+const dropIndexIfExists = async (queryInterface, tableName, indexName) => {
+    const indexes = await getIndexNames(queryInterface, tableName);
+    if (indexes.includes(indexName)) {
+        await queryInterface.removeIndex(tableName, indexName);
+    }
+};
+
+const quoteIdentifier = (queryInterface, identifier) => {
+    if (typeof queryInterface.quoteIdentifier === 'function') {
+        return queryInterface.quoteIdentifier(identifier);
+    }
+
+    const qi = queryInterface.sequelize?.getQueryInterface?.();
+    if (qi?.queryGenerator?.quoteIdentifier) {
+        return qi.queryGenerator.quoteIdentifier(identifier);
+    }
+
+    return `\`${identifier.replace(/`/g, '``')}\``;
+};
+
+const addUserForeignKey = async (queryInterface, tableName, column, options = {}) => {
+    const constraintName = `${tableName}_${column}_fkey`;
+    const constraints = await queryInterface.getForeignKeyReferencesForTable(tableName, options);
+    const alreadyExists = constraints.some((constraint) => constraint.columnName === column);
+
+    if (!alreadyExists) {
+        await queryInterface.addConstraint(tableName, {
+            fields: [column],
+            type: 'foreign key',
+            name: constraintName,
+            references: {
+                table: USER_TABLE,
+                field: 'id'
+            },
+            onUpdate: 'CASCADE',
+            onDelete: options.onDelete ?? 'CASCADE'
+        }, options);
+    }
+};
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const tableName = await resolveExistingTableName(queryInterface, TICKET_TABLE_CANDIDATES);
+        if (!tableName) {
+            return;
+        }
+
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            const dialect = queryInterface.sequelize.getDialect();
+            const quotedTable = quoteIdentifier(queryInterface, tableName);
+
+            if (!await columnExists(queryInterface, tableName, 'creatorId')) {
+                await queryInterface.addColumn(tableName, 'creatorId', {
+                    type: Sequelize.INTEGER,
+                    allowNull: dialect === 'sqlite'
+                }, { transaction });
+            }
+
+            if (!await columnExists(queryInterface, tableName, 'assignedToId')) {
+                await queryInterface.addColumn(tableName, 'assignedToId', {
+                    type: Sequelize.INTEGER,
+                    allowNull: true
+                }, { transaction });
+            }
+
+            if (!await columnExists(queryInterface, tableName, 'lastMessageAt')) {
+                await queryInterface.addColumn(tableName, 'lastMessageAt', {
+                    type: Sequelize.DATE,
+                    allowNull: true
+                }, { transaction });
+            }
+
+            if (!await columnExists(queryInterface, tableName, 'firstResponseAt')) {
+                await queryInterface.addColumn(tableName, 'firstResponseAt', {
+                    type: Sequelize.DATE,
+                    allowNull: true
+                }, { transaction });
+            }
+
+            if (!await columnExists(queryInterface, tableName, 'resolvedAt')) {
+                await queryInterface.addColumn(tableName, 'resolvedAt', {
+                    type: Sequelize.DATE,
+                    allowNull: true
+                }, { transaction });
+            }
+
+            const quotedStatus = quoteIdentifier(queryInterface, 'status');
+
+            const statusTransitions = [
+                { from: ['open'], to: 'pending' },
+                { from: ['waiting'], to: 'in_progress' },
+                { from: ['closed'], to: 'resolved' }
+            ];
+
+            for (const transition of statusTransitions) {
+                const values = transition.from.map((value) => `'${value}'`).join(', ');
+                await queryInterface.sequelize.query(
+                    `UPDATE ${quotedTable} SET ${quotedStatus} = '${transition.to}' WHERE ${quotedStatus} IN (${values});`,
+                    { transaction }
+                );
+            }
+
+            if (await columnExists(queryInterface, tableName, 'userId')) {
+                const quotedCreator = quoteIdentifier(queryInterface, 'creatorId');
+                const quotedUser = quoteIdentifier(queryInterface, 'userId');
+
+                await queryInterface.sequelize.query(
+                    `UPDATE ${quotedTable} SET ${quotedCreator} = ${quotedUser} WHERE ${quotedCreator} IS NULL AND ${quotedUser} IS NOT NULL;`,
+                    { transaction }
+                );
+            }
+
+            if (dialect !== 'sqlite') {
+                await queryInterface.changeColumn(tableName, 'creatorId', {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    references: {
+                        model: USER_TABLE,
+                        key: 'id'
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'CASCADE'
+                }, { transaction });
+            }
+
+            await addUserForeignKey(queryInterface, tableName, 'creatorId', {
+                onDelete: 'CASCADE',
+                transaction
+            });
+            await addUserForeignKey(queryInterface, tableName, 'assignedToId', {
+                onDelete: 'SET NULL',
+                transaction
+            });
+
+            await dropIndexIfExists(queryInterface, tableName, OLD_STATUS_INDEX);
+
+            const existingIndexes = await getIndexNames(queryInterface, tableName);
+            if (!existingIndexes.includes(NEW_STATUS_INDEX)) {
+                await queryInterface.addIndex(tableName, {
+                    name: NEW_STATUS_INDEX,
+                    fields: ['creatorId', 'status']
+                }, { transaction });
+            }
+
+            if (!existingIndexes.includes(ASSIGNEE_STATUS_INDEX)) {
+                await queryInterface.addIndex(tableName, {
+                    name: ASSIGNEE_STATUS_INDEX,
+                    fields: ['assignedToId', 'status']
+                }, { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'description')) {
+                await queryInterface.removeColumn(tableName, 'description', { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'userId')) {
+                await queryInterface.removeColumn(tableName, 'userId', { transaction });
+            }
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        const tableName = await resolveExistingTableName(queryInterface, TICKET_TABLE_CANDIDATES);
+        if (!tableName) {
+            return;
+        }
+
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            const dialect = queryInterface.sequelize.getDialect();
+            const quotedTable = quoteIdentifier(queryInterface, tableName);
+
+            await dropIndexIfExists(queryInterface, tableName, NEW_STATUS_INDEX);
+            await dropIndexIfExists(queryInterface, tableName, ASSIGNEE_STATUS_INDEX);
+
+            if (!await columnExists(queryInterface, tableName, 'description')) {
+                await queryInterface.addColumn(tableName, 'description', {
+                    type: Sequelize.TEXT,
+                    allowNull: true
+                }, { transaction });
+            }
+
+            if (!await columnExists(queryInterface, tableName, 'userId')) {
+                await queryInterface.addColumn(tableName, 'userId', {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                    references: {
+                        model: USER_TABLE,
+                        key: 'id'
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'CASCADE'
+                }, { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'creatorId')) {
+                const quotedCreator = quoteIdentifier(queryInterface, 'creatorId');
+                const quotedUser = quoteIdentifier(queryInterface, 'userId');
+
+                await queryInterface.sequelize.query(
+                    `UPDATE ${quotedTable} SET ${quotedUser} = ${quotedCreator} WHERE ${quotedUser} IS NULL AND ${quotedCreator} IS NOT NULL;`,
+                    { transaction }
+                );
+            }
+
+            const quotedStatus = quoteIdentifier(queryInterface, 'status');
+            const statusRollback = [
+                { from: ['pending'], to: 'open' },
+                { from: ['in_progress'], to: 'waiting' }
+            ];
+
+            for (const transition of statusRollback) {
+                const values = transition.from.map((value) => `'${value}'`).join(', ');
+                await queryInterface.sequelize.query(
+                    `UPDATE ${quotedTable} SET ${quotedStatus} = '${transition.to}' WHERE ${quotedStatus} IN (${values});`,
+                    { transaction }
+                );
+            }
+
+            if (dialect !== 'sqlite') {
+                await queryInterface.changeColumn(tableName, 'userId', {
+                    type: Sequelize.INTEGER,
+                    allowNull: false,
+                    references: {
+                        model: USER_TABLE,
+                        key: 'id'
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'CASCADE'
+                }, { transaction });
+            }
+
+            const indexes = await getIndexNames(queryInterface, tableName);
+            if (!indexes.includes(OLD_STATUS_INDEX)) {
+                await queryInterface.addIndex(tableName, {
+                    name: OLD_STATUS_INDEX,
+                    fields: ['userId', 'status']
+                }, { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'resolvedAt')) {
+                await queryInterface.removeColumn(tableName, 'resolvedAt', { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'firstResponseAt')) {
+                await queryInterface.removeColumn(tableName, 'firstResponseAt', { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'lastMessageAt')) {
+                await queryInterface.removeColumn(tableName, 'lastMessageAt', { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'assignedToId')) {
+                await queryInterface.removeColumn(tableName, 'assignedToId', { transaction });
+            }
+
+            if (await columnExists(queryInterface, tableName, 'creatorId')) {
+                await queryInterface.removeColumn(tableName, 'creatorId', { transaction });
+            }
+
+            await transaction.commit();
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    }
+};

--- a/database/models/index.js
+++ b/database/models/index.js
@@ -182,10 +182,22 @@ if (FinanceEntry && FinanceCategory && !(FinanceEntry.associations && FinanceEnt
     });
 }
 
-if (SupportTicket && User && !(SupportTicket.associations && SupportTicket.associations.requester)) {
+if (SupportTicket && User && !(SupportTicket.associations && SupportTicket.associations.creator)) {
     SupportTicket.belongsTo(User, {
-        as: 'requester',
-        foreignKey: 'userId'
+        as: 'creator',
+        foreignKey: 'creatorId',
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE'
+    });
+}
+
+if (SupportTicket && User && !(SupportTicket.associations && SupportTicket.associations.assignee)) {
+    SupportTicket.belongsTo(User, {
+        as: 'assignee',
+        foreignKey: 'assignedToId',
+        constraints: false,
+        onDelete: 'SET NULL',
+        onUpdate: 'CASCADE'
     });
 }
 

--- a/database/models/supportTicket.js
+++ b/database/models/supportTicket.js
@@ -9,28 +9,50 @@ module.exports = (sequelize, DataTypes) => {
                 len: [3, 150]
             }
         },
-        description: {
-            type: DataTypes.TEXT,
-            allowNull: false
-        },
         status: {
             type: DataTypes.STRING(20),
             allowNull: false,
-            defaultValue: 'open',
+            defaultValue: 'pending',
             validate: {
-                isIn: [['open', 'waiting', 'resolved', 'closed']]
+                isIn: [['pending', 'in_progress', 'resolved']]
             }
         },
-        userId: {
+        creatorId: {
             type: DataTypes.INTEGER,
-            allowNull: false
+            allowNull: false,
+            validate: {
+                isInt: true
+            }
+        },
+        assignedToId: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            validate: {
+                isInt: true
+            }
+        },
+        lastMessageAt: {
+            type: DataTypes.DATE,
+            allowNull: true
+        },
+        firstResponseAt: {
+            type: DataTypes.DATE,
+            allowNull: true
+        },
+        resolvedAt: {
+            type: DataTypes.DATE,
+            allowNull: true
         }
     }, {
         tableName: 'supportTickets',
         indexes: [
             {
-                name: 'supportTickets_userId_status',
-                fields: ['userId', 'status']
+                name: 'supportTickets_creatorId_status',
+                fields: ['creatorId', 'status']
+            },
+            {
+                name: 'supportTickets_assignedTo_status',
+                fields: ['assignedToId', 'status']
             }
         ]
     });
@@ -40,8 +62,17 @@ module.exports = (sequelize, DataTypes) => {
 
         if (User) {
             SupportTicket.belongsTo(User, {
-                as: 'requester',
-                foreignKey: 'userId'
+                as: 'creator',
+                foreignKey: 'creatorId',
+                onDelete: 'CASCADE',
+                onUpdate: 'CASCADE'
+            });
+
+            SupportTicket.belongsTo(User, {
+                as: 'assignee',
+                foreignKey: 'assignedToId',
+                onDelete: 'SET NULL',
+                onUpdate: 'CASCADE'
             });
         }
 

--- a/src/services/supportChatService.js
+++ b/src/services/supportChatService.js
@@ -83,7 +83,7 @@ const ensureTicketAccess = async (ticketId, user) => {
         throw error;
     }
 
-    const isOwner = ticket.userId === user.id;
+    const isOwner = ticket.creatorId === user.id;
     const isAdmin = getRoleLevel(user.role) >= getRoleLevel(USER_ROLES.ADMIN);
 
     if (!isOwner && !isAdmin) {
@@ -281,7 +281,7 @@ const notifyAdminJoined = async ({ ticket, adminUser }) => {
             active: true,
             repeatFrequency: 'none',
             status: 'scheduled',
-            userId: ticket.userId,
+            userId: ticket.creatorId,
             sendToAll: false,
             sent: false
         });

--- a/src/views/support/chat.ejs
+++ b/src/views/support/chat.ejs
@@ -10,7 +10,17 @@
                             <i class="bi bi-life-preserver me-1"></i>Chamado #<%= ticket.id %>
                         </span>
                         <h1 class="h4 fw-semibold mb-1"><%= ticket.subject %></h1>
-                        <p class="text-muted small mb-0"><%= ticket.description %></p>
+                        <% const initialMessage = Array.isArray(history) && history.length ? history[0].content : null; %>
+                        <% if (initialMessage) { %>
+                            <p class="text-muted small mb-0"><%= initialMessage %></p>
+                        <% } else if (ticket.lastMessageAt) { %>
+                            <p class="text-muted small mb-0">
+                                Última interação em
+                                <%= new Date(ticket.lastMessageAt).toLocaleString('pt-BR', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' }) %>
+                            </p>
+                        <% } else { %>
+                            <p class="text-muted small mb-0">Aguardando primeira mensagem.</p>
+                        <% } %>
                     </div>
 
                     <div class="support-chat__status d-flex align-items-center gap-2">

--- a/src/views/support/listTickets.ejs
+++ b/src/views/support/listTickets.ejs
@@ -78,9 +78,10 @@
                                     </td>
                                     <% if (isAdmin) { %>
                                         <td>
-                                            <% if (ticket.requester) { %>
-                                                <div class="fw-semibold"><%= ticket.requester.name || 'Usuário' %></div>
-                                                <small class="text-muted"><%= ticket.requester.email %></small>
+                                            <% const ticketOwner = ticket.creator || ticket.requester; %>
+                                            <% if (ticketOwner) { %>
+                                                <div class="fw-semibold"><%= ticketOwner.name || 'Usuário' %></div>
+                                                <small class="text-muted"><%= ticketOwner.email %></small>
                                             <% } else { %>
                                                 <span class="text-muted">Não informado</span>
                                             <% } %>

--- a/src/views/support/ticketDetail.ejs
+++ b/src/views/support/ticketDetail.ejs
@@ -42,19 +42,28 @@
                 <div class="card-body p-4 p-lg-5">
                     <h2 class="h4 fw-semibold mb-3">Detalhes do chamado</h2>
                     <p class="lead text-body-secondary mb-4"><%= ticketSafe.subject %></p>
-                    <article class="prose">
-                        <% (ticketSafe.description || '').split(/\n+/).forEach((paragraph) => { %>
-                            <% if (paragraph.trim()) { %>
-                                <p class="text-body"><%= paragraph %></p>
-                            <% } %>
-                        <% }); %>
-                    </article>
+                    <% const descriptionText = ticketSafe.description || ticketSafe.initialMessage || ''; %>
+                    <% if (descriptionText) { %>
+                        <article class="prose">
+                            <% descriptionText.split(/\n+/).forEach((paragraph) => { %>
+                                <% if (paragraph.trim()) { %>
+                                    <p class="text-body"><%= paragraph %></p>
+                                <% } %>
+                            <% }); %>
+                        </article>
+                    <% } else { %>
+                        <div class="alert alert-info mt-3" role="alert">
+                            <i class="bi bi-info-circle me-2"></i>
+                            Nenhum detalhamento inicial disponível. Consulte o histórico de mensagens para mais informações.
+                        </div>
+                    <% } %>
 
-                    <% if (ticketSafe.requester && isAdmin) { %>
+                    <% const ticketOwner = ticketSafe.creator || ticketSafe.requester; %>
+                    <% if (ticketOwner && isAdmin) { %>
                         <div class="mt-4 p-3 rounded-4 bg-body-tertiary">
                             <h3 class="h6 text-uppercase text-muted mb-2">Solicitante</h3>
-                            <div class="fw-semibold"><%= ticketSafe.requester.name || 'Usuário' %></div>
-                            <div class="text-muted small"><%= ticketSafe.requester.email %></div>
+                            <div class="fw-semibold"><%= ticketOwner.name || 'Usuário' %></div>
+                            <div class="text-muted small"><%= ticketOwner.email %></div>
                         </div>
                     <% } %>
                 </div>

--- a/tests/integration/support/chat.test.js
+++ b/tests/integration/support/chat.test.js
@@ -58,8 +58,8 @@ const TEST_TICKET = {
     id: 101,
     subject: 'Suporte estratégico',
     description: 'Precisamos de suporte avançado.',
-    status: 'open',
-    userId: 1,
+    status: 'pending',
+    creatorId: 1,
     get() {
         return { ...this };
     }
@@ -89,7 +89,7 @@ describe('Support chat socket handshake', () => {
             {
                 id: 1,
                 ticketId: TEST_TICKET.id,
-                senderId: TEST_TICKET.userId,
+                senderId: TEST_TICKET.creatorId,
                 senderRole: 'client',
                 messageType: 'text',
                 content: 'Mensagem inicial',
@@ -139,7 +139,7 @@ describe('Support chat socket handshake', () => {
     it('permite que o solicitante do ticket realize o handshake e receba o histórico', async () => {
         const agent = request.agent(app);
         const loginResponse = await agent.post('/login').send({
-            id: TEST_TICKET.userId,
+            id: TEST_TICKET.creatorId,
             name: 'Cliente',
             role: 'client',
             active: true
@@ -167,7 +167,7 @@ describe('Support chat socket handshake', () => {
     it('bloqueia usuários sem perfil admin de ingressarem como atendentes', async () => {
         const agent = request.agent(app);
         const loginResponse = await agent.post('/login').send({
-            id: TEST_TICKET.userId,
+            id: TEST_TICKET.creatorId,
             name: 'Cliente',
             role: 'client',
             active: true
@@ -190,7 +190,7 @@ describe('Support chat socket handshake', () => {
     it('registra mensagens ao enviar texto para o chat', async () => {
         const agent = request.agent(app);
         const loginResponse = await agent.post('/login').send({
-            id: TEST_TICKET.userId,
+            id: TEST_TICKET.creatorId,
             name: 'Cliente',
             role: 'client',
             active: true


### PR DESCRIPTION
## Summary
- restructure the supportTickets table with creator/assignee references, lifecycle timestamps, and status normalization
- expose the new attributes and indexes through the SupportTicket model and centralized associations
- update chat flows, UI templates, and integration tests to target the creator instead of the legacy userId field

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb3fb43110832fb0a9fefb535cc740