### PR TITLE
Add GET budgets route and ensure pagination response

### DIFF
--- a/src/controllers/budgetController.js
+++ b/src/controllers/budgetController.js
@@ -174,8 +174,24 @@ const budgetController = {
                 userId,
                 financeCategoryId: req.query?.financeCategoryId ? parseIntegerId(req.query.financeCategoryId, 'Categoria financeira inválida.') : undefined
             };
-            const budgets = await budgetService.listBudgets(filters);
-            return sendSuccess(res, { data: budgets });
+            const result = await budgetService.listBudgets(filters);
+
+            const data = Array.isArray(result?.data)
+                ? result.data
+                : Array.isArray(result)
+                    ? result
+                    : [];
+
+            const pagination = result && typeof result === 'object' && !Array.isArray(result) && result.pagination
+                ? result.pagination
+                : {
+                    page: 1,
+                    pageSize: Array.isArray(data) ? data.length : 0,
+                    totalItems: Array.isArray(data) ? data.length : 0,
+                    totalPages: Array.isArray(data) && data.length > 0 ? 1 : 0
+                };
+
+            return sendSuccess(res, { data: { data, pagination } });
         } catch (error) {
             return handleError(res, error, 'Erro ao listar orçamentos.');
         }

--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -190,6 +190,17 @@ router.post(
     })
 );
 
+router.get(
+    '/budgets',
+    authMiddleware,
+    requireFinanceAccess,
+    audit('financeBudget.list', (req) => {
+        const categoryId = req.query?.financeCategoryId || 'all';
+        return `FinanceBudget:list:${categoryId}`;
+    }),
+    adaptBudgetJsonResponse(budgetController.list)
+);
+
 router.put(
     '/budgets/:id',
     authMiddleware,

--- a/tests/integration/financeController.budgets.test.js
+++ b/tests/integration/financeController.budgets.test.js
@@ -165,4 +165,34 @@ describe('FinanceController budgets endpoints', () => {
         expect(response.status).toBe(400);
         expect(response.body).toEqual({ message: 'Cada limite de alerta deve ser um número maior que zero.' });
     });
+
+    it('lista os orçamentos existentes com paginação padrão', async () => {
+        await Budget.create({
+            userId: user.id,
+            financeCategoryId: category.id,
+            monthlyLimit: 500.75,
+            thresholds: [0.5, 0.8],
+            referenceMonth: '2024-09-01'
+        });
+
+        const response = await request(app)
+            .get('/finance/budgets');
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data).toHaveLength(1);
+        expect(response.body.data[0]).toMatchObject({
+            userId: user.id,
+            financeCategoryId: category.id,
+            referenceMonth: '2024-09-01'
+        });
+        expect(response.body.data[0].monthlyLimit).toBeCloseTo(500.75);
+        expect(response.body.data[0].thresholds).toEqual([0.5, 0.8]);
+        expect(response.body.pagination).toEqual({
+            page: 1,
+            pageSize: 25,
+            totalItems: 1,
+            totalPages: 1
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- add the authenticated, permissioned GET /finance/budgets route that reuses the JSON adapter
- adjust the budget controller list action to always return `{ data, pagination }`
- cover the new listing endpoint with an integration test

## Testing
- npx jest --runInBand tests/integration/financeController.budgets.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cda0e31160832fafacb0d93b8eeb54