### PR TITLE
Atualiza anexos de suporte para relacionar mensagens

### DIFF
--- a/database/migrations/20240924-rename-support-tables.js
+++ b/database/migrations/20240924-rename-support-tables.js
@@ -27,6 +27,20 @@ module.exports = {
             }
         };
 
+        const columnExists = async (tableName, columnName) => {
+            try {
+                const definition = await queryInterface.describeTable(tableName, { transaction });
+                return Boolean(definition?.[columnName]);
+            } catch (error) {
+                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
+                    error?.original?.code === 'SQLITE_ERROR' ||
+                    /does not exist/i.test(error?.message ?? '')) {
+                    return false;
+                }
+                throw error;
+            }
+        };
+
         try {
             const dialect = queryInterface.sequelize.getDialect();
 
@@ -83,21 +97,23 @@ module.exports = {
                     { transaction }
                 );
 
-                await queryInterface.changeColumn(
-                    CAMEL_ATTACHMENT_TABLE,
-                    'messageId',
-                    {
-                        type: Sequelize.INTEGER,
-                        allowNull: false,
-                        references: {
-                            model: CAMEL_MESSAGE_TABLE,
-                            key: 'id'
+                if (await columnExists(CAMEL_ATTACHMENT_TABLE, 'messageId')) {
+                    await queryInterface.changeColumn(
+                        CAMEL_ATTACHMENT_TABLE,
+                        'messageId',
+                        {
+                            type: Sequelize.INTEGER,
+                            allowNull: true,
+                            references: {
+                                model: CAMEL_MESSAGE_TABLE,
+                                key: 'id'
+                            },
+                            onUpdate: 'CASCADE',
+                            onDelete: 'CASCADE'
                         },
-                        onUpdate: 'CASCADE',
-                        onDelete: 'CASCADE'
-                    },
-                    { transaction }
-                );
+                        { transaction }
+                    );
+                }
             }
 
             await transaction.commit();
@@ -114,6 +130,20 @@ module.exports = {
             try {
                 await queryInterface.describeTable(tableName, { transaction });
                 return true;
+            } catch (error) {
+                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
+                    error?.original?.code === 'SQLITE_ERROR' ||
+                    /does not exist/i.test(error?.message ?? '')) {
+                    return false;
+                }
+                throw error;
+            }
+        };
+
+        const columnExists = async (tableName, columnName) => {
+            try {
+                const definition = await queryInterface.describeTable(tableName, { transaction });
+                return Boolean(definition?.[columnName]);
             } catch (error) {
                 if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
                     error?.original?.code === 'SQLITE_ERROR' ||
@@ -180,21 +210,23 @@ module.exports = {
                     { transaction }
                 );
 
-                await queryInterface.changeColumn(
-                    PASCAL_ATTACHMENT_TABLE,
-                    'messageId',
-                    {
-                        type: Sequelize.INTEGER,
-                        allowNull: false,
-                        references: {
-                            model: PASCAL_MESSAGE_TABLE,
-                            key: 'id'
+                if (await columnExists(PASCAL_ATTACHMENT_TABLE, 'messageId')) {
+                    await queryInterface.changeColumn(
+                        PASCAL_ATTACHMENT_TABLE,
+                        'messageId',
+                        {
+                            type: Sequelize.INTEGER,
+                            allowNull: true,
+                            references: {
+                                model: PASCAL_MESSAGE_TABLE,
+                                key: 'id'
+                            },
+                            onUpdate: 'CASCADE',
+                            onDelete: 'CASCADE'
                         },
-                        onUpdate: 'CASCADE',
-                        onDelete: 'CASCADE'
-                    },
-                    { transaction }
-                );
+                        { transaction }
+                    );
+                }
             }
 
             await transaction.commit();

--- a/database/migrations/20240926-update-support-attachment-columns.js
+++ b/database/migrations/20240926-update-support-attachment-columns.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const ATTACHMENT_TABLE_CANDIDATES = Object.freeze(['supportAttachments', 'SupportAttachments']);
+const MESSAGE_TABLE_CANDIDATES = Object.freeze(['supportMessages', 'SupportMessages']);
+const MESSAGE_ID_INDEX = 'supportAttachments_messageId_idx';
+
+const isTableMissingError = (error) => {
+    const driverCode = error?.original?.code;
+    const message = error?.message ?? '';
+
+    return driverCode === 'ER_NO_SUCH_TABLE' ||
+        driverCode === 'SQLITE_ERROR' ||
+        /does not exist/i.test(message) ||
+        /no such table/i.test(message) ||
+        /unknown table/i.test(message);
+};
+
+const describeTable = async (queryInterface, tableName) => {
+    try {
+        return await queryInterface.describeTable(tableName);
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return null;
+        }
+
+        throw error;
+    }
+};
+
+const resolveExistingTableName = async (queryInterface, candidates) => {
+    for (const name of candidates) {
+        if (await describeTable(queryInterface, name)) {
+            return name;
+        }
+    }
+
+    return null;
+};
+
+const columnExists = async (queryInterface, tableName, columnName) => {
+    const definition = await describeTable(queryInterface, tableName);
+    return Boolean(definition?.[columnName]);
+};
+
+const getIndexNames = async (queryInterface, tableName) => {
+    try {
+        const indexes = await queryInterface.showIndex(tableName);
+        return indexes.map((index) => index.name);
+    } catch (error) {
+        if (isTableMissingError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+};
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const attachmentTableName = await resolveExistingTableName(
+            queryInterface,
+            ATTACHMENT_TABLE_CANDIDATES
+        );
+
+        if (!attachmentTableName) {
+            return;
+        }
+
+        const messageTableName = await resolveExistingTableName(
+            queryInterface,
+            MESSAGE_TABLE_CANDIDATES
+        );
+
+        if (!(await columnExists(queryInterface, attachmentTableName, 'messageId'))) {
+            const columnDefinition = {
+                type: Sequelize.INTEGER,
+                allowNull: true
+            };
+
+            if (messageTableName) {
+                columnDefinition.references = {
+                    model: messageTableName,
+                    key: 'id'
+                };
+                columnDefinition.onUpdate = 'CASCADE';
+                columnDefinition.onDelete = 'CASCADE';
+            }
+
+            await queryInterface.addColumn(attachmentTableName, 'messageId', columnDefinition);
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'originalName') &&
+            !(await columnExists(queryInterface, attachmentTableName, 'fileName'))) {
+            await queryInterface.renameColumn(attachmentTableName, 'originalName', 'fileName');
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'mimeType') &&
+            !(await columnExists(queryInterface, attachmentTableName, 'contentType'))) {
+            await queryInterface.renameColumn(attachmentTableName, 'mimeType', 'contentType');
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'size') &&
+            !(await columnExists(queryInterface, attachmentTableName, 'fileSize'))) {
+            await queryInterface.renameColumn(attachmentTableName, 'size', 'fileSize');
+        }
+
+        const existingIndexes = await getIndexNames(queryInterface, attachmentTableName);
+        if (!existingIndexes.includes(MESSAGE_ID_INDEX)) {
+            await queryInterface.addIndex(attachmentTableName, {
+                fields: ['messageId'],
+                name: MESSAGE_ID_INDEX
+            });
+        }
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        const attachmentTableName = await resolveExistingTableName(
+            queryInterface,
+            ATTACHMENT_TABLE_CANDIDATES
+        );
+
+        if (!attachmentTableName) {
+            return;
+        }
+
+        const existingIndexes = await getIndexNames(queryInterface, attachmentTableName);
+        if (existingIndexes.includes(MESSAGE_ID_INDEX)) {
+            await queryInterface.removeIndex(attachmentTableName, MESSAGE_ID_INDEX);
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'fileSize') &&
+            !(await columnExists(queryInterface, attachmentTableName, 'size'))) {
+            await queryInterface.renameColumn(attachmentTableName, 'fileSize', 'size');
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'contentType') &&
+            !(await columnExists(queryInterface, attachmentTableName, 'mimeType'))) {
+            await queryInterface.renameColumn(attachmentTableName, 'contentType', 'mimeType');
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'fileName') &&
+            !(await columnExists(queryInterface, attachmentTableName, 'originalName'))) {
+            await queryInterface.renameColumn(attachmentTableName, 'fileName', 'originalName');
+        }
+
+        if (await columnExists(queryInterface, attachmentTableName, 'messageId')) {
+            await queryInterface.removeColumn(attachmentTableName, 'messageId');
+        }
+    }
+};

