### PR TITLE
feat: add support ticket listing endpoints

### DIFF
--- a/src/controllers/supportTicketController.js
+++ b/src/controllers/supportTicketController.js
@@ -1,0 +1,149 @@
+const { TICKET_STATUSES, isSupportAgentRole } = require('../constants/support');
+const { ROLE_LABELS } = require('../constants/roles');
+const supportTicketService = require('../services/supportTicketService');
+
+const getRequestUser = (req) => {
+    if (req.user && req.user.active) {
+        return req.user;
+    }
+
+    if (req.session && req.session.user && req.session.user.active) {
+        return req.session.user;
+    }
+
+    return null;
+};
+
+const pullFlashMessage = (req, type) => {
+    if (typeof req.flash !== 'function') {
+        return null;
+    }
+
+    const messages = req.flash(type);
+    if (!Array.isArray(messages) || messages.length === 0) {
+        return null;
+    }
+
+    return messages[0];
+};
+
+const pushFlashMessage = (req, type, message) => {
+    if (typeof req.flash === 'function') {
+        req.flash(type, message);
+    }
+};
+
+const supportTicketController = {
+    async listTickets(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                pushFlashMessage(req, 'error_msg', 'Você precisa estar logado para acessar esta página.');
+                return res.redirect('/login');
+            }
+
+            const tickets = await supportTicketService.listTicketsForUser({ user });
+
+            res.render('support/tickets', {
+                tickets,
+                statuses: TICKET_STATUSES,
+                isAgent: isSupportAgentRole(user.role),
+                user,
+                appName: req.app?.locals?.appName || 'Sistema de Gestão',
+                roleLabels: ROLE_LABELS,
+                notifications: [],
+                success_msg: pullFlashMessage(req, 'success_msg'),
+                error_msg: pullFlashMessage(req, 'error_msg'),
+                pageTitle: 'Central de suporte'
+            });
+        } catch (error) {
+            console.error('Erro ao listar chamados de suporte:', error);
+            pushFlashMessage(req, 'error_msg', error?.message || 'Não foi possível carregar seus chamados.');
+            return res.redirect('/');
+        }
+    },
+
+    async createTicket(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                pushFlashMessage(req, 'error_msg', 'Você precisa estar logado para criar um chamado.');
+                return res.redirect('/login');
+            }
+
+            const { subject, description } = req.body || {};
+
+            await supportTicketService.createTicket({
+                subject,
+                description,
+                creator: user,
+                attachments: [],
+                ipAddress: req.ip
+            });
+
+            pushFlashMessage(req, 'success_msg', 'Chamado criado com sucesso. Nossa equipe já foi notificada!');
+            return res.redirect('/support/tickets');
+        } catch (error) {
+            console.error('Erro ao criar chamado de suporte:', error);
+            pushFlashMessage(req, 'error_msg', error?.message || 'Não foi possível criar o chamado.');
+            return res.redirect('/support/tickets');
+        }
+    },
+
+    async addMessage(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                pushFlashMessage(req, 'error_msg', 'Você precisa estar logado para atualizar o chamado.');
+                return res.redirect('/login');
+            }
+
+            const ticketId = Number.parseInt(req.params.ticketId, 10);
+            const { body } = req.body || {};
+
+            await supportTicketService.addMessage({
+                ticketId,
+                sender: user,
+                body,
+                attachments: [],
+                ipAddress: req.ip
+            });
+
+            pushFlashMessage(req, 'success_msg', 'Mensagem enviada com sucesso.');
+            return res.redirect('/support/tickets');
+        } catch (error) {
+            console.error('Erro ao adicionar mensagem no chamado de suporte:', error);
+            pushFlashMessage(req, 'error_msg', error?.message || 'Não foi possível enviar a mensagem.');
+            return res.redirect('/support/tickets');
+        }
+    },
+
+    async updateStatus(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                pushFlashMessage(req, 'error_msg', 'Você precisa estar logado para atualizar o status.');
+                return res.redirect('/login');
+            }
+
+            const ticketId = Number.parseInt(req.params.ticketId, 10);
+            const { status } = req.body || {};
+
+            await supportTicketService.updateTicketStatus({
+                ticketId,
+                status,
+                actor: user,
+                ipAddress: req.ip
+            });
+
+            pushFlashMessage(req, 'success_msg', 'Status do chamado atualizado.');
+            return res.redirect('/support/tickets');
+        } catch (error) {
+            console.error('Erro ao atualizar status do chamado de suporte:', error);
+            pushFlashMessage(req, 'error_msg', error?.message || 'Não foi possível atualizar o status do chamado.');
+            return res.redirect('/support/tickets');
+        }
+    }
+};
+
+module.exports = supportTicketController;

--- a/src/routes/supportRoutes.js
+++ b/src/routes/supportRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const multer = require('multer');
 
 const supportController = require('../controllers/supportController');
+const supportTicketController = require('../controllers/supportTicketController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const { constants: chatConstants } = require('../services/supportChatService');
 
@@ -14,6 +15,10 @@ const upload = multer({
     }
 });
 
