### PR TITLE
feat: add detailed support ticket view

### DIFF
--- a/src/controllers/supportTicketController.js
+++ b/src/controllers/supportTicketController.js
@@ -2,6 +2,103 @@ const { TICKET_STATUSES, isSupportAgentRole } = require('../constants/support');
 const { ROLE_LABELS } = require('../constants/roles');
 const supportTicketService = require('../services/supportTicketService');
 
+const STATUS_LABELS = Object.freeze({
+    [TICKET_STATUSES.PENDING]: 'Pendente',
+    [TICKET_STATUSES.IN_PROGRESS]: 'Em andamento',
+    [TICKET_STATUSES.RESOLVED]: 'Resolvido'
+});
+
+const PRIORITY_LABELS = Object.freeze({
+    low: 'Baixa',
+    medium: 'Média',
+    high: 'Alta'
+});
+
+const formatDateTime = (value) => {
+    if (!value) {
+        return '—';
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return '—';
+    }
+
+    return new Intl.DateTimeFormat('pt-BR', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+    }).format(date);
+};
+
+const formatFileSize = (sizeInBytes) => {
+    const size = Number(sizeInBytes);
+    if (!Number.isFinite(size) || size <= 0) {
+        return '—';
+    }
+
+    const units = ['B', 'KB', 'MB', 'GB'];
+    const exponent = Math.min(
+        Math.floor(Math.log(size) / Math.log(1024)),
+        units.length - 1
+    );
+    const normalizedSize = size / (1024 ** exponent);
+
+    return `${normalizedSize.toFixed(normalizedSize >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const buildTicketDetailViewModel = (ticket) => {
+    if (!ticket) {
+        return null;
+    }
+
+    const normalizedPriority = ticket.priority || 'medium';
+    const attachments = Array.isArray(ticket.attachments)
+        ? ticket.attachments.map((attachment) => ({
+            ...attachment,
+            mimeType: attachment.contentType || 'Arquivo',
+            sizeFormatted: formatFileSize(attachment.fileSize),
+            createdAtFormatted: formatDateTime(attachment.createdAt),
+            downloadUrl: attachment.id ? `/support/attachments/${attachment.id}/download` : null
+        }))
+        : [];
+
+    const initialMessage = Array.isArray(ticket.messages) && ticket.messages.length
+        ? ticket.messages[0].body
+        : '';
+
+    return {
+        ...ticket,
+        attachments,
+        attachmentCount: attachments.length,
+        createdAtFormatted: formatDateTime(ticket.createdAt),
+        updatedAtFormatted: formatDateTime(ticket.updatedAt),
+        statusLabel: STATUS_LABELS[ticket.status] || '—',
+        priority: normalizedPriority,
+        priorityLabel: PRIORITY_LABELS[normalizedPriority] || 'Padrão',
+        initialMessage
+    };
+};
+
+const buildMessageTimeline = (messages = []) => {
+    return messages.map((message) => ({
+        ...message,
+        createdAtFormatted: formatDateTime(message.createdAt),
+        senderDisplay: message.sender?.name || 'Usuário',
+        senderRoleLabel: message.sender?.role ? ROLE_LABELS[message.sender.role] || 'Usuário' : null,
+        attachments: Array.isArray(message.attachments)
+            ? message.attachments.map((attachment) => ({
+                ...attachment,
+                mimeType: attachment.contentType || 'Arquivo',
+                sizeFormatted: formatFileSize(attachment.fileSize),
+                downloadUrl: attachment.id ? `/support/attachments/${attachment.id}/download` : null
+            }))
+            : []
+    }));
+};
+
 const getRequestUser = (req) => {
     if (req.user && req.user.active) {
         return req.user;
@@ -141,6 +238,50 @@ const supportTicketController = {
         } catch (error) {
             console.error('Erro ao atualizar status do chamado de suporte:', error);
             pushFlashMessage(req, 'error_msg', error?.message || 'Não foi possível atualizar o status do chamado.');
+            return res.redirect('/support/tickets');
+        }
+    },
+
+    async showTicket(req, res) {
+        try {
+            const user = getRequestUser(req);
+            if (!user) {
+                pushFlashMessage(req, 'error_msg', 'Você precisa estar logado para visualizar o chamado.');
+                return res.redirect('/login');
+            }
+
+            const ticket = await supportTicketService.getTicketById({
+                ticketId: req.params.ticketId
+            });
+
+            const isAgent = isSupportAgentRole(user.role);
+            const isCreator = ticket.creatorId === user.id;
+            const isAssignee = ticket.assignedToId && ticket.assignedToId === user.id;
+
+            if (!isAgent && !isCreator && !isAssignee) {
+                pushFlashMessage(req, 'error_msg', 'Você não possui permissão para visualizar este chamado.');
+                return res.redirect('/support/tickets');
+            }
+
+            const ticketView = buildTicketDetailViewModel(ticket);
+            const timeline = buildMessageTimeline(ticket.messages);
+
+            res.render('support/ticketDetail', {
+                ticket: ticketView,
+                messages: timeline,
+                isAgent,
+                user,
+                chatUrl: `/support/tickets/${ticket.id}/chat`,
+                roleLabels: ROLE_LABELS,
+                notifications: [],
+                success_msg: pullFlashMessage(req, 'success_msg'),
+                error_msg: pullFlashMessage(req, 'error_msg'),
+                pageTitle: `Chamado #${ticket.id}`,
+                appName: req.app?.locals?.appName || 'Sistema de Gestão'
+            });
+        } catch (error) {
+            console.error('Erro ao exibir detalhes do chamado de suporte:', error);
+            pushFlashMessage(req, 'error_msg', error?.message || 'Não foi possível carregar os detalhes do chamado.');
             return res.redirect('/support/tickets');
         }
     }