--- a/database/models/index.js
+++ b/database/models/index.js
@@ -220,13 +220,6 @@ if (SupportMessage && User && !(SupportMessage.associations && SupportMessage.as
     });
 }
 
-if (SupportMessage && SupportAttachment && !(SupportMessage.associations && SupportMessage.associations.attachment)) {
-    SupportMessage.belongsTo(SupportAttachment, {
-        as: 'attachment',
-        foreignKey: 'attachmentId'
-    });
-}
-
 if (SupportAttachment && SupportTicket && !(SupportAttachment.associations && SupportAttachment.associations.ticket)) {
     SupportAttachment.belongsTo(SupportTicket, {
         as: 'ticket',
@@ -235,11 +228,19 @@ if (SupportAttachment && SupportTicket && !(SupportAttachment.associations && Su
     });
 }
 
+if (SupportMessage && SupportAttachment && !(SupportMessage.associations && SupportMessage.associations.attachments)) {
+    SupportMessage.hasMany(SupportAttachment, {
+        as: 'attachments',
+        foreignKey: 'messageId',
+        onDelete: 'CASCADE'
+    });
+}
+
 if (SupportAttachment && SupportMessage && !(SupportAttachment.associations && SupportAttachment.associations.message)) {
-    SupportAttachment.hasOne(SupportMessage, {
+    SupportAttachment.belongsTo(SupportMessage, {
         as: 'message',
-        foreignKey: 'attachmentId',
-        constraints: false
+        foreignKey: 'messageId',
+        onDelete: 'CASCADE'
     });
 }
 

--- a/database/models/supportAttachment.js
+++ b/database/models/supportAttachment.js
@@ -6,11 +6,15 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.INTEGER,
             allowNull: false
         },
+        messageId: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
         uploadedById: {
             type: DataTypes.INTEGER,
             allowNull: true
         },
-        originalName: {
+        fileName: {
             type: DataTypes.STRING(255),
             allowNull: false
         },
@@ -18,12 +22,12 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.STRING(255),
             allowNull: false
         },
-        mimeType: {
+        contentType: {
             type: DataTypes.STRING(120),
             allowNull: false
         },
-        size: {
-            type: DataTypes.INTEGER.UNSIGNED,
+        fileSize: {
+            type: DataTypes.BIGINT,
             allowNull: false
         },
         checksum: {
@@ -36,6 +40,10 @@ module.exports = (sequelize, DataTypes) => {
             {
                 name: 'supportAttachments_ticketId_idx',
                 fields: ['ticketId']
+            },
+            {
+                name: 'supportAttachments_messageId_idx',
+                fields: ['messageId']
             }
         ]
     });
@@ -59,10 +67,10 @@ module.exports = (sequelize, DataTypes) => {
         }
 
         if (SupportMessage) {
-            SupportAttachment.hasOne(SupportMessage, {
+            SupportAttachment.belongsTo(SupportMessage, {
                 as: 'message',
-                foreignKey: 'attachmentId',
-                constraints: false
+                foreignKey: 'messageId',
+                onDelete: 'CASCADE'
             });
         }
     };


### PR DESCRIPTION
## Summary
- adiciona migration para incluir messageId e renomear colunas dos anexos de suporte, com checagens de existência e índice dedicado
- ajusta o model SupportAttachment para expor os novos nomes e relacionar mensagens/tickets via Sequelize
- atualiza associações manuais e corrige a migration de renomeação para tratar messageId opcionalmente

## Testing
- `npm test` *(falhou: dependência socket.io não instalada no ambiente de testes)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3fb78254832f8f3bc9bbef5aedaa