### PR TITLE
Handle Sequelize No description missing table errors

### DIFF
--- a/database/migrations/20240921-create-support-tickets.js
+++ b/database/migrations/20240921-create-support-tickets.js
@@ -23,7 +23,8 @@ const isTableMissingError = (error) => {
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
         /unknown table/i.test(message) ||
-        /não existe/i.test(message);
+        /não existe/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {

--- a/database/migrations/20240922-create-support-messages.js
+++ b/database/migrations/20240922-create-support-messages.js
@@ -21,7 +21,8 @@ const isTableMissingError = (error) => {
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
         /unknown table/i.test(message) ||
-        /não existe/i.test(message);
+        /não existe/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {

--- a/database/migrations/20240923-create-support-attachments.js
+++ b/database/migrations/20240923-create-support-attachments.js
@@ -22,7 +22,8 @@ const isTableMissingError = (error) => {
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
         /unknown table/i.test(message) ||
-        /não existe/i.test(message);
+        /não existe/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {

--- a/database/migrations/20240924-rename-support-tables.js
+++ b/database/migrations/20240924-rename-support-tables.js
@@ -23,7 +23,8 @@ const isTableMissingError = (error) => {
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
         /unknown table/i.test(message) ||
-        /não existe/i.test(message);
+        /não existe/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const ignoreIfTableMissing = async (operation) => {

--- a/database/migrations/20240925-update-support-messages-schema.js
+++ b/database/migrations/20240925-update-support-messages-schema.js
@@ -15,14 +15,19 @@ const AGENT_ROLE_HINTS = Object.freeze([
 ]);
 
 const isTableMissingError = (error) => {
-    const driverCode = error?.original?.code;
-    const message = error?.message ?? '';
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
 
     return driverCode === 'ER_NO_SUCH_TABLE' ||
         driverCode === 'SQLITE_ERROR' ||
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
-        /unknown table/i.test(message);
+        /unknown table/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName, options = {}) => {

--- a/database/migrations/20240926-update-support-attachment-columns.js
+++ b/database/migrations/20240926-update-support-attachment-columns.js
@@ -5,14 +5,19 @@ const MESSAGE_TABLE_CANDIDATES = Object.freeze(['supportMessages', 'SupportMessa
 const MESSAGE_ID_INDEX = 'supportAttachments_messageId_idx';
 
 const isTableMissingError = (error) => {
-    const driverCode = error?.original?.code;
-    const message = error?.message ?? '';
+    const driverCode = error?.original?.code || error?.parent?.code;
+    const message = [
+        error?.message,
+        error?.original?.message,
+        error?.parent?.message
+    ].filter(Boolean).join(' ') || '';
 
     return driverCode === 'ER_NO_SUCH_TABLE' ||
         driverCode === 'SQLITE_ERROR' ||
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
-        /unknown table/i.test(message);
+        /unknown table/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const describeTable = async (queryInterface, tableName) => {

--- a/database/migrations/20240926-update-support-tickets-structure.js
+++ b/database/migrations/20240926-update-support-tickets-structure.js
@@ -20,7 +20,8 @@ const isTableMissingError = (error) => {
         /does not exist/i.test(message) ||
         /no such table/i.test(message) ||
         /unknown table/i.test(message) ||
-        /não existe/i.test(message);
+        /não existe/i.test(message) ||
+        /no description found/i.test(message);
 };
 
 const tableExists = async (queryInterface, tableName) => {


### PR DESCRIPTION
## Summary
- treat Sequelize "No description found" messages as missing-table errors across support-related migrations
- extend attachment and message migrations to aggregate nested error messages before classification

## Testing
- `npx sequelize-cli db:migrate --debug` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9896ce00832f84a46c0234c80b47