### PR TITLE
Handle empty finance data states

### DIFF
--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -83,8 +83,20 @@ const adaptBudgetJsonResponse = (handler, { prepare } = {}) => async (req, res, 
 
     res.json = (payload) => {
         if (payload && typeof payload === 'object') {
-            if (payload.success === true && Object.prototype.hasOwnProperty.call(payload, 'data')) {
-                return originalJson(payload.data);
+            if (payload.success === true) {
+                if (payload.pagination !== undefined) {
+                    const normalizedData = Object.prototype.hasOwnProperty.call(payload, 'data')
+                        ? payload.data
+                        : [];
+                    return originalJson({
+                        data: Array.isArray(normalizedData) ? normalizedData : [],
+                        pagination: payload.pagination
+                    });
+                }
+
+                if (Object.prototype.hasOwnProperty.call(payload, 'data')) {
+                    return originalJson(payload.data);
+                }
             }
 
             if (payload.success === false && payload.message) {

--- a/src/views/finance/manageFinance.ejs
+++ b/src/views/finance/manageFinance.ejs
@@ -18,13 +18,13 @@
     ? periodLabel.trim()
     : 'Todo o período'; %>
 <% const defaultFilters = {
-    startDate: '2024-05-01',
-    endDate: '2024-05-31',
-    type: 'receivable',
-    status: 'paid',
-    investmentPeriodMonths: 12,
-    investmentContribution: 0,
-    investmentContributionFrequency: 'monthly'
+    startDate: '',
+    endDate: '',
+    type: '',
+    status: '',
+    investmentPeriodMonths: '',
+    investmentContribution: '',
+    investmentContributionFrequency: ''
 }; %>
 <% const rawFilters = (typeof filters !== 'undefined' && filters && typeof filters === 'object') ? filters : {}; %>
 <% const filterValues = { ...defaultFilters, ...rawFilters }; %>
@@ -34,12 +34,12 @@
     ? budgetPageUrl.trim()
     : defaultBudgetPageUrl; %>
 <% const defaultSummaryTotals = {
-    receivable: 3200.75,
-    payable: 1850.25,
+    receivable: 0,
+    payable: 0,
     net: 0,
-    overdue: 450.2,
-    paid: 2200.55,
-    pending: 980.35
+    overdue: 0,
+    paid: 0,
+    pending: 0
 }; %>
 <% const summaryTotalsSource = (typeof financeTotals === 'object' && financeTotals) ? financeTotals : {}; %>
 <% const summaryTotals = { ...defaultSummaryTotals, ...summaryTotalsSource }; %>
@@ -51,18 +51,15 @@
 <% const formatCurrency = formatCurrencyFn; %>
 <% const netAmount = Number(summaryTotals.net || 0); %>
 <% const netClass = netAmount > 0 ? 'text-success' : netAmount < 0 ? 'text-danger' : 'text-muted'; %>
-<% const defaultMonthlySummary = [
-    { month: '2024-04', receivable: 1600.50, payable: 920.15 },
-    { month: '2024-05', receivable: 1600.25, payable: 930.10 }
-]; %>
+<% const defaultMonthlySummary = []; %>
 <% const monthlySummaryList = (typeof monthlySummary !== 'undefined' && Array.isArray(monthlySummary) && monthlySummary.length)
     ? monthlySummary
     : defaultMonthlySummary; %>
 <% const hasMonthlySummary = monthlySummaryList.length > 0; %>
 <% const summaryMonthly = monthlySummaryList; %>
 <% const defaultStatusSummary = {
-    receivable: { pending: 1200.4, paid: 1600.35, overdue: 400.0, cancelled: 0 },
-    payable: { pending: 900.2, paid: 750.05, overdue: 200.0, cancelled: 0 }
+    receivable: {},
+    payable: {}
 }; %>
 <% const statusSummaryData = (typeof statusSummary !== 'undefined' && typeof statusSummary === 'object' && statusSummary)
     ? statusSummary

--- a/tests/unit/views/manageFinance.test.js
+++ b/tests/unit/views/manageFinance.test.js
@@ -42,6 +42,22 @@ const buildViewContext = () => ({
     projectionAlerts: [],
     financeGoals: [],
     goalSummary: { total: 0, alerts: 0 },
+    financeTotals: {
+        receivable: 3200.75,
+        payable: 1850.25,
+        net: 1350.5,
+        overdue: 450.2,
+        paid: 2200.55,
+        pending: 980.35
+    },
+    monthlySummary: [
+        { month: '2024-04', receivable: 1600.5, payable: 920.15 },
+        { month: '2024-05', receivable: 1600.25, payable: 930.1 }
+    ],
+    statusSummary: {
+        receivable: { pending: 1200.4, paid: 1600.35, overdue: 400, cancelled: 0 },
+        payable: { pending: 900.2, paid: 750.05, overdue: 200, cancelled: 0 }
+    },
     filters: {
         startDate: '2024-05-01',
         endDate: '2024-05-31',


### PR DESCRIPTION
## Summary
- remove illustrative finance defaults from the manageFinance view and allow empty collections
- normalize summary data in the finance controller before rendering and keep budget JSON pagination metadata
- update the finance view unit test context to provide concrete totals for assertions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf05acf25c832fb14e24772621bf6e