### PR TITLE
Guard against duplicate enum rename

### DIFF
--- a/database/migrations/20240928-rename-user-role-enum.js
+++ b/database/migrations/20240928-rename-user-role-enum.js
@@ -26,8 +26,13 @@ module.exports = {
         }
 
         await queryInterface.sequelize.transaction(async (transaction) => {
-            const typeExists = await doesTypeExist(queryInterface, transaction, OLD_ENUM_NAME);
-            if (!typeExists) {
+            const newTypeExists = await doesTypeExist(queryInterface, transaction, NEW_ENUM_NAME);
+            if (newTypeExists) {
+                return;
+            }
+
+            const oldTypeExists = await doesTypeExist(queryInterface, transaction, OLD_ENUM_NAME);
+            if (!oldTypeExists) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- avoid attempting to rename the user role enum when the new type is already present
- maintain the existing rename flow when only the legacy enum type exists

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd84c6f8cc832facb49344d030c6de