### PR TITLE
refactor: consolidate support ticket datetime formatter

### DIFF
--- a/src/controllers/supportTicketController.js
+++ b/src/controllers/supportTicketController.js
@@ -14,25 +14,6 @@ const PRIORITY_LABELS = Object.freeze({
     high: 'Alta'
 });
 
-const formatDateTime = (value) => {
-    if (!value) {
-        return '—';
-    }
-
-    const date = value instanceof Date ? value : new Date(value);
-    if (Number.isNaN(date.getTime())) {
-        return '—';
-    }
-
-    return new Intl.DateTimeFormat('pt-BR', {
-        day: '2-digit',
-        month: 'short',
-        year: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit'
-    }).format(date);
-};
-
 const formatFileSize = (sizeInBytes) => {
     const size = Number(sizeInBytes);
     if (!Number.isFinite(size) || size <= 0) {


### PR DESCRIPTION
## Summary
- remove the duplicate `formatDateTime` helper definition in the support ticket controller
- keep the more robust formatter implementation and ensure all existing usages share the same helper

## Testing
- npm run test:health
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf230e8f34832f8fe567af02c918ba