### PR TITLE
Corrige navegação do cabeçalho e status de suporte

### DIFF
--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -138,7 +138,13 @@
     const navQuickActions = dedupeByRoute(providedQuickActions || computedQuickActions);
     const quickActionRoutes = new Set(navQuickActions.map((item) => item.route));
     const navMenuItems = dedupeByRoute(
-        (providedMenuItems || computedMenuItems).filter((item) => !quickActionRoutes.has(item.route))
+        (providedMenuItems || computedMenuItems).filter((item) => {
+            if (Array.isArray(item.children) && item.children.length) {
+                return true;
+            }
+
+            return !quickActionRoutes.has(item.route);
+        })
     );
 %>
 

--- a/src/views/support/chat.ejs
+++ b/src/views/support/chat.ejs
@@ -1,5 +1,27 @@
 <%- include('../partials/header') %>
 
+<%
+    const statusStyles = {
+        pending: {
+            label: 'Pendente',
+            indicatorClass: 'status-indicator--pending'
+        },
+        in_progress: {
+            label: 'Em andamento',
+            indicatorClass: 'status-indicator--in-progress'
+        },
+        resolved: {
+            label: 'Resolvido',
+            indicatorClass: 'status-indicator--resolved'
+        }
+    };
+    const ticketStatusKey = ticket && typeof ticket.status === 'string' ? ticket.status : 'pending';
+    const ticketStatusStyle = statusStyles[ticketStatusKey] || {
+        label: ticketStatusKey || 'Status indefinido',
+        indicatorClass: 'status-indicator--default'
+    };
+%>
+
 <section class="support-chat-wrapper">
     <div class="row g-4">
         <div class="col-lg-4">
@@ -24,8 +46,8 @@
                     </div>
 
                     <div class="support-chat__status d-flex align-items-center gap-2">
-                        <span class="status-indicator"></span>
-                        <span class="text-uppercase small fw-semibold"><%= ticket.status %></span>
+                        <span class="status-indicator <%= ticketStatusStyle.indicatorClass %>" aria-hidden="true"></span>
+                        <span class="text-uppercase small fw-semibold"><%= ticketStatusStyle.label %></span>
                     </div>
 
                     <div>
@@ -220,8 +242,26 @@
         width: 10px;
         height: 10px;
         border-radius: 50%;
+    }
+
+    .support-chat__status .status-indicator--pending {
+        background: #f59e0b;
+        box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.15);
+    }
+
+    .support-chat__status .status-indicator--in-progress {
+        background: #3b82f6;
+        box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+    }
+
+    .support-chat__status .status-indicator--resolved {
         background: #22c55e;
         box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+    }
+
+    .support-chat__status .status-indicator--default {
+        background: #94a3b8;
+        box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.15);
     }
 
     @media (max-width: 991px) {

--- a/src/views/support/listTickets.ejs
+++ b/src/views/support/listTickets.ejs
@@ -2,9 +2,9 @@
 
 <% const safeTickets = Array.isArray(tickets) ? tickets : []; %>
 <% const statusBadgeClasses = {
-    open: 'bg-primary-subtle text-primary',
-    'in-progress': 'bg-warning-subtle text-warning',
-    closed: 'bg-success-subtle text-success'
+    pending: 'bg-warning-subtle text-warning',
+    in_progress: 'bg-primary-subtle text-primary',
+    resolved: 'bg-success-subtle text-success'
 }; %>
 <% const priorityDotClasses = {
     low: 'bg-success',

--- a/src/views/support/ticketDetail.ejs
+++ b/src/views/support/ticketDetail.ejs
@@ -4,9 +4,9 @@
 <% const attachmentsSafe = Array.isArray(ticketSafe.attachments) ? ticketSafe.attachments : []; %>
 <% const messagesSafe = Array.isArray(messages) ? messages : []; %>
 <% const statusBadgeClasses = {
-    open: 'bg-primary-subtle text-primary',
-    'in-progress': 'bg-warning-subtle text-warning',
-    closed: 'bg-success-subtle text-success'
+    pending: 'bg-warning-subtle text-warning',
+    in_progress: 'bg-primary-subtle text-primary',
+    resolved: 'bg-success-subtle text-success'
 }; %>
 <% const priorityDotClasses = {
     low: 'bg-success',


### PR DESCRIPTION
## Summary
- impede que o menu principal perca itens com submenu quando há atalhos rápidos duplicados
- ajusta as classes de status dos tickets para refletir corretamente os estados pendente, em andamento e resolvido
- melhora o cabeçalho do chat de suporte exibindo rótulos amigáveis e indicador visual conforme o status

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf25a9427c832f84f5d0cb7c4c534d