### PR TITLE
Ensure user role enum uses shared type

### DIFF
--- a/database/models/user.js
+++ b/database/models/user.js
@@ -94,7 +94,7 @@ module.exports = (sequelize, DataTypes) => {
             }
         },
         role: {
-            type: DataTypes.ENUM(...ROLE_ORDER),
+            type: DataTypes.ENUM({ values: ROLE_ORDER, name: 'user_role_enum' }),
             defaultValue: USER_ROLES.CLIENT,
             allowNull: false,
             set(value) {


### PR DESCRIPTION
## Summary
- update the User model to reuse the user_role_enum type created by the migration
- verified there are no other mismatched enum names for the Users.role column

## Testing
- npm test
- SESSION_SECRET=devsecret DB_DIALECT=sqlite npm start

------
https://chatgpt.com/codex/tasks/task_e_68cd7e818378832f88c4cb84333ff2ce