### PR TITLE
Fix FinanceEntries migration row count quoting

### DIFF
--- a/database/migrations/20240927-add-user-to-finance-entries.js
+++ b/database/migrations/20240927-add-user-to-finance-entries.js
@@ -74,10 +74,16 @@ module.exports = {
             });
         }
 
-        const qi = queryInterface.sequelize.getQueryInterface();
-        const quotedTable = typeof qi?.quoteTable === 'function' ? qi.quoteTable(tableName) : tableName;
-        const [rows] = await queryInterface.sequelize.query(`SELECT COUNT(*) AS count FROM ${quotedTable}`);
-        const totalRows = extractRowCount(rows);
+        const countResult = await queryInterface.rawSelect(
+            tableName,
+            {
+                plain: true,
+                attributes: [[Sequelize.fn('COUNT', Sequelize.col('*')), 'count']]
+            },
+            'count'
+        );
+
+        const totalRows = extractRowCount(countResult);
 
         if (totalRows === 0) {
             await queryInterface.changeColumn(tableName, columnName, {


### PR DESCRIPTION
## Summary
- switch the FinanceEntries migration row count to use queryInterface.rawSelect for dialect-aware quoting

## Testing
- npx sequelize-cli db:migrate --debug *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68cc26d30bf4832f98f77acaecbf304e