### PR TITLE
feat: scope finance data by user

### DIFF
--- a/database/migrations/20240927-add-user-to-finance-entries.js
+++ b/database/migrations/20240927-add-user-to-finance-entries.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const extractRowCount = (rows) => {
+    if (rows === null || rows === undefined) {
+        return 0;
+    }
+
+    if (Array.isArray(rows)) {
+        if (rows.length === 0) {
+            return 0;
+        }
+        return extractRowCount(rows[0]);
+    }
+
+    if (typeof rows === 'object') {
+        const value = rows.count
+            ?? rows.COUNT
+            ?? rows.total
+            ?? rows.TOTAL
+            ?? rows['count(*)']
+            ?? rows['COUNT(*)']
+            ?? rows['COUNT']
+            ?? rows['total']
+            ?? rows['TOTAL'];
+
+        if (value === undefined || value === null) {
+            return 0;
+        }
+
+        const numeric = Number(value);
+        return Number.isFinite(numeric) ? numeric : 0;
+    }
+
+    const numeric = Number(rows);
+    return Number.isFinite(numeric) ? numeric : 0;
+};
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const tableName = 'FinanceEntries';
+        const columnName = 'userId';
+        const userIndexName = 'finance_entries_user_idx';
+        const compositeIndexName = 'finance_entries_user_category_idx';
+
+        const tableDefinition = await queryInterface.describeTable(tableName);
+
+        if (!tableDefinition[columnName]) {
+            await queryInterface.addColumn(tableName, columnName, {
+                type: Sequelize.INTEGER,
+                allowNull: true,
+                references: {
+                    model: 'Users',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            });
+        }
+
+        const existingIndexes = await queryInterface.showIndex(tableName);
+        const indexNames = new Set(existingIndexes.map((index) => index.name));
+
+        if (!indexNames.has(userIndexName)) {
+            await queryInterface.addIndex(tableName, {
+                name: userIndexName,
+                fields: [columnName]
+            });
+        }
+
+        if (tableDefinition.financeCategoryId && !indexNames.has(compositeIndexName)) {
+            await queryInterface.addIndex(tableName, {
+                name: compositeIndexName,
+                fields: ['userId', 'financeCategoryId']
+            });
+        }
+
+        const qi = queryInterface.sequelize.getQueryInterface();
+        const quotedTable = typeof qi?.quoteTable === 'function' ? qi.quoteTable(tableName) : tableName;
+        const [rows] = await queryInterface.sequelize.query(`SELECT COUNT(*) AS count FROM ${quotedTable}`);
+        const totalRows = extractRowCount(rows);
+
+        if (totalRows === 0) {
+            await queryInterface.changeColumn(tableName, columnName, {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'Users',
+                    key: 'id'
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE'
+            });
+        }
+    },
+
+    down: async (queryInterface) => {
+        const tableName = 'FinanceEntries';
+        const columnName = 'userId';
+        const userIndexName = 'finance_entries_user_idx';
+        const compositeIndexName = 'finance_entries_user_category_idx';
+
+        const existingIndexes = await queryInterface.showIndex(tableName);
+        const indexNames = new Set(existingIndexes.map((index) => index.name));
+
+        if (indexNames.has(compositeIndexName)) {
+            await queryInterface.removeIndex(tableName, compositeIndexName);
+        }
+
+        if (indexNames.has(userIndexName)) {
+            await queryInterface.removeIndex(tableName, userIndexName);
+        }
+
+        const tableDefinition = await queryInterface.describeTable(tableName);
+        if (tableDefinition[columnName]) {
+            await queryInterface.removeColumn(tableName, columnName);
+        }
+    }
+};