--- a/src/routes/supportRoutes.js
+++ b/src/routes/supportRoutes.js
@@ -19,6 +19,7 @@ router.get('/tickets', authMiddleware, supportTicketController.listTickets);
 router.post('/tickets', authMiddleware, supportTicketController.createTicket);
 router.post('/tickets/:ticketId/messages', authMiddleware, supportTicketController.addMessage);
 router.post('/tickets/:ticketId/status', authMiddleware, supportTicketController.updateStatus);
+router.get('/tickets/:ticketId', authMiddleware, supportTicketController.showTicket);
 router.get('/tickets/:ticketId/chat', authMiddleware, supportController.renderChat);
 router.get('/tickets/:ticketId/history', authMiddleware, supportController.fetchHistory);
 router.post(

--- a/src/services/supportTicketService.js
+++ b/src/services/supportTicketService.js
@@ -145,7 +145,19 @@ const mapTicketPayload = (ticketInstance) => {
         : ticketInstance;
 
     const attachments = Array.isArray(plain.attachments)
-        ? plain.attachments.slice().sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+        ? plain.attachments
+            .slice()
+            .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+            .map((attachment) => ({
+                id: attachment.id,
+                ticketId: attachment.ticketId,
+                messageId: attachment.messageId || null,
+                uploadedById: attachment.uploadedById || null,
+                fileName: attachment.fileName,
+                fileSize: attachment.fileSize || null,
+                contentType: attachment.contentType || null,
+                createdAt: attachment.createdAt
+            }))
         : [];
 
     const attachmentsByMessageId = attachments.reduce((accumulator, attachment) => {
@@ -218,7 +230,67 @@ const mapTicketPayload = (ticketInstance) => {
             }
             : null,
         messages: normalizedMessages
+            .map((message) => ({
+                ...message,
+                attachments: (message.attachments || []).map((attachment) => ({
+                    ...attachment,
+                    contentType: attachment.contentType || null
+                }))
+            })),
+        attachments,
+        attachmentCount: attachments.length
     };
+};
+
+const getTicketById = async ({ ticketId }) => {
+    const numericId = Number.parseInt(ticketId, 10);
+
+    if (!Number.isInteger(numericId) || numericId <= 0) {
+        throw new Error('Identificador de chamado inválido.');
+    }
+
+    const ticket = await SupportTicket.findByPk(numericId, {
+        include: [
+            {
+                model: User,
+                as: 'creator',
+                attributes: ['id', 'name', 'email', 'role']
+            },
+            {
+                model: User,
+                as: 'assignee',
+                attributes: ['id', 'name', 'email', 'role']
+            },
+            {
+                model: SupportMessage,
+                as: 'messages',
+                include: [
+                    {
+                        model: User,
+                        as: 'sender',
+                        attributes: ['id', 'name', 'role']
+                    }
+                ]
+            },
+            {
+                model: SupportAttachment,
+                as: 'attachments',
+                attributes: ['id', 'ticketId', 'messageId', 'uploadedById', 'fileName', 'fileSize', 'contentType', 'createdAt']
+            }
+        ],
+        order: [
+            [{ model: SupportMessage, as: 'messages' }, 'createdAt', 'ASC'],
+            [{ model: SupportAttachment, as: 'attachments' }, 'createdAt', 'ASC']
+        ]
+    });
+
+    if (!ticket) {
+        const error = new Error('Chamado não encontrado.');
+        error.statusCode = 404;
+        throw error;
+    }
+
+    return mapTicketPayload(ticket);
 };
 
 const listTicketsForUser = async ({ user, statusFilter = null }) => {
@@ -535,6 +607,7 @@ const assignTicket = async ({
 
 module.exports = {
     listTicketsForUser,
+    getTicketById,
     createTicket,
     addMessage,
     updateTicketStatus,

--- a/src/views/support/ticketDetail.ejs
+++ b/src/views/support/ticketDetail.ejs
@@ -2,6 +2,7 @@
 
 <% const ticketSafe = ticket || {}; %>
 <% const attachmentsSafe = Array.isArray(ticketSafe.attachments) ? ticketSafe.attachments : []; %>
+<% const messagesSafe = Array.isArray(messages) ? messages : []; %>
 <% const statusBadgeClasses = {
     open: 'bg-primary-subtle text-primary',
     'in-progress': 'bg-warning-subtle text-warning',
@@ -69,6 +70,73 @@
                 </div>
             </div>
 
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body p-4 p-lg-5">
+                    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-3">
+                        <h2 class="h4 fw-semibold mb-0">Histórico de mensagens</h2>
+                        <a href="<%= chatUrl %>" class="btn btn-gradient btn-lg shadow-sm">
+                            <i class="bi bi-chat-dots me-2"></i>
+                            Abrir conversa em tempo real
+                        </a>
+                    </div>
+
+                    <% if (!messagesSafe.length) { %>
+                        <div class="text-center text-muted py-4">
+                            <i class="bi bi-inbox display-6 mb-3"></i>
+                            <p class="mb-0">Ainda não há mensagens neste chamado.</p>
+                        </div>
+                    <% } else { %>
+                        <div class="timeline">
+                            <% messagesSafe.forEach((message) => { %>
+                                <div class="timeline-item py-4 border-bottom">
+                                    <div class="d-flex justify-content-between align-items-start">
+                                        <div>
+                                            <div class="fw-semibold d-flex align-items-center gap-2">
+                                                <i class="bi <%= message.isFromAgent ? 'bi-headset' : 'bi-person-circle' %> text-primary"></i>
+                                                <span><%= message.senderDisplay %></span>
+                                                <% if (message.senderRoleLabel) { %>
+                                                    <span class="badge bg-body-secondary text-muted"><%= message.senderRoleLabel %></span>
+                                                <% } %>
+                                                <% if (message.isSystem) { %>
+                                                    <span class="badge bg-warning-subtle text-warning">Sistema</span>
+                                                <% } %>
+                                            </div>
+                                            <div class="text-muted small"><%= message.createdAtFormatted %></div>
+                                        </div>
+                                    </div>
+                                    <% if (message.body) { %>
+                                        <article class="prose mt-3">
+                                            <% message.body.split(/\n+/).forEach((paragraph) => { %>
+                                                <% if (paragraph.trim()) { %>
+                                                    <p class="text-body"><%= paragraph %></p>
+                                                <% } %>
+                                            <% }); %>
+                                        </article>
+                                    <% } %>
+
+                                    <% if (message.attachments && message.attachments.length) { %>
+                                        <div class="mt-3">
+                                            <h3 class="h6 text-uppercase text-muted mb-2">Anexos</h3>
+                                            <div class="d-flex flex-column gap-2">
+                                                <% message.attachments.forEach((attachment) => { %>
+                                                    <a href="<%= attachment.downloadUrl %>" class="d-flex align-items-center justify-content-between px-3 py-2 border rounded-4 text-decoration-none hover-shadow">
+                                                        <div>
+                                                            <div class="fw-semibold text-body"><%= attachment.fileName %></div>
+                                                            <small class="text-muted"><%= attachment.mimeType %> · <%= attachment.sizeFormatted %></small>
+                                                        </div>
+                                                        <i class="bi bi-download text-primary"></i>
+                                                    </a>
+                                                <% }); %>
+                                            </div>
+                                        </div>
+                                    <% } %>
+                                </div>
+                            <% }); %>
+                        </div>
+                    <% } %>
+                </div>
+            </div>
+
             <div class="card border-0 shadow-sm">
                 <div class="card-body p-4 p-lg-5">
                     <div class="d-flex justify-content-between align-items-center mb-3">
@@ -89,7 +157,15 @@
                                         <div class="fw-semibold"><%= attachment.fileName %></div>
                                         <small class="text-muted"><%= attachment.mimeType %> · <%= attachment.sizeFormatted %></small>
                                     </div>
-                                    <span class="badge bg-body-secondary text-muted"><%= attachment.createdAt ? new Date(attachment.createdAt).toLocaleString('pt-BR', { hour: '2-digit', minute: '2-digit', day: '2-digit', month: 'short' }) : '' %></span>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <span class="badge bg-body-secondary text-muted"><%= attachment.createdAtFormatted %></span>
+                                        <% if (attachment.downloadUrl) { %>
+                                            <a href="<%= attachment.downloadUrl %>" class="btn btn-sm btn-outline-primary">
+                                                <i class="bi bi-download"></i>
+                                                Baixar
+                                            </a>
+                                        <% } %>
+                                    </div>
                                 </li>
                             <% }); %>
                         </ul>


### PR DESCRIPTION
## Summary
- add a support ticket service query to fetch a ticket with messages and attachments
- expose a controller action and route to render the detailed ticket page with access validation
- enhance the ticket detail view with message history, download links, and chat shortcut

## Testing
- npm run test:unit -- supportTicketService
- npm run test:integration -- supportTicketRoutes

------
https://chatgpt.com/codex/tasks/task_e_68cf1ff88088832f8db50657bb128755