### PR TITLE
Protect scheduledAt migration with transaction checks

### DIFF
--- a/database/migrations/20240908-add-scheduled-at-to-notifications.js
+++ b/database/migrations/20240908-add-scheduled-at-to-notifications.js
@@ -2,24 +2,44 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Notifications', 'scheduledAt', {
-      type: Sequelize.DATE,
-      allowNull: true,
-    });
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const tableDefinition = await queryInterface.describeTable('Notifications', { transaction });
 
-    const rawDialect = queryInterface.sequelize?.getDialect?.() || queryInterface.sequelize?.dialect?.name;
-    const normalizedDialect = typeof rawDialect === 'string' ? rawDialect.toLowerCase() : '';
-    if (normalizedDialect === 'postgres' || normalizedDialect === 'postgresql') {
-      await queryInterface.sequelize.query(`
+      if (!tableDefinition.scheduledAt) {
+        await queryInterface.addColumn(
+          'Notifications',
+          'scheduledAt',
+          {
+            type: Sequelize.DATE,
+            allowNull: true,
+          },
+          { transaction }
+        );
+      }
+
+      const rawDialect = queryInterface.sequelize?.getDialect?.() || queryInterface.sequelize?.dialect?.name;
+      const normalizedDialect = typeof rawDialect === 'string' ? rawDialect.toLowerCase() : '';
+      if (normalizedDialect === 'postgres' || normalizedDialect === 'postgresql') {
+        await queryInterface.sequelize.query(
+          `
         UPDATE "Notifications"
         SET "scheduledAt" = "triggerDate"
         WHERE "triggerDate" IS NOT NULL
           AND ("scheduledAt" IS NULL OR "scheduledAt" = "triggerDate");
-      `);
-    }
+      `,
+          { transaction }
+        );
+      }
+    });
   },
 
   async down(queryInterface) {
-    await queryInterface.removeColumn('Notifications', 'scheduledAt');
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      const tableDefinition = await queryInterface.describeTable('Notifications', { transaction });
+
+      if (tableDefinition.scheduledAt) {
+        await queryInterface.removeColumn('Notifications', 'scheduledAt', { transaction });
+      }
+    });
   },
 };


### PR DESCRIPTION
## Summary
- wrap the scheduledAt migration in a transaction and add the column only when missing
- preserve the conditional PostgreSQL update for scheduledAt from triggerDate
- make the down migration idempotent by checking for scheduledAt before removing it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd8fdbc70c832f9f01c66654bc3a63