--- a/database/models/financeEntry.js
+++ b/database/models/financeEntry.js
@@ -8,6 +8,19 @@ const allowedRecurringIntervals = new Set(FINANCE_RECURRING_INTERVAL_VALUES);
 
 module.exports = (sequelize, DataTypes) => {
     const FinanceEntry = sequelize.define('FinanceEntry', {
+        userId: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            references: {
+                model: 'Users',
+                key: 'id'
+            },
+            validate: {
+                isInt: {
+                    msg: 'Usuário responsável inválido.'
+                }
+            }
+        },
         description: {
             type: DataTypes.STRING,
             allowNull: false,
@@ -114,6 +127,13 @@ module.exports = (sequelize, DataTypes) => {
             FinanceEntry.belongsTo(models.FinanceCategory, {
                 as: 'category',
                 foreignKey: 'financeCategoryId'
+            });
+        }
+
+        if (models.User) {
+            FinanceEntry.belongsTo(models.User, {
+                as: 'user',
+                foreignKey: 'userId'
             });
         }
     };

--- a/database/models/index.js
+++ b/database/models/index.js
@@ -182,6 +182,20 @@ if (FinanceEntry && FinanceCategory && !(FinanceEntry.associations && FinanceEnt
     });
 }
 
+if (User && FinanceEntry && !(FinanceEntry.associations && FinanceEntry.associations.user)) {
+    FinanceEntry.belongsTo(User, {
+        as: 'user',
+        foreignKey: 'userId'
+    });
+}
+
+if (User && FinanceEntry && !(User.associations && User.associations.financeEntries)) {
+    User.hasMany(FinanceEntry, {
+        as: 'financeEntries',
+        foreignKey: 'userId'
+    });
+}
+
 if (SupportTicket && User && !(SupportTicket.associations && SupportTicket.associations.creator)) {
     SupportTicket.belongsTo(User, {
         as: 'creator',

--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -122,6 +122,15 @@ const normalizeAmountInput = (value) => {
 
 const resolveCurrentUserId = (req) => req?.user?.id ?? req?.session?.user?.id ?? null;
 
+const normalizeUserId = (value) => {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+
+    const numeric = Number(value);
+    return Number.isInteger(numeric) ? numeric : null;
+};
+
 const createCategoryResolver = async (userId) => {
     return financeImportService.createFinanceCategoryResolver({ ownerId: userId });
 };
@@ -369,7 +378,7 @@ const isMissingTableDbError = (error, tableName) => {
     return message.includes('no such table') && message.includes(String(tableName).toLowerCase());
 };
 
-const prepareImportPreview = async (rawEntries = []) => {
+const prepareImportPreview = async (rawEntries = [], options = {}) => {
     const totals = { total: 0, new: 0, conflicting: 0, invalid: 0 };
     if (!Array.isArray(rawEntries) || !rawEntries.length) {
         return { entries: [], totals, validationErrors: [] };
@@ -377,10 +386,20 @@ const prepareImportPreview = async (rawEntries = []) => {
 
     const normalizedEntries = [];
     const validationErrors = [];
+    const userId = normalizeUserId(options.userId);
+    const categoryResolver = options.categoryResolver;
 
     for (const [index, entry] of rawEntries.entries()) {
         try {
-            const prepared = await financeImportService.prepareEntryForPersistence(entry);
+            const prepareOptions = {};
+            if (categoryResolver) {
+                prepareOptions.categoryResolver = categoryResolver;
+            }
+            if (userId !== null) {
+                prepareOptions.userId = userId;
+            }
+
+            const prepared = await financeImportService.prepareEntryForPersistence(entry, prepareOptions);
             normalizedEntries.push({ ...prepared, originalIndex: index });
         } catch (error) {
             const message = error?.message || 'Entrada inválida.';
@@ -394,10 +413,16 @@ const prepareImportPreview = async (rawEntries = []) => {
     const dueDates = [...new Set(normalizedEntries.map((item) => item.dueDate))];
     let existingEntries = [];
     if (dueDates.length) {
+        const where = {
+            dueDate: { [Op.in]: dueDates }
+        };
+
+        if (userId !== null) {
+            where.userId = userId;
+        }
+
         existingEntries = await FinanceEntry.findAll({
-            where: {
-                dueDate: { [Op.in]: dueDates }
-            },
+            where,
             attributes: ['description', 'value', 'dueDate'],
             raw: true
         });
@@ -474,22 +499,6 @@ const buildFiltersFromQuery = (query = {}) => {
 };
 
 const buildEntriesQueryOptions = (filters = {}) => {
-    const include = [
-        {
-            model: FinanceAttachment,
-            as: 'attachments',
-            attributes: ['id', 'fileName', 'mimeType', 'size', 'createdAt']
-        }
-    ];
-
-    if (FinanceCategory) {
-        include.push({
-            model: FinanceCategory,
-            as: 'category',
-            attributes: ['id', 'name', 'slug', 'color']
-        });
-    }
-
     const options = {
         include: [
             {
@@ -512,6 +521,11 @@ const buildEntriesQueryOptions = (filters = {}) => {
 
     const where = {};
 
+    const userId = normalizeUserId(filters.userId);
+    if (userId !== null) {
+        where.userId = userId;
+    }
+
     const dateFilter = reportingUtils.buildDateFilter(filters);
     if (dateFilter) {
         where.dueDate = dateFilter;
@@ -525,9 +539,7 @@ const buildEntriesQueryOptions = (filters = {}) => {
         where.status = filters.status;
     }
 
-    if (Object.keys(where).length > 0) {
-        options.where = where;
-    }
+    options.where = Object.keys(where).length > 0 ? where : undefined;
 
     return options;
 };
@@ -762,6 +774,11 @@ module.exports = {
     listFinanceEntries: async (req, res) => {
         try {
             const filters = buildFiltersFromQuery(req.query);
+            const userId = resolveCurrentUserId(req);
+
+            if (userId !== null) {
+                filters.userId = userId;
+            }
             const entriesPromise = FinanceEntry.findAll(buildEntriesQueryOptions(filters));
             const summaryPromise = createSummaryPromise(entriesPromise, filters);
             const goalsPromise = (async () => {
@@ -780,8 +797,6 @@ module.exports = {
                 includeCategoryConsumption: true,
                 entriesPromise
             });
-
-            const userId = req.user?.id || req.session?.user?.id || null;
 
             const categoriesPromise = (async () => {
                 if (!FinanceCategory || typeof FinanceCategory.findAll !== 'function') {
@@ -901,11 +916,16 @@ module.exports = {
                 return res.status(400).json({ ok: false, message: 'Orçamento inválido.' });
             }
 
+            const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                return res.status(403).json({ ok: false, message: 'Usuário não autenticado.' });
+            }
+
             if (!Budget || typeof Budget.findByPk !== 'function') {
                 return res.status(500).json({ ok: false, message: 'Recurso de orçamento indisponível.' });
             }
 
-            const budget = await Budget.findByPk(budgetId);
+            const budget = await Budget.findOne({ where: { id: budgetId, userId: currentUserId } });
             if (!budget) {
                 return res.status(404).json({ ok: false, message: 'Orçamento não encontrado.' });
             }
@@ -918,6 +938,7 @@ module.exports = {
             await budget.save();
 
             const filters = buildFiltersFromQuery(req.query);
+            filters.userId = currentUserId;
             const overview = await financeReportingService.getBudgetSummaries(filters, {
                 includeCategoryConsumption: true
             });
@@ -957,7 +978,15 @@ module.exports = {
                 throw new Error('Nenhum lançamento válido foi encontrado no arquivo.');
             }
 
-            const preview = await prepareImportPreview(parseResult.entries);
+            const currentUserId = resolveCurrentUserId(req);
+            const categoryResolver = currentUserId !== null
+                ? await createCategoryResolver(currentUserId)
+                : null;
+
+            const preview = await prepareImportPreview(parseResult.entries, {
+                userId: currentUserId,
+                categoryResolver
+            });
             const payload = {
                 fileName: req.file.originalname,
                 uploadedAt: new Date().toISOString(),
@@ -1007,6 +1036,9 @@ module.exports = {
             }
 
             const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                throw new Error('Usuário não autenticado.');
+            }
             const categoryResolver = await createCategoryResolver(currentUserId);
             const preparedEntries = [];
             const skippedEntries = [];
@@ -1025,7 +1057,10 @@ module.exports = {
                 }
 
                 try {
-                    const prepared = await financeImportService.prepareEntryForPersistence(entry, { categoryResolver });
+                    const prepared = await financeImportService.prepareEntryForPersistence(entry, {
+                        categoryResolver,
+                        userId: currentUserId
+                    });
                     preparedEntries.push({
                         ...prepared,
                         categoryId: normalizeCategoryId(prepared.financeCategoryId)
@@ -1046,7 +1081,10 @@ module.exports = {
             let existingEntries = [];
             if (dueDates.length) {
                 existingEntries = await FinanceEntry.findAll({
-                    where: { dueDate: { [Op.in]: dueDates } },
+                    where: {
+                        dueDate: { [Op.in]: dueDates },
+                        userId: currentUserId
+                    },
                     attributes: ['id', 'description', 'value', 'dueDate']
                 });
             }
@@ -1080,7 +1118,10 @@ module.exports = {
 
             let createdRecords = [];
             if (finalEntries.length) {
-                const payload = finalEntries.map(({ hash, categoryName, categoryId, ...fields }) => fields);
+                const payload = finalEntries.map(({ hash, categoryName, categoryId, ...fields }) => ({
+                    ...fields,
+                    userId: currentUserId
+                }));
                 const result = await FinanceEntry.bulkCreate(payload, { validate: true, returning: true });
                 createdRecords = Array.isArray(result) ? result : [];
             }
@@ -1144,6 +1185,11 @@ module.exports = {
         let storedKeys = [];
 
         try {
+            const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                req.flash('error_msg', 'Usuário não autenticado.');
+                return res.redirect('/finance');
+            }
             const { description, type, value, dueDate, recurring, recurringInterval } = req.body;
             const financeCategoryId = normalizeCategoryId(
                 req.body.financeCategoryId ?? req.body.categoryId
@@ -1157,6 +1203,7 @@ module.exports = {
                 value,
                 dueDate,
                 financeCategoryId,
+                userId: currentUserId,
                 recurring: (recurring === 'true'),
                 recurringInterval: normalizeRecurringInterval(recurringInterval)
             };
@@ -1197,6 +1244,11 @@ module.exports = {
         let storedKeys = [];
 
         try {
+            const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                req.flash('error_msg', 'Usuário não autenticado.');
+                return res.redirect('/finance');
+            }
             const { id } = req.params;
             const {
                 description,
@@ -1215,12 +1267,14 @@ module.exports = {
 
             transaction = await beginTransaction();
 
-            let entry;
+            const findOptions = {
+                where: { id, userId: currentUserId }
+            };
             if (transaction) {
-                entry = await FinanceEntry.findByPk(id, { transaction });
-            } else {
-                entry = await FinanceEntry.findByPk(id);
+                findOptions.transaction = transaction;
             }
+
+            const entry = await FinanceEntry.findOne(findOptions);
 
             if (!entry) {
                 if (transaction) {
@@ -1273,8 +1327,15 @@ module.exports = {
 
     deleteFinanceEntry: async (req, res) => {
         try {
+            const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                req.flash('error_msg', 'Usuário não autenticado.');
+                return res.redirect('/finance');
+            }
             const { id } = req.params;
-            const entry = await FinanceEntry.findByPk(id);
+            const entry = await FinanceEntry.findOne({
+                where: { id, userId: currentUserId }
+            });
             if (!entry) {
                 req.flash('error_msg', 'Lançamento não encontrado.');
                 return res.redirect('/finance');
@@ -1553,6 +1614,11 @@ module.exports = {
     exportPdf: async (req, res) => {
         try {
             const filters = buildFiltersFromQuery(req.query);
+            const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                return res.status(403).json({ error: 'Usuário não autenticado.' });
+            }
+            filters.userId = currentUserId;
             const entriesPromise = FinanceEntry.findAll(buildEntriesQueryOptions(filters));
             const summaryPromise = createSummaryPromise(entriesPromise, filters);
             const budgetOverviewPromise = budgetService.getBudgetOverview(filters, {
@@ -1703,6 +1769,11 @@ module.exports = {
     exportExcel: async (req, res) => {
         try {
             const filters = buildFiltersFromQuery(req.query);
+            const currentUserId = resolveCurrentUserId(req);
+            if (currentUserId === null) {
+                return res.status(403).json({ error: 'Usuário não autenticado.' });
+            }
+            filters.userId = currentUserId;
             const entriesPromise = FinanceEntry.findAll(buildEntriesQueryOptions(filters));
             const summaryPromise = createSummaryPromise(entriesPromise, filters);
             const budgetOverviewPromise = budgetService.getBudgetOverview(filters, {

--- a/src/services/budgetService.js
+++ b/src/services/budgetService.js
@@ -439,7 +439,13 @@ const deleteBudget = async ({ id, userId } = {}, options = {}) => {
 };
 
 const getBudgetOverview = async (filters = {}, options = {}) => {
-    const response = await financeReportingService.getBudgetSummaries(filters, {
+    const normalizedFilters = { ...filters };
+    const userId = parseIntegerId(filters?.userId ?? options?.userId);
+    if (userId !== null) {
+        normalizedFilters.userId = userId;
+    }
+
+    const response = await financeReportingService.getBudgetSummaries(normalizedFilters, {
         ...(options || {}),
         includeCategoryConsumption: true
     });

--- a/src/services/financeReportingService.js
+++ b/src/services/financeReportingService.js
@@ -124,6 +124,15 @@ const parseProjectionMonths = (value) => {
     return Math.min(parsed, MAX_PROJECTION_MONTHS);
 };
 
+const parseIntegerId = (value) => {
+    if (value === null || value === undefined || value === '') {
+        return null;
+    }
+
+    const numeric = Number(value);
+    return Number.isInteger(numeric) ? numeric : null;
+};
+
 const isMissingTableError = (error, tableName) => {
     if (!error) {
         return false;
@@ -588,6 +597,10 @@ const fetchBudgetRows = async (filters = {}) => {
     }
 
     const where = {};
+    const userId = parseIntegerId(filters.userId);
+    if (userId !== null) {
+        where.userId = userId;
+    }
 
     if (Number.isInteger(filters.userId)) {
         where.userId = filters.userId;
@@ -633,6 +646,10 @@ const fetchCategoryMonthlyConsumption = async (filters = {}) => {
     }
 
     const where = {};
+    const userId = parseIntegerId(filters.userId);
+    if (userId !== null) {
+        where.userId = userId;
+    }
     const dateFilter = buildDateFilter(filters);
     if (dateFilter) {
         where.dueDate = dateFilter;
@@ -1131,6 +1148,11 @@ const buildTotalsFromStatus = (statusSummary) => {
 
 const fetchEntries = async (filters = {}) => {
     const where = {};
+
+    const userId = parseIntegerId(filters.userId);
+    if (userId !== null) {
+        where.userId = userId;
+    }
 
     const dateFilter = buildDateFilter(filters);
     if (dateFilter) {

--- a/tests/integration/financeController.attachments.test.js
+++ b/tests/integration/financeController.attachments.test.js
@@ -27,7 +27,7 @@ jest.mock('../../src/middlewares/audit', () => () => (req, res, next) => next())
 
 const financeRoutes = require('../../src/routes/financeRoutes');
 const fileStorageService = require('../../src/services/fileStorageService');
-const { FinanceEntry, FinanceAttachment, sequelize } = require('../../database/models');
+const { FinanceEntry, FinanceAttachment, sequelize, User } = require('../../database/models');
 
 const buildApp = () => {
     const app = express();
@@ -48,6 +48,15 @@ describe('FinanceController attachments', () => {
 
     beforeEach(async () => {
         await sequelize.sync({ force: true });
+        const unique = `${Date.now()}-${Math.random()}`;
+        await User.create({
+            id: 1,
+            name: 'Finance Attachments',
+            email: `attachments-${unique}@example.com`,
+            password: 'SenhaSegura123',
+            role: 'admin',
+            active: true
+        });
         await fsp.rm(storageRoot, { recursive: true, force: true });
         await fsp.mkdir(storageRoot, { recursive: true });
         app = buildApp();
@@ -97,7 +106,8 @@ describe('FinanceController attachments', () => {
             value: '2200.00',
             dueDate: '2024-10-15',
             recurring: false,
-            recurringInterval: null
+            recurringInterval: null,
+            userId: 1
         });
 
         const noteBuffer = Buffer.from('Relatorio financeiro confidencial');

--- a/tests/integration/financeController.export.test.js
+++ b/tests/integration/financeController.export.test.js
@@ -248,11 +248,12 @@ describe('FinanceController export endpoints', () => {
         expect(FinanceEntry.findAll).toHaveBeenCalledWith(expect.objectContaining({
             order: expect.any(Array),
             where: expect.objectContaining({
-                dueDate: expect.objectContaining({})
+                dueDate: expect.objectContaining({}),
+                userId: expect.any(Number)
             })
         }));
         expect(financeReportingService.getFinanceSummary).toHaveBeenCalledWith(
-            { startDate: '2024-01-01', endDate: '2024-01-31' },
+            { startDate: '2024-01-01', endDate: '2024-01-31', userId: expect.any(Number) },
             expect.objectContaining({ entries: sampleEntries })
         );
         expect(reportChartService.generateFinanceReportChart).toHaveBeenCalledWith(summaryResponse);
@@ -286,11 +287,12 @@ describe('FinanceController export endpoints', () => {
         expect(FinanceEntry.findAll).toHaveBeenCalledWith(expect.objectContaining({
             order: expect.any(Array),
             where: expect.objectContaining({
-                dueDate: expect.objectContaining({})
+                dueDate: expect.objectContaining({}),
+                userId: expect.any(Number)
             })
         }));
         expect(financeReportingService.getFinanceSummary).toHaveBeenCalledWith(
-            { startDate: '2024-02-01', endDate: '2024-02-28' },
+            { startDate: '2024-02-01', endDate: '2024-02-28', userId: expect.any(Number) },
             expect.objectContaining({ entries: sampleEntries })
         );
         expect(reportChartService.generateFinanceReportChart).toHaveBeenCalledWith(summaryResponse, {

--- a/tests/integration/financeFilters.integration.test.js
+++ b/tests/integration/financeFilters.integration.test.js
@@ -64,7 +64,8 @@ describe('Finance routes filtering', () => {
             order: expect.any(Array),
             where: expect.objectContaining({
                 type: 'receivable',
-                status: 'paid'
+                status: 'paid',
+                userId: 1000
             })
         });
 
@@ -77,7 +78,8 @@ describe('Finance routes filtering', () => {
                 startDate: '2024-03-01',
                 endDate: '2024-03-31',
                 type: 'receivable',
-                status: 'paid'
+                status: 'paid',
+                userId: 1000
             },
             expect.objectContaining({ entries: filteredEntries })
         );

--- a/tests/integration/routes.smoke.test.js
+++ b/tests/integration/routes.smoke.test.js
@@ -86,6 +86,9 @@ describe('Smoke tests das rotas principais', () => {
         const response = await agent.get('/finance');
 
         expect(FinanceEntry.findAll).toHaveBeenCalledTimes(1);
+        expect(FinanceEntry.findAll).toHaveBeenCalledWith(expect.objectContaining({
+            where: expect.objectContaining({ userId: expect.any(Number) })
+        }));
         expect(FinanceGoal.findAll).toHaveBeenCalledTimes(2);
         expect(response.status).toBe(200);
         expect(response.text).toContain('Gerenciar finanças estratégicas');

--- a/tests/unit/controllers/financeController.test.js
+++ b/tests/unit/controllers/financeController.test.js
@@ -5,7 +5,8 @@ jest.mock('../../../database/models', () => {
         FinanceEntry: {
             create: jest.fn(),
             findAll: jest.fn(),
-            findByPk: jest.fn()
+            findByPk: jest.fn(),
+            findOne: jest.fn()
         },
         Sequelize: { Op }
     };
@@ -33,7 +34,8 @@ describe('financeController', () => {
                 recurring: 'true',
                 recurringInterval: 'Mensal'
             },
-            flash: jest.fn()
+            flash: jest.fn(),
+            user: { id: 42 }
         };
         const res = buildResponseMock();
 
@@ -42,7 +44,7 @@ describe('financeController', () => {
         await financeController.createFinanceEntry(req, res);
 
         expect(FinanceEntry.create).toHaveBeenCalledWith(
-            expect.objectContaining({ recurringInterval: 'monthly' })
+            expect.objectContaining({ recurringInterval: 'monthly', userId: 42 })
         );
         expect(req.flash).toHaveBeenCalledWith('success_msg', expect.any(String));
         expect(res.redirect).toHaveBeenCalledWith('/finance');
@@ -64,6 +66,7 @@ describe('financeController', () => {
         };
 
         FinanceEntry.findByPk.mockResolvedValue(entry);
+        FinanceEntry.findOne.mockResolvedValue(entry);
 
         const req = {
             params: { id: 7 },
@@ -77,7 +80,8 @@ describe('financeController', () => {
                 recurring: 'true',
                 recurringInterval: 'Quinzenal'
             },
-            flash: jest.fn()
+            flash: jest.fn(),
+            user: { id: 7 }
         };
         const res = buildResponseMock();
 

--- a/tests/unit/financeReportingService.test.js
+++ b/tests/unit/financeReportingService.test.js
@@ -24,6 +24,16 @@ describe('financeReportingService', () => {
         }));
     });
 
+    it('filtra lançamentos pelo usuário informado', async () => {
+        const findSpy = jest.spyOn(FinanceEntry, 'findAll').mockResolvedValueOnce([]);
+
+        await getStatusSummary({ userId: 77 });
+
+        expect(findSpy).toHaveBeenCalledWith(expect.objectContaining({
+            where: expect.objectContaining({ userId: 77 })
+        }));
+    });
+
     it('agrupa os lançamentos por status e tipo', async () => {
         jest.spyOn(FinanceEntry, 'findAll').mockResolvedValueOnce([
             { type: 'payable', status: 'pending', value: '120.50', dueDate: '2024-04-10' },


### PR DESCRIPTION
## Summary
- add migration to attach FinanceEntries to Users and wire up model associations
- persist the authenticated user on finance entry CRUD/import flows and scope listings/reporting
- ensure reporting and budget services respect user boundaries and extend tests for cross-user separation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbe85edd10832f8e1921818a859b9b