### PR TITLE
Atualiza anexos do chat de suporte

### DIFF
--- a/public/js/support-chat.js
+++ b/public/js/support-chat.js
@@ -26,6 +26,23 @@ const state = {
 
 const socket = typeof io === 'function' ? io() : null;
 
+const getAttachmentName = (attachment) => {
+    if (!attachment) {
+        return 'arquivo';
+    }
+
+    return attachment.fileName || attachment.originalName || 'arquivo';
+};
+
+const getAttachmentSize = (attachment) => {
+    if (!attachment) {
+        return 0;
+    }
+
+    const size = Number(attachment.fileSize ?? attachment.size ?? 0);
+    return Number.isFinite(size) && size >= 0 ? size : 0;
+};
+
 const formatTime = (value) => {
     const date = value ? new Date(value) : new Date();
     if (Number.isNaN(date.getTime())) {
@@ -121,7 +138,7 @@ const renderMessage = (message) => {
         const attachmentLink = document.createElement('a');
         attachmentLink.href = `/support/attachments/${message.attachment.id}/download`;
         attachmentLink.className = 'd-inline-flex align-items-center gap-2 small fw-semibold';
-        attachmentLink.innerHTML = `<i class="bi bi-paperclip"></i> ${message.attachment.originalName}`;
+        attachmentLink.innerHTML = `<i class="bi bi-paperclip"></i> ${getAttachmentName(message.attachment)}`;
         bubble.append(attachmentLink);
     }
 
@@ -158,13 +175,13 @@ const renderAttachments = () => {
         item.className = 'attachment-item d-flex align-items-center gap-3';
         item.dataset.attachmentId = attachment.id;
 
-        const sizeKb = ((attachment.size || 0) / 1024).toFixed(1);
+        const sizeKb = (getAttachmentSize(attachment) / 1024).toFixed(1);
 
         item.innerHTML = `
             <span class="attachment-icon bg-primary-subtle text-primary"><i class="bi bi-paperclip"></i></span>
             <div class="flex-grow-1">
                 <a class="text-decoration-none fw-semibold" href="/support/attachments/${attachment.id}/download">
-                    ${attachment.originalName}
+                    ${getAttachmentName(attachment)}
                 </a>
                 <small class="text-muted d-block">Tamanho: ${sizeKb} KB</small>
             </div>

--- a/src/views/support/chat.ejs
+++ b/src/views/support/chat.ejs
@@ -65,9 +65,9 @@
                                                     class="text-decoration-none fw-semibold"
                                                     href="/support/attachments/<%= attachment.id %>/download"
                                                 >
-                                                    <%= attachment.originalName %>
+                                                    <%= attachment.fileName || attachment.originalName %>
                                                 </a>
-                                                <small class="text-muted d-block">Tamanho: <%= (((attachment.size || 0) / 1024).toFixed(1)) %> KB</small>
+                                                <small class="text-muted d-block">Tamanho: <%= (((attachment.fileSize || attachment.size || 0) / 1024).toFixed(1)) %> KB</small>
                                             </div>
                                         </li>
                                     <% }); %>


### PR DESCRIPTION
## Summary
- Normaliza anexos do chat de suporte para expor fileName, contentType e fileSize mantendo compatibilidade com clientes existentes
- Atualiza controller, view e frontend para exibir os novos campos e reforça os cabeçalhos de download dos anexos
- Amplia os testes de rotas de suporte para cobrir upload, listagem e download com os novos atributos

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a458572c832fbbc847d204c691b8