### PR TITLE
Rename user role enum type

### DIFF
--- a/database/migrations/20240928-rename-user-role-enum.js
+++ b/database/migrations/20240928-rename-user-role-enum.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const OLD_ENUM_NAME = 'user_role_enum';
+const NEW_ENUM_NAME = 'enum_Users_role';
+
+const doesTypeExist = async (queryInterface, transaction, typeName) => {
+    const [results] = await queryInterface.sequelize.query(
+        `SELECT EXISTS (
+            SELECT 1
+            FROM pg_type
+            WHERE typname = :typeName
+        ) AS "exists";`,
+        {
+            transaction,
+            replacements: { typeName }
+        }
+    );
+
+    return Boolean(results?.[0]?.exists);
+};
+
+module.exports = {
+    async up(queryInterface) {
+        if (queryInterface.sequelize.getDialect() !== 'postgres') {
+            return;
+        }
+
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            const typeExists = await doesTypeExist(queryInterface, transaction, OLD_ENUM_NAME);
+            if (!typeExists) {
+                return;
+            }
+
+            await queryInterface.sequelize.query(
+                `ALTER TYPE ${OLD_ENUM_NAME} RENAME TO "${NEW_ENUM_NAME}";`,
+                { transaction }
+            );
+        });
+    },
+
+    async down(queryInterface) {
+        if (queryInterface.sequelize.getDialect() !== 'postgres') {
+            return;
+        }
+
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            const typeExists = await doesTypeExist(queryInterface, transaction, NEW_ENUM_NAME);
+            if (!typeExists) {
+                return;
+            }
+
+            await queryInterface.sequelize.query(
+                `ALTER TYPE "${NEW_ENUM_NAME}" RENAME TO ${OLD_ENUM_NAME};`,
+                { transaction }
+            );
+        });
+    }
+};

--- a/database/models/user.js
+++ b/database/models/user.js
@@ -94,7 +94,7 @@ module.exports = (sequelize, DataTypes) => {
             }
         },
         role: {
-            type: DataTypes.ENUM({ values: ROLE_ORDER, name: 'user_role_enum' }),
+            type: DataTypes.ENUM({ values: ROLE_ORDER, name: 'enum_Users_role' }),
             defaultValue: USER_ROLES.CLIENT,
             allowNull: false,
             set(value) {


### PR DESCRIPTION
## Summary
- add a defensive migration that renames the Postgres user role enum to "enum_Users_role" only when the old type exists
- update the User model to bind the role attribute to the renamed enum type while preserving the existing role ordering

## Testing
- SESSION_SECRET=secret DB_DIALECT=sqlite DB_STORAGE=:memory: npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd81ca1f68832f950c76a99faab127