### PR TITLE
Preserve pagination metadata in budget responses

### DIFF
--- a/src/routes/financeRoutes.js
+++ b/src/routes/financeRoutes.js
@@ -84,6 +84,12 @@ const adaptBudgetJsonResponse = (handler, { prepare } = {}) => async (req, res, 
     res.json = (payload) => {
         if (payload && typeof payload === 'object') {
             if (payload.success === true && Object.prototype.hasOwnProperty.call(payload, 'data')) {
+                if (payload && Object.prototype.hasOwnProperty.call(payload, 'pagination') && payload.pagination !== undefined) {
+                    return originalJson({
+                        data: payload.data,
+                        pagination: payload.pagination
+                    });
+                }
                 return originalJson(payload.data);
             }
 


### PR DESCRIPTION
## Summary
- adjust the budget response adapter to keep pagination metadata alongside the data payload when present
- ensure non-paginated budget responses retain their existing shapes while still benefiting from the adapter handling

## Testing
- npm test -- tests/integration/financeController.budgets.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf05c84e6c832fa432142e0a9b3ba1