### PR TITLE
Guard support table renames when target exists

### DIFF
--- a/database/migrations/20240924-rename-support-tables.js
+++ b/database/migrations/20240924-rename-support-tables.js
@@ -69,7 +69,10 @@ module.exports = {
         try {
             const dialect = queryInterface.sequelize.getDialect();
 
-            if (await tableExists(PASCAL_TICKET_TABLE)) {
+            const pascalTicketExists = await tableExists(PASCAL_TICKET_TABLE);
+            const camelTicketExists = await tableExists(CAMEL_TICKET_TABLE);
+
+            if (pascalTicketExists && !camelTicketExists) {
                 await ignoreIfTableMissing(() => queryInterface.renameTable(
                     PASCAL_TICKET_TABLE,
                     CAMEL_TICKET_TABLE,
@@ -83,7 +86,10 @@ module.exports = {
                 }
             }
 
-            if (await tableExists(PASCAL_MESSAGE_TABLE)) {
+            const pascalMessageExists = await tableExists(PASCAL_MESSAGE_TABLE);
+            const camelMessageExists = await tableExists(CAMEL_MESSAGE_TABLE);
+
+            if (pascalMessageExists && !camelMessageExists) {
                 await ignoreIfTableMissing(() => queryInterface.renameTable(
                     PASCAL_MESSAGE_TABLE,
                     CAMEL_MESSAGE_TABLE,
@@ -91,7 +97,10 @@ module.exports = {
                 ));
             }
 
-            if (await tableExists(PASCAL_ATTACHMENT_TABLE)) {
+            const pascalAttachmentExists = await tableExists(PASCAL_ATTACHMENT_TABLE);
+            const camelAttachmentExists = await tableExists(CAMEL_ATTACHMENT_TABLE);
+
+            if (pascalAttachmentExists && !camelAttachmentExists) {
                 await ignoreIfTableMissing(() => queryInterface.renameTable(
                     PASCAL_ATTACHMENT_TABLE,
                     CAMEL_ATTACHMENT_TABLE,
@@ -190,7 +199,10 @@ module.exports = {
         try {
             const dialect = queryInterface.sequelize.getDialect();
 
-            if (await tableExists(CAMEL_ATTACHMENT_TABLE)) {
+            const camelAttachmentExists = await tableExists(CAMEL_ATTACHMENT_TABLE);
+            const pascalAttachmentExists = await tableExists(PASCAL_ATTACHMENT_TABLE);
+
+            if (camelAttachmentExists && !pascalAttachmentExists) {
                 await ignoreIfTableMissing(() => queryInterface.renameTable(
                     CAMEL_ATTACHMENT_TABLE,
                     PASCAL_ATTACHMENT_TABLE,
@@ -198,7 +210,10 @@ module.exports = {
                 ));
             }
 
-            if (await tableExists(CAMEL_MESSAGE_TABLE)) {
+            const camelMessageExists = await tableExists(CAMEL_MESSAGE_TABLE);
+            const pascalMessageExists = await tableExists(PASCAL_MESSAGE_TABLE);
+
+            if (camelMessageExists && !pascalMessageExists) {
                 await ignoreIfTableMissing(() => queryInterface.renameTable(
                     CAMEL_MESSAGE_TABLE,
                     PASCAL_MESSAGE_TABLE,
@@ -206,7 +221,10 @@ module.exports = {
                 ));
             }
 
-            if (await tableExists(CAMEL_TICKET_TABLE)) {
+            const camelTicketExists = await tableExists(CAMEL_TICKET_TABLE);
+            const pascalTicketExists = await tableExists(PASCAL_TICKET_TABLE);
+
+            if (camelTicketExists && !pascalTicketExists) {
                 await ignoreIfTableMissing(() => queryInterface.renameTable(
                     CAMEL_TICKET_TABLE,
                     PASCAL_TICKET_TABLE,

--- a/tests/unit/migrations/rename-support-tables.migration.test.js
+++ b/tests/unit/migrations/rename-support-tables.migration.test.js
@@ -1,0 +1,125 @@
+process.env.NODE_ENV = 'test';
+
+const { Sequelize } = require('sequelize');
+const migration = require('../../../database/migrations/20240924-rename-support-tables');
+
+const createMissingTableError = (tableName) => {
+    const error = new Error(`relation "${tableName}" does not exist`);
+    error.original = { code: '42P01', message: error.message };
+    error.parent = { code: '42P01', message: error.message };
+    return error;
+};
+
+const createTableDefinitions = () => ({
+    SupportTickets: {
+        id: {},
+        status: {}
+    },
+    supportTickets: {
+        id: {},
+        status: {}
+    },
+    SupportMessages: {
+        id: {},
+        ticketId: {}
+    },
+    supportMessages: {
+        id: {},
+        ticketId: {}
+    },
+    SupportAttachments: {
+        id: {},
+        ticketId: {},
+        messageId: {}
+    },
+    supportAttachments: {
+        id: {},
+        ticketId: {},
+        messageId: {}
+    }
+});
+
+const buildQueryInterfaceMock = (tableDefinitions) => {
+    const transaction = {
+        commit: jest.fn().mockResolvedValue(undefined),
+        rollback: jest.fn().mockResolvedValue(undefined)
+    };
+
+    const describeTable = jest.fn(async (tableName) => {
+        const definition = tableDefinitions[tableName];
+        if (!definition) {
+            throw createMissingTableError(tableName);
+        }
+        return definition;
+    });
+
+    const renameTable = jest.fn().mockResolvedValue(undefined);
+    const changeColumn = jest.fn().mockResolvedValue(undefined);
+
+    const sequelize = {
+        transaction: jest.fn().mockResolvedValue(transaction),
+        getDialect: jest.fn().mockReturnValue('postgres'),
+        query: jest.fn().mockResolvedValue(undefined)
+    };
+
+    return {
+        queryInterface: {
+            sequelize,
+            describeTable,
+            renameTable,
+            changeColumn
+        },
+        transaction,
+        describeTable,
+        renameTable,
+        changeColumn,
+        sequelize
+    };
+};
+
+describe('20240924-rename-support-tables migration', () => {
+    it('skips renames in the up migration when camelCase tables already exist', async () => {
+        const tableDefinitions = createTableDefinitions();
+        const {
+            queryInterface,
+            transaction,
+            renameTable,
+            describeTable,
+            sequelize
+        } = buildQueryInterfaceMock(tableDefinitions);
+
+        await expect(migration.up(queryInterface, Sequelize)).resolves.toBeUndefined();
+
+        expect(describeTable).toHaveBeenCalledWith('SupportTickets', expect.objectContaining({ transaction: expect.any(Object) }));
+        expect(describeTable).toHaveBeenCalledWith('supportTickets', expect.objectContaining({ transaction: expect.any(Object) }));
+        expect(renameTable).not.toHaveBeenCalledWith('SupportTickets', 'supportTickets', expect.any(Object));
+        expect(renameTable).not.toHaveBeenCalledWith('SupportMessages', 'supportMessages', expect.any(Object));
+        expect(renameTable).not.toHaveBeenCalledWith('SupportAttachments', 'supportAttachments', expect.any(Object));
+        expect(sequelize.query).not.toHaveBeenCalled();
+        expect(transaction.commit).toHaveBeenCalledTimes(1);
+        expect(transaction.rollback).not.toHaveBeenCalled();
+    });
+
+    it('skips renames in the down migration when PascalCase tables already exist', async () => {
+        const tableDefinitions = createTableDefinitions();
+        const {
+            queryInterface,
+            transaction,
+            renameTable,
+            describeTable,
+            sequelize
+        } = buildQueryInterfaceMock(tableDefinitions);
+
+        await expect(migration.down(queryInterface, Sequelize)).resolves.toBeUndefined();
+
+        expect(describeTable).toHaveBeenCalledWith('supportTickets', expect.objectContaining({ transaction: expect.any(Object) }));
+        expect(describeTable).toHaveBeenCalledWith('SupportTickets', expect.objectContaining({ transaction: expect.any(Object) }));
+        expect(renameTable).not.toHaveBeenCalledWith('supportTickets', 'SupportTickets', expect.any(Object));
+        expect(renameTable).not.toHaveBeenCalledWith('supportMessages', 'SupportMessages', expect.any(Object));
+        expect(renameTable).not.toHaveBeenCalledWith('supportAttachments', 'SupportAttachments', expect.any(Object));
+        expect(sequelize.query).not.toHaveBeenCalled();
+        expect(transaction.commit).toHaveBeenCalledTimes(1);
+        expect(transaction.rollback).not.toHaveBeenCalled();
+    });
+});
+


### PR DESCRIPTION
## Summary
- add guard checks so support ticket/message/attachment tables are only renamed when the destination name is absent
- apply the same destination-existence guard in the down migration
- introduce unit tests that simulate both naming variants existing and assert the renames are skipped without errors

## Testing
- npm run test:unit
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68cd94d397b8832fbd688edbd3ac6746