### PR TITLE
Improve support migrations missing-table detection

### DIFF
--- a/database/migrations/20240921-create-support-tickets.js
+++ b/database/migrations/20240921-create-support-tickets.js
@@ -5,14 +5,20 @@ const CANDIDATE_TABLE_NAMES = Object.freeze(['supportTickets', 'SupportTickets']
 const SUPPORT_TICKETS_USER_STATUS_INDEX = 'supportTickets_userId_status';
 
 const isTableMissingError = (error) => {
-    const driverCode = error?.original?.code;
-    const message = error?.message ?? '';
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
 
     return driverCode === 'ER_NO_SUCH_TABLE' ||
         driverCode === 'SQLITE_ERROR' ||
+        driverCode === '42P01' ||
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
-        /unknown table/i.test(message);
+        /unknown table/i.test(message) ||
+        /não existe/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {

--- a/database/migrations/20240922-create-support-messages.js
+++ b/database/migrations/20240922-create-support-messages.js
@@ -8,14 +8,20 @@ const MESSAGE_SENDER_INDEX = 'supportMessages_senderId_idx';
 const MESSAGE_ATTACHMENT_INDEX = 'supportMessages_attachmentId_idx';
 
 const isTableMissingError = (error) => {
-    const driverCode = error?.original?.code;
-    const message = error?.message ?? '';
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
 
     return driverCode === 'ER_NO_SUCH_TABLE' ||
         driverCode === 'SQLITE_ERROR' ||
+        driverCode === '42P01' ||
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
-        /unknown table/i.test(message);
+        /unknown table/i.test(message) ||
+        /não existe/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {

--- a/database/migrations/20240923-create-support-attachments.js
+++ b/database/migrations/20240923-create-support-attachments.js
@@ -9,14 +9,20 @@ const ATTACHMENT_UPLOADER_INDEX = 'supportAttachments_uploaderId_idx';
 const MESSAGE_ATTACHMENT_CONSTRAINT = 'supportMessages_attachmentId_fkey';
 
 const isTableMissingError = (error) => {
-    const driverCode = error?.original?.code;
-    const message = error?.message ?? '';
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
 
     return driverCode === 'ER_NO_SUCH_TABLE' ||
         driverCode === 'SQLITE_ERROR' ||
+        driverCode === '42P01' ||
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
-        /unknown table/i.test(message);
+        /unknown table/i.test(message) ||
+        /não existe/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {

--- a/database/migrations/20240924-rename-support-tables.js
+++ b/database/migrations/20240924-rename-support-tables.js
@@ -9,6 +9,23 @@ const CAMEL_ATTACHMENT_TABLE = 'supportAttachments';
 const PASCAL_STATUS_ENUM = 'enum_SupportTickets_status';
 const CAMEL_STATUS_ENUM = 'enum_supportTickets_status';
 
+const isTableMissingError = (error) => {
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
+
+    return driverCode === 'ER_NO_SUCH_TABLE' ||
+        driverCode === 'SQLITE_ERROR' ||
+        driverCode === '42P01' ||
+        /does not exist/i.test(message) ||
+        /no such table/i.test(message) ||
+        /unknown table/i.test(message) ||
+        /não existe/i.test(message);
+};
+
 module.exports = {
     up: async (queryInterface, Sequelize) => {
         const transaction = await queryInterface.sequelize.transaction();
@@ -18,9 +35,7 @@ module.exports = {
                 await queryInterface.describeTable(tableName, { transaction });
                 return true;
             } catch (error) {
-                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
-                    error?.original?.code === 'SQLITE_ERROR' ||
-                    /does not exist/i.test(error?.message ?? '')) {
+                if (isTableMissingError(error)) {
                     return false;
                 }
                 throw error;
@@ -32,9 +47,7 @@ module.exports = {
                 const definition = await queryInterface.describeTable(tableName, { transaction });
                 return Boolean(definition?.[columnName]);
             } catch (error) {
-                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
-                    error?.original?.code === 'SQLITE_ERROR' ||
-                    /does not exist/i.test(error?.message ?? '')) {
+                if (isTableMissingError(error)) {
                     return false;
                 }
                 throw error;
@@ -131,9 +144,7 @@ module.exports = {
                 await queryInterface.describeTable(tableName, { transaction });
                 return true;
             } catch (error) {
-                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
-                    error?.original?.code === 'SQLITE_ERROR' ||
-                    /does not exist/i.test(error?.message ?? '')) {
+                if (isTableMissingError(error)) {
                     return false;
                 }
                 throw error;
@@ -145,9 +156,7 @@ module.exports = {
                 const definition = await queryInterface.describeTable(tableName, { transaction });
                 return Boolean(definition?.[columnName]);
             } catch (error) {
-                if (error?.original?.code === 'ER_NO_SUCH_TABLE' ||
-                    error?.original?.code === 'SQLITE_ERROR' ||
-                    /does not exist/i.test(error?.message ?? '')) {
+                if (isTableMissingError(error)) {
                     return false;
                 }
                 throw error;

--- a/database/migrations/20240926-update-support-tickets-structure.js
+++ b/database/migrations/20240926-update-support-tickets-structure.js
@@ -7,14 +7,20 @@ const NEW_STATUS_INDEX = 'supportTickets_creatorId_status';
 const ASSIGNEE_STATUS_INDEX = 'supportTickets_assignedTo_status';
 
 const isTableMissingError = (error) => {
-    const driverCode = error?.original?.code;
-    const message = error?.message ?? '';
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
 
     return driverCode === 'ER_NO_SUCH_TABLE' ||
         driverCode === 'SQLITE_ERROR' ||
+        driverCode === '42P01' ||
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
-        /unknown table/i.test(message);
+        /unknown table/i.test(message) ||
+        /não existe/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {


### PR DESCRIPTION
## Summary
- extend the support migration `isTableMissingError` helper to inspect PostgreSQL error codes and localized "não existe" messages
- reuse the helper inside the rename migration when checking table/column existence to keep consistent detection logic

## Testing
- `npx sequelize-cli db:migrate` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4a151bc4832f8b7256f78883dd2c