### PR TITLE
Fix support chat reconnect handling

### DIFF
--- a/public/js/support-chat.js
+++ b/public/js/support-chat.js
@@ -365,7 +365,11 @@ const bindSocketEvents = () => {
     }
 
     socket.on('connect', () => {
-        if (!state.isAdmin) {
+        if (state.isAdmin) {
+            if (state.asAdmin) {
+                joinChat(true);
+            }
+        } else {
             joinChat(false);
         }
     });
@@ -378,6 +382,15 @@ const bindSocketEvents = () => {
 
     socket.on('support:agent:online', () => {
         setAgentStatus('Administrador conectado', 'primary');
+    });
+
+    socket.on('disconnect', () => {
+        state.joined = false;
+        state.joining = false;
+
+        if (state.isAdmin && elements.adminEntryButton) {
+            elements.adminEntryButton.classList.remove('d-none');
+        }
     });
 };
 


### PR DESCRIPTION
## Summary
- reset the support chat join state when the socket disconnects so the admin entry control becomes available again
- invoke chat rejoin on every reconnect, restoring admin sessions automatically when appropriate

## Testing
- npm test *(fails: known integration budget listing test expects response envelope with data array)*
- npm run test:integration -- tests/integration/financeController.budgets.test.js *(fails: same response envelope expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68cf06770300832f9ee3ff8252bd1063