+router.get('/tickets', authMiddleware, supportTicketController.listTickets);
+router.post('/tickets', authMiddleware, supportTicketController.createTicket);
+router.post('/tickets/:ticketId/messages', authMiddleware, supportTicketController.addMessage);
+router.post('/tickets/:ticketId/status', authMiddleware, supportTicketController.updateStatus);
 router.get('/tickets/:ticketId/chat', authMiddleware, supportController.renderChat);
 router.get('/tickets/:ticketId/history', authMiddleware, supportController.fetchHistory);
 router.post(

--- a/tests/integration/support/supportTicketRoutes.test.js
+++ b/tests/integration/support/supportTicketRoutes.test.js
@@ -1,0 +1,143 @@
+process.env.NODE_ENV = 'test';
+
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+let mockCurrentUser = {
+    id: 1,
+    role: 'client',
+    active: true,
+    name: 'Cliente Teste',
+    email: 'cliente@example.com'
+};
+
+const createFlashStub = () => {
+    const store = {};
+    return (req, res, next) => {
+        req.flash = jest.fn((type, message) => {
+            if (message) {
+                if (!store[type]) {
+                    store[type] = [];
+                }
+                store[type].push(message);
+                return store[type];
+            }
+
+            const messages = store[type] ? [...store[type]] : [];
+            store[type] = [];
+            return messages;
+        });
+        next();
+    };
+};
+
+jest.mock('../../../src/middlewares/authMiddleware', () => jest.fn((req, res, next) => {
+    req.user = { ...mockCurrentUser };
+    next();
+}));
+
+jest.mock('../../../src/services/supportTicketService', () => ({
+    listTicketsForUser: jest.fn(),
+    createTicket: jest.fn(),
+    addMessage: jest.fn(),
+    updateTicketStatus: jest.fn()
+}));
+
+const supportRoutes = require('../../../src/routes/supportRoutes');
+const supportTicketService = require('../../../src/services/supportTicketService');
+
+const buildApp = () => {
+    const app = express();
+    app.set('view engine', 'ejs');
+    app.set('views', path.join(__dirname, '../../../src/views'));
+    app.use(express.urlencoded({ extended: true }));
+    app.use(express.json());
+    app.use(createFlashStub());
+    app.use('/support', supportRoutes);
+    return app;
+};
+
+describe('Rotas de suporte - tickets', () => {
+    let app;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCurrentUser = {
+            id: 1,
+            role: 'client',
+            active: true,
+            name: 'Cliente Teste',
+            email: 'cliente@example.com'
+        };
+        app = buildApp();
+        supportTicketService.listTicketsForUser.mockResolvedValue([
+            {
+                id: 10,
+                subject: 'Problema no acesso',
+                status: 'pending',
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                messages: [],
+                creator: { id: 1, name: 'Cliente Teste', role: 'client' },
+                assignee: null
+            }
+        ]);
+        supportTicketService.createTicket.mockResolvedValue({ ticket: { id: 10 } });
+        supportTicketService.addMessage.mockResolvedValue({ ticket: { id: 10 } });
+        supportTicketService.updateTicketStatus.mockResolvedValue({ id: 10 });
+    });
+
+    it('renderiza a lista de tickets do usuário autenticado', async () => {
+        const response = await request(app).get('/support/tickets');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Problema no acesso');
+        expect(supportTicketService.listTicketsForUser).toHaveBeenCalledWith({
+            user: expect.objectContaining({ id: 1 })
+        });
+    });
+
+    it('permite criar um novo ticket e redireciona para a listagem', async () => {
+        const response = await request(app)
+            .post('/support/tickets')
+            .send({ subject: 'Erro na fatura', description: '<p>Detalhes</p>' });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/support/tickets');
+        expect(supportTicketService.createTicket).toHaveBeenCalledWith(expect.objectContaining({
+            subject: 'Erro na fatura',
+            description: '<p>Detalhes</p>',
+            creator: expect.objectContaining({ id: 1 })
+        }));
+    });
+
+    it('registra uma nova mensagem para o ticket', async () => {
+        const response = await request(app)
+            .post('/support/tickets/10/messages')
+            .send({ body: 'Atualização importante' });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/support/tickets');
+        expect(supportTicketService.addMessage).toHaveBeenCalledWith(expect.objectContaining({
+            ticketId: 10,
+            sender: expect.objectContaining({ id: 1 }),
+            body: 'Atualização importante'
+        }));
+    });
+
+    it('atualiza o status do ticket solicitado', async () => {
+        mockCurrentUser = { ...mockCurrentUser, role: 'admin' };
+        const response = await request(app)
+            .post('/support/tickets/10/status')
+            .send({ status: 'resolved' });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/support/tickets');
+        expect(supportTicketService.updateTicketStatus).toHaveBeenCalledWith(expect.objectContaining({
+            ticketId: 10,
+            status: 'resolved',
+            actor: expect.objectContaining({ id: 1 })
+        }));
+    });
+});


### PR DESCRIPTION
## Summary
- add a dedicated supportTicketController to render the ticket list and coordinate ticket creation, messaging, and status updates
- extend supportTicketService with a listTicketsForUser helper that returns enriched ticket payloads for the UI
- wire new /support/tickets routes through auth middleware and cover the endpoints with integration tests

## Testing
- npm test -- test:integration

------
https://chatgpt.com/codex/tasks/task_e_68cda0e17bb0832fb7bfe75a5dd4209a