### PR TITLE
Implement finance payments pagination and aggregated summaries

### DIFF
--- a/src/controllers/financeController.js
+++ b/src/controllers/financeController.js
@@ -678,6 +678,23 @@ const serializeAttachmentForView = (attachment) => {
     };
 };
 
+const formatDateInputValue = (value) => {
+    if (!value) {
+        return '';
+    }
+
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return value;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (!Number.isFinite(date?.getTime())) {
+        return '';
+    }
+
+    return date.toISOString().slice(0, 10);
+};
+
 const serializeEntryForView = (entry) => {
     const plain = typeof entry?.get === 'function'
         ? entry.get({ plain: true })
@@ -705,13 +722,18 @@ const serializeEntryForView = (entry) => {
         ? plain.attachments.map(serializeAttachmentForView)
         : [];
 
+    const valueNumber = parseAmount(plain.value);
+
     return {
         id: plain.id ?? null,
         description: sanitizeText(plain.description),
         type: normalizedType,
-        value: parseAmount(plain.value),
+        value: valueNumber,
+        valueInput: Number.isFinite(valueNumber) ? valueNumber.toFixed(2) : '0.00',
         dueDate: plain.dueDate || null,
+        dueDateInput: formatDateInputValue(plain.dueDate),
         paymentDate: plain.paymentDate || null,
+        paymentDateInput: formatDateInputValue(plain.paymentDate),
         status: normalizedStatus,
         categoryId,
         categoryLabel: categoryName,
@@ -913,7 +935,32 @@ const buildFiltersFromQuery = (query = {}) => {
     return filters;
 };
 
-const buildEntriesQueryOptions = (filters = {}) => {
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+
+const resolvePaginationFromQuery = (query = {}) => {
+    const rawPage = Number.parseInt(query.page, 10);
+    const rawPageSize = Number.parseInt(query.pageSize ?? query.limit, 10);
+
+    const page = Number.isInteger(rawPage) && rawPage > 0 ? rawPage : 1;
+
+    let pageSize = Number.isInteger(rawPageSize) && rawPageSize > 0 ? rawPageSize : DEFAULT_PAGE_SIZE;
+    if (pageSize > MAX_PAGE_SIZE) {
+        pageSize = MAX_PAGE_SIZE;
+    }
+
+    const limit = pageSize;
+    const offset = (page - 1) * pageSize;
+
+    return {
+        page,
+        pageSize,
+        limit,
+        offset
+    };
+};
+
+const buildEntriesQueryOptions = (filters = {}, extraOptions = {}) => {
     const options = {
         include: [
             {
@@ -955,6 +1002,20 @@ const buildEntriesQueryOptions = (filters = {}) => {
     }
 
     options.where = Object.keys(where).length > 0 ? where : undefined;
+
+    const limit = Number.isInteger(extraOptions.limit) && extraOptions.limit > 0
+        ? extraOptions.limit
+        : null;
+    const offset = Number.isInteger(extraOptions.offset) && extraOptions.offset >= 0
+        ? extraOptions.offset
+        : null;
+
+    if (limit !== null) {
+        options.limit = limit;
+    }
+    if (offset !== null) {
+        options.offset = offset;
+    }
 
     return options;
 };
@@ -1301,9 +1362,21 @@ const renderPaymentsPage = async (req, res) => {
             filters.userId = userId;
         }
 
-        const entriesPromise = FinanceEntry.findAll(buildEntriesQueryOptions(filters));
-        const summaryPromise = createSummaryPromise(entriesPromise, filters);
+        const pagination = resolvePaginationFromQuery(req.query);
+        const entryOptions = buildEntriesQueryOptions(filters, pagination);
+        const totalCountPromise = FinanceEntry.count({ where: entryOptions.where });
+        const summaryPromise = financeReportingService.getFinanceSummary(filters, { includeProjections: false });
         const categoriesPromise = fetchFinanceCategoriesForUser(userId);
+
+        const totalRecordsRaw = await totalCountPromise;
+        const totalRecords = Number.isInteger(totalRecordsRaw) ? totalRecordsRaw : 0;
+        const totalPages = totalRecords > 0 ? Math.ceil(totalRecords / pagination.pageSize) : 1;
+        const currentPage = totalRecords > 0 ? Math.min(pagination.page, totalPages) : 1;
+
+        entryOptions.limit = pagination.pageSize;
+        entryOptions.offset = (currentPage - 1) * pagination.pageSize;
+
+        const entriesPromise = FinanceEntry.findAll(entryOptions);
 
         const [entries, summary, categories] = await Promise.all([
             entriesPromise,
@@ -1335,6 +1408,18 @@ const renderPaymentsPage = async (req, res) => {
             ? normalizedSummary.projections
             : [];
 
+        const totalItems = totalRecords;
+        const paginationMeta = {
+            page: currentPage,
+            pageSize: pagination.pageSize,
+            totalPages,
+            totalRecords: totalItems,
+            hasPrevious: currentPage > 1,
+            hasNext: currentPage < totalPages,
+            previousPage: currentPage > 1 ? currentPage - 1 : null,
+            nextPage: currentPage < totalPages ? currentPage + 1 : null
+        };
+
         const importPreview = req.session?.financeImportPreview || null;
         if (importPreview) {
             res.locals.importPreview = importPreview;
@@ -1354,6 +1439,7 @@ const renderPaymentsPage = async (req, res) => {
             recurringIntervalOptions,
             contributionFrequencyLabels: CONTRIBUTION_FREQUENCY_LABELS,
             importPreview,
+            pagination: paginationMeta,
             formatCurrency
         });
     } catch (error) {

--- a/src/services/financeReportingService.js
+++ b/src/services/financeReportingService.js
@@ -372,6 +372,27 @@ const buildStatusSummaryFromEntries = (entries) => {
     return summary;
 };
 
+const buildStatusSummaryFromAggregates = (rows) => {
+    const summary = createEmptyStatusSummary();
+
+    if (!Array.isArray(rows)) {
+        return summary;
+    }
+
+    for (const row of rows) {
+        const type = FINANCE_TYPES.includes(row?.type) ? row.type : null;
+        const status = FINANCE_STATUSES.includes(row?.status) ? row.status : null;
+        if (!type || !status) {
+            continue;
+        }
+
+        const totalValue = row?.totalValue ?? row?.sum ?? row?.value ?? 0;
+        summary[type][status] += toNumber(totalValue);
+    }
+
+    return summary;
+};
+
 const formatMonth = (value) => {
     let date;
 
@@ -419,6 +440,40 @@ const buildMonthlySummaryFromEntries = (entries) => {
     return Object.keys(monthly)
         .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
         .map(month => ({ month, ...monthly[month] }));
+};
+
+const buildMonthlySummaryFromAggregates = (rows) => {
+    if (!Array.isArray(rows) || !rows.length) {
+        return [];
+    }
+
+    const monthly = {};
+
+    for (const row of rows) {
+        const type = FINANCE_TYPES.includes(row?.type) ? row.type : null;
+        if (!type) {
+            continue;
+        }
+
+        const monthKey = typeof row?.month === 'string' ? row.month : formatMonth(row?.month);
+        if (!monthKey) {
+            continue;
+        }
+
+        if (!monthly[monthKey]) {
+            monthly[monthKey] = { payable: 0, receivable: 0 };
+        }
+
+        monthly[monthKey][type] += toNumber(row?.totalValue ?? row?.sum ?? row?.value ?? 0);
+    }
+
+    return Object.keys(monthly)
+        .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+        .map((month) => ({
+            month,
+            payable: toNumber(monthly[month].payable),
+            receivable: toNumber(monthly[month].receivable)
+        }));
 };
 
 const startOfMonth = (date) => {
@@ -1146,7 +1201,7 @@ const buildTotalsFromStatus = (statusSummary) => {
     return totals;
 };
 
-const fetchEntries = async (filters = {}) => {
+const fetchEntries = async (filters = {}, options = {}) => {
     const where = {};
 
     const userId = parseIntegerId(filters.userId);
@@ -1178,15 +1233,59 @@ const fetchEntries = async (filters = {}) => {
         }
     }
 
-    return FinanceEntry.findAll({
-        attributes: ['id', 'type', 'status', 'value', 'dueDate'],
+    const mode = options.mode || 'list';
+
+    if (mode === 'statusSummary') {
+        return FinanceEntry.findAll({
+            attributes: [
+                'type',
+                'status',
+                [Sequelize.fn('SUM', Sequelize.col('FinanceEntry.value')), 'totalValue'],
+                [Sequelize.fn('COUNT', Sequelize.col('FinanceEntry.id')), 'count']
+            ],
+            where,
+            group: ['FinanceEntry.type', 'FinanceEntry.status'],
+            raw: true
+        });
+    }
+
+    if (mode === 'monthlySummary') {
+        const monthExpression = buildMonthKeyExpression('FinanceEntry.dueDate');
+        return FinanceEntry.findAll({
+            attributes: [
+                [monthExpression, 'month'],
+                'type',
+                [Sequelize.fn('SUM', Sequelize.col('FinanceEntry.value')), 'totalValue']
+            ],
+            where,
+            group: [monthExpression, 'FinanceEntry.type'],
+            order: [[Sequelize.literal('month'), 'ASC']],
+            raw: true
+        });
+    }
+
+    const attributes = Array.isArray(options.attributes) && options.attributes.length
+        ? options.attributes
+        : ['id', 'type', 'status', 'value', 'dueDate', 'paymentDate', 'recurring', 'recurringInterval'];
+
+    const queryOptions = {
+        attributes,
         where,
-        order: [
+        order: options.order || [
             ['dueDate', 'ASC'],
             ['id', 'ASC']
         ],
-        raw: true
-    });
+        raw: options.raw === undefined ? true : options.raw
+    };
+
+    if (Number.isInteger(options.limit) && options.limit > 0) {
+        queryOptions.limit = options.limit;
+    }
+    if (Number.isInteger(options.offset) && options.offset >= 0) {
+        queryOptions.offset = options.offset;
+    }
+
+    return FinanceEntry.findAll(queryOptions);
 };
 
 const resolveEntries = async (filters = {}, options = {}) => {
@@ -1197,13 +1296,19 @@ const resolveEntries = async (filters = {}, options = {}) => {
 };
 
 const getStatusSummary = async (filters = {}, options = {}) => {
-    const entries = await resolveEntries(filters, options);
-    return buildStatusSummaryFromEntries(entries);
+    if (Array.isArray(options.entries)) {
+        return buildStatusSummaryFromEntries(options.entries);
+    }
+    const rows = await fetchEntries(filters, { mode: 'statusSummary' });
+    return buildStatusSummaryFromAggregates(rows);
 };
 
 const getMonthlySummary = async (filters = {}, options = {}) => {
-    const entries = await resolveEntries(filters, options);
-    return buildMonthlySummaryFromEntries(entries);
+    if (Array.isArray(options.entries)) {
+        return buildMonthlySummaryFromEntries(options.entries);
+    }
+    const rows = await fetchEntries(filters, { mode: 'monthlySummary' });
+    return buildMonthlySummaryFromAggregates(rows);
 };
 
 const getMonthlyProjection = async (filters = {}, options = {}) => {
@@ -1213,13 +1318,39 @@ const getMonthlyProjection = async (filters = {}, options = {}) => {
 };
 
 const getFinanceSummary = async (filters = {}, options = {}) => {
-    const entries = await resolveEntries(filters, options);
-    const statusSummary = buildStatusSummaryFromEntries(entries);
-    const projectionSettings = resolveProjectionSettings(filters, options);
-    const projections = await buildMonthlyProjectionFromEntries(entries, projectionSettings, options);
+    const providedEntries = Array.isArray(options.entries) ? options.entries : null;
+    const includeProjections = options.includeProjections !== false;
+
+    const statusPromise = providedEntries
+        ? Promise.resolve(buildStatusSummaryFromEntries(providedEntries))
+        : (async () => {
+            const rows = await fetchEntries(filters, { mode: 'statusSummary' });
+            return buildStatusSummaryFromAggregates(rows);
+        })();
+
+    const monthlyPromise = providedEntries
+        ? Promise.resolve(buildMonthlySummaryFromEntries(providedEntries))
+        : (async () => {
+            const rows = await fetchEntries(filters, { mode: 'monthlySummary' });
+            return buildMonthlySummaryFromAggregates(rows);
+        })();
+
+    const [statusSummary, monthlySummary] = await Promise.all([statusPromise, monthlyPromise]);
+
+    let projections = [];
+    let entriesForProjection = providedEntries;
+
+    if (includeProjections) {
+        if (!entriesForProjection) {
+            entriesForProjection = await fetchEntries(filters);
+        }
+        const projectionSettings = resolveProjectionSettings(filters, options);
+        projections = await buildMonthlyProjectionFromEntries(entriesForProjection, projectionSettings, options);
+    }
+
     return {
         statusSummary,
-        monthlySummary: buildMonthlySummaryFromEntries(entries),
+        monthlySummary,
         totals: buildTotalsFromStatus(statusSummary),
         projections
     };

--- a/src/views/finance/payments.ejs
+++ b/src/views/finance/payments.ejs
@@ -91,6 +91,41 @@
         ? csrfToken
         : (typeof locals?.csrfToken === 'string' ? locals.csrfToken : '');
     const periodText = typeof periodLabel === 'string' && periodLabel.trim() ? periodLabel.trim() : 'Todo o período';
+    const paginationDefaults = { page: 1, pageSize: 25, totalPages: 1, totalRecords: Array.isArray(entries) ? entries.length : 0 };
+    const paginationSource = pagination && typeof pagination === 'object' ? pagination : (typeof locals?.pagination === 'object' ? locals.pagination : null);
+    const paginationData = { ...paginationDefaults, ...(paginationSource || {}) };
+    paginationData.page = Number.isInteger(Number(paginationData.page)) && Number(paginationData.page) > 0 ? Number(paginationData.page) : 1;
+    paginationData.pageSize = Number.isInteger(Number(paginationData.pageSize)) && Number(paginationData.pageSize) > 0 ? Number(paginationData.pageSize) : paginationDefaults.pageSize;
+    paginationData.totalPages = Number.isInteger(Number(paginationData.totalPages)) && Number(paginationData.totalPages) > 0 ? Number(paginationData.totalPages) : 1;
+    paginationData.totalRecords = Number.isInteger(Number(paginationData.totalRecords)) && Number(paginationData.totalRecords) >= 0 ? Number(paginationData.totalRecords) : 0;
+    const pageWindowSize = 5;
+    const tentativeStart = Math.max(1, paginationData.page - Math.floor(pageWindowSize / 2));
+    let tentativeEnd = Math.min(paginationData.totalPages, tentativeStart + pageWindowSize - 1);
+    const adjustedStart = Math.max(1, tentativeEnd - pageWindowSize + 1);
+    const pageNumbers = [];
+    for (let page = adjustedStart; page <= tentativeEnd; page += 1) {
+        pageNumbers.push(page);
+    }
+    const buildPageHref = (pageNumber) => {
+        const numericPage = Number(pageNumber);
+        if (!Number.isInteger(numericPage) || numericPage < 1) {
+            return '#';
+        }
+        const params = new URLSearchParams();
+        Object.entries(filterValues).forEach(([key, value]) => {
+            if (value !== undefined && value !== null && String(value).trim()) {
+                params.set(key, value);
+            }
+        });
+        if (paginationData.pageSize) {
+            params.set('pageSize', paginationData.pageSize);
+        }
+        params.set('page', numericPage);
+        const queryString = params.toString();
+        return queryString ? `/finance/payments?${queryString}` : '/finance/payments';
+    };
+    const firstItemIndex = paginationData.totalRecords === 0 ? 0 : ((paginationData.page - 1) * paginationData.pageSize) + 1;
+    const lastItemIndex = paginationData.totalRecords === 0 ? 0 : Math.min(paginationData.page * paginationData.pageSize, paginationData.totalRecords);
 %>
 
 <%- include('./partials/pageHeader', {
@@ -320,6 +355,12 @@
                 <div>
                     <h3 class="fw-semibold mb-1">Lançamentos recentes</h3>
                     <p class="text-muted mb-0">Monitoramento contínuo de receitas, despesas e recorrências.</p>
+                    <% if (paginationData.totalRecords > 0) { %>
+                        <p class="text-muted small mb-0">
+                            Exibindo <strong><%= firstItemIndex %></strong> - <strong><%= lastItemIndex %></strong>
+                            de <strong><%= paginationData.totalRecords %></strong> lançamento<%= paginationData.totalRecords === 1 ? '' : 's' %>.
+                        </p>
+                    <% } %>
                 </div>
                 <div class="d-flex flex-column flex-sm-row align-items-sm-center justify-content-end gap-2 text-sm-end">
                     <span class="badge rounded-pill bg-light text-muted">
@@ -409,7 +450,19 @@
                                                 class="btn btn-outline-primary"
                                                 type="button"
                                                 data-bs-toggle="modal"
-                                                data-bs-target="#editEntryModal<%= entry.id %>"
+                                                data-bs-target="#financeEntryModal"
+                                                data-entry-edit
+                                                data-entry-id="<%= entry.id %>"
+                                                data-entry-description="<%= entry.description %>"
+                                                data-entry-type="<%= entry.type %>"
+                                                data-entry-status="<%= entry.status %>"
+                                                data-entry-value="<%= entry.valueInput %>"
+                                                data-entry-due-date="<%= entry.dueDateInput %>"
+                                                data-entry-payment-date="<%= entry.paymentDateInput %>"
+                                                data-entry-recurring="<%= entry.recurring ? 'true' : 'false' %>"
+                                                data-entry-recurring-interval="<%= entry.recurringInterval || '' %>"
+                                                data-entry-category-id="<%= entry.categoryId === null ? '' : entry.categoryId %>"
+                                                data-entry-attachments="<%- encodeURIComponent(JSON.stringify(entry.attachments || [])) %>"
                                             >
                                                 <i class="bi bi-pencil-square" aria-hidden="true"></i>
                                             </button>
@@ -429,129 +482,157 @@
                     </tbody>
                 </table>
             </div>
+            <% if (paginationData.totalPages > 1) { %>
+                <nav class="d-flex justify-content-end mt-3" aria-label="Paginação de lançamentos">
+                    <ul class="pagination pagination-sm mb-0 flex-wrap gap-2">
+                        <li class="page-item <%= paginationData.page > 1 ? '' : 'disabled' %>">
+                            <a
+                                class="page-link"
+                                href="<%= paginationData.page > 1 ? buildPageHref(paginationData.page - 1) : '#' %>"
+                                aria-label="Página anterior"
+                                <%= paginationData.page > 1 ? '' : 'tabindex="-1" aria-disabled="true"' %>
+                            >
+                                <span aria-hidden="true">&laquo;</span>
+                            </a>
+                        </li>
+                        <% if (adjustedStart > 1) { %>
+                            <li class="page-item">
+                                <a class="page-link" href="<%= buildPageHref(1) %>">1</a>
+                            </li>
+                            <% if (adjustedStart > 2) { %>
+                                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                            <% } %>
+                        <% } %>
+                        <% pageNumbers.forEach((pageNumber) => { %>
+                            <li class="page-item <%= pageNumber === paginationData.page ? 'active' : '' %>">
+                                <% if (pageNumber === paginationData.page) { %>
+                                    <span class="page-link" aria-current="page"><%= pageNumber %></span>
+                                <% } else { %>
+                                    <a class="page-link" href="<%= buildPageHref(pageNumber) %>"><%= pageNumber %></a>
+                                <% } %>
+                            </li>
+                        <% }) %>
+                        <% if (pageNumbers.length && pageNumbers[pageNumbers.length - 1] < paginationData.totalPages) { %>
+                            <% if (pageNumbers[pageNumbers.length - 1] < paginationData.totalPages - 1) { %>
+                                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                            <% } %>
+                            <li class="page-item">
+                                <a class="page-link" href="<%= buildPageHref(paginationData.totalPages) %>"><%= paginationData.totalPages %></a>
+                            </li>
+                        <% } %>
+                        <li class="page-item <%= paginationData.page < paginationData.totalPages ? '' : 'disabled' %>">
+                            <a
+                                class="page-link"
+                                href="<%= paginationData.page < paginationData.totalPages ? buildPageHref(paginationData.page + 1) : '#' %>"
+                                aria-label="Próxima página"
+                                <%= paginationData.page < paginationData.totalPages ? '' : 'tabindex="-1" aria-disabled="true"' %>
+                            >
+                                <span aria-hidden="true">&raquo;</span>
+                            </a>
+                        </li>
+                    </ul>
+                </nav>
+            <% } %>
         </div>
     </div>
 
-    <% if (entries && entries.length) { %>
-        <% entries.forEach((entry) => { %>
-            <div class="modal fade" id="editEntryModal<%= entry.id %>" tabindex="-1" aria-labelledby="editEntryModalLabel<%= entry.id %>" aria-hidden="true">
-                <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="editEntryModalLabel<%= entry.id %>">Editar lançamento #<%= entry.id %></h5>
-                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
-                        </div>
-                        <form action="/finance/update/<%= entry.id %>?_method=PUT" method="POST" enctype="multipart/form-data">
-                            <div class="modal-body row g-3">
-                                <% if (resolvedCsrfToken) { %>
-                                    <input type="hidden" name="_csrf" value="<%= resolvedCsrfToken %>" />
-                                <% } %>
-                                <div class="col-12">
-                                    <label class="form-label">Descrição</label>
-                                    <input type="text" class="form-control" name="description" value="<%= entry.description %>" required />
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label">Tipo</label>
-                                    <select class="form-select" name="type" required>
-                                        <option value="receivable" <%= entry.type === 'receivable' ? 'selected' : '' %>>Receber</option>
-                                        <option value="payable" <%= entry.type === 'payable' ? 'selected' : '' %>>Pagar</option>
-                                    </select>
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label">Categoria</label>
-                                    <select class="form-select" name="financeCategoryId">
-                                        <% financeCategoryOptions.forEach((category) => { %>
-                                            <option value="<%= category.id === null ? '' : category.id %>" <%= (entry.financeCategoryId || null) === category.id ? 'selected' : '' %>>
-                                                <%= category.name %>
-                                            </option>
-                                        <% }) %>
-                                    </select>
-                                </div>
-                                <div class="col-md-4">
-                                    <label class="form-label">Valor</label>
-                                    <input type="number" class="form-control" name="value" value="<%= Number(entry.value || 0).toFixed(2) %>" step="0.01" min="0" required />
-                                </div>
-                                <div class="col-md-4">
-                                    <label class="form-label">Data de vencimento</label>
-                                    <input type="date" class="form-control" name="dueDate" value="<%= entry.dueDate ? entry.dueDate : '' %>" required />
-                                </div>
-                                <div class="col-md-4">
-                                    <label class="form-label">Data de pagamento</label>
-                                    <input type="date" class="form-control" name="paymentDate" value="<%= entry.paymentDate ? entry.paymentDate : '' %>" />
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label">Status</label>
-                                    <select class="form-select" name="status">
-                                        <% statusKeys.forEach((statusKey) => { %>
-                                            <option value="<%= statusKey %>" <%= entry.status === statusKey ? 'selected' : '' %>>
-                                                <%= statusLabels[statusKey] %>
-                                            </option>
-                                        <% }) %>
-                                    </select>
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label">Recorrência</label>
-                                    <select class="form-select" name="recurring">
-                                        <option value="true" <%= entry.recurring ? 'selected' : '' %>>Lançamento recorrente</option>
-                                        <option value="false" <%= !entry.recurring ? 'selected' : '' %>>Evento único</option>
-                                    </select>
-                                </div>
-                                <div class="col-12">
-                                    <label class="form-label">Intervalo de recorrência</label>
-                                    <input
-                                        type="text"
-                                        class="form-control"
-                                        name="recurringInterval"
-                                        list="recurring-interval-options"
-                                        value="<%= entry.recurringInterval || '' %>"
-                                        placeholder="Ex.: mensal, trimestral"
-                                    />
-                                </div>
-                                <div class="col-12">
-                                    <label class="form-label">Anexos cadastrados</label>
-                                    <% if (entry.attachments && entry.attachments.length) { %>
-                                        <ul class="list-group list-group-flush rounded shadow-sm">
-                                            <% entry.attachments.forEach((attachment) => { %>
-                                                <li class="list-group-item d-flex align-items-center justify-content-between gap-3">
-                                                    <div class="d-flex align-items-center gap-2 text-truncate">
-                                                        <i class="bi bi-paperclip text-primary" aria-hidden="true"></i>
-                                                        <span class="text-truncate" title="<%= attachment.fileName %>"><%= attachment.fileName %></span>
-                                                    </div>
-                                                    <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2 text-sm-end">
-                                                        <span class="text-muted small"><%= Math.max(1, Math.round((attachment.size || 0) / 1024)) %> KB</span>
-                                                        <a class="btn btn-outline-primary btn-sm" href="/finance/attachments/<%= attachment.id %>/download">
-                                                            <i class="bi bi-download me-1" aria-hidden="true"></i>Baixar
-                                                        </a>
-                                                    </div>
-                                                </li>
-                                            <% }) %>
-                                        </ul>
-                                    <% } else { %>
-                                        <p class="text-muted small mb-0">Nenhum anexo disponível para este lançamento.</p>
-                                    <% } %>
-                                </div>
-                                <div class="col-12">
-                                    <label class="form-label">Adicionar novos anexos</label>
-                                    <input
-                                        type="file"
-                                        class="form-control"
-                                        name="attachments"
-                                        multiple
-                                        accept=".pdf,.png,.jpg,.jpeg,.doc,.docx,.xls,.xlsx,.csv,.txt,.zip"
-                                    />
-                                    <div class="form-text">Anexe arquivos relevantes (até 10MB por arquivo).</div>
-                                </div>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
-                                <button type="submit" class="btn btn-gradient">Salvar</button>
-                            </div>
-                        </form>
-                    </div>
+    <div class="modal fade" id="financeEntryModal" tabindex="-1" aria-labelledby="financeEntryModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="financeEntryModalLabel" data-modal-title>Editar lançamento</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fechar"></button>
                 </div>
+                <form action="/finance/update/0?_method=PUT" method="POST" enctype="multipart/form-data" data-modal-form>
+                    <div class="modal-body row g-3">
+                        <% if (resolvedCsrfToken) { %>
+                            <input type="hidden" name="_csrf" value="<%= resolvedCsrfToken %>" />
+                        <% } %>
+                        <div class="col-12">
+                            <label class="form-label" for="modal-entry-description">Descrição</label>
+                            <input type="text" class="form-control" id="modal-entry-description" name="description" data-modal-field="description" required />
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="modal-entry-type">Tipo</label>
+                            <select class="form-select" id="modal-entry-type" name="type" data-modal-field="type" required>
+                                <option value="receivable">Receber</option>
+                                <option value="payable">Pagar</option>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="modal-entry-category">Categoria</label>
+                            <select class="form-select" id="modal-entry-category" name="financeCategoryId" data-modal-field="financeCategoryId">
+                                <% financeCategoryOptions.forEach((category) => { %>
+                                    <option value="<%= category.id === null ? '' : category.id %>"><%= category.name %></option>
+                                <% }) %>
+                            </select>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label" for="modal-entry-value">Valor</label>
+                            <input type="number" class="form-control" id="modal-entry-value" name="value" data-modal-field="value" step="0.01" min="0" required />
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label" for="modal-entry-due-date">Data de vencimento</label>
+                            <input type="date" class="form-control" id="modal-entry-due-date" name="dueDate" data-modal-field="dueDate" required />
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label" for="modal-entry-payment-date">Data de pagamento</label>
+                            <input type="date" class="form-control" id="modal-entry-payment-date" name="paymentDate" data-modal-field="paymentDate" />
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="modal-entry-status">Status</label>
+                            <select class="form-select" id="modal-entry-status" name="status" data-modal-field="status">
+                                <% statusKeys.forEach((statusKey) => { %>
+                                    <option value="<%= statusKey %>"><%= statusLabels[statusKey] %></option>
+                                <% }) %>
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="modal-entry-recurring">Recorrência</label>
+                            <select class="form-select" id="modal-entry-recurring" name="recurring" data-modal-field="recurring">
+                                <option value="true">Lançamento recorrente</option>
+                                <option value="false">Evento único</option>
+                            </select>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label" for="modal-entry-recurring-interval">Intervalo de recorrência</label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                id="modal-entry-recurring-interval"
+                                name="recurringInterval"
+                                data-modal-field="recurringInterval"
+                                list="recurring-interval-options"
+                                placeholder="Ex.: mensal, trimestral"
+                            />
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">Anexos cadastrados</label>
+                            <div class="border rounded-3 p-3 bg-light-subtle" data-modal-attachments>
+                                <p class="text-muted small mb-0">Nenhum anexo disponível para este lançamento.</p>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label" for="modal-entry-attachments">Adicionar novos anexos</label>
+                            <input
+                                type="file"
+                                class="form-control"
+                                id="modal-entry-attachments"
+                                name="attachments"
+                                multiple
+                                accept=".pdf,.png,.jpg,.jpeg,.doc,.docx,.xls,.xlsx,.csv,.txt,.zip"
+                            />
+                            <div class="form-text">Anexe arquivos relevantes (até 10MB por arquivo).</div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                        <button type="submit" class="btn btn-gradient">Salvar</button>
+                    </div>
+                </form>
             </div>
-        <% }); %>
-    <% } %>
+        </div>
+    </div>
 
     <div class="col-12 col-xxl-10">
         <div class="card card-soft responsive-panel">
@@ -747,7 +828,8 @@
         monthlySummary: monthlySummaryList,
         filters: filterValues,
         summaryTotals,
-        periodLabel: periodText
+        periodLabel: periodText,
+        pagination: paginationData
     }) %>
 </script>
 <script defer src="/js/financePayments.js"></script>

--- a/tests/unit/financeReportingService.test.js
+++ b/tests/unit/financeReportingService.test.js
@@ -19,7 +19,7 @@ describe('financeReportingService', () => {
         });
         expect(FinanceEntry.findAll).toHaveBeenCalledTimes(1);
         expect(FinanceEntry.findAll).toHaveBeenCalledWith(expect.objectContaining({
-            attributes: ['id', 'type', 'status', 'value', 'dueDate'],
+            group: expect.arrayContaining(['FinanceEntry.type', 'FinanceEntry.status']),
             raw: true
         }));
     });
@@ -36,12 +36,12 @@ describe('financeReportingService', () => {
 
     it('agrupa os lançamentos por status e tipo', async () => {
         jest.spyOn(FinanceEntry, 'findAll').mockResolvedValueOnce([
-            { type: 'payable', status: 'pending', value: '120.50', dueDate: '2024-04-10' },
-            { type: 'payable', status: 'paid', value: '80', dueDate: '2024-04-11' },
-            { type: 'receivable', status: 'paid', value: '150.20', dueDate: '2024-04-12' },
-            { type: 'receivable', status: 'overdue', value: '200', dueDate: '2024-05-01' },
-            { type: 'receivable', status: 'cancelled', value: '50', dueDate: '2024-05-02' },
-            { type: 'invalid', status: 'pending', value: '999', dueDate: '2024-06-01' }
+            { type: 'payable', status: 'pending', totalValue: '120.50' },
+            { type: 'payable', status: 'paid', totalValue: '80' },
+            { type: 'receivable', status: 'paid', totalValue: '150.20' },
+            { type: 'receivable', status: 'overdue', totalValue: '200' },
+            { type: 'receivable', status: 'cancelled', totalValue: '50' },
+            { type: 'invalid', status: 'pending', totalValue: '999' }
         ]);
 
         const summary = await getStatusSummary();
@@ -54,12 +54,10 @@ describe('financeReportingService', () => {
 
     it('organiza os dados por mês', async () => {
         jest.spyOn(FinanceEntry, 'findAll').mockResolvedValueOnce([
-            { type: 'payable', status: 'pending', value: 100, dueDate: '2024-01-15' },
-            { type: 'payable', status: 'paid', value: 50, dueDate: '2024-01-20' },
-            { type: 'receivable', status: 'paid', value: '200', dueDate: '2024-02-05' },
-            { type: 'receivable', status: 'paid', value: '150', dueDate: '2024-01-08' },
-            { type: 'receivable', status: 'paid', value: '120', dueDate: '2024-02-12' },
-            { type: 'payable', status: 'paid', value: '10', dueDate: 'invalid-date' }
+            { month: '2024-01', type: 'payable', totalValue: 150 },
+            { month: '2024-01', type: 'receivable', totalValue: 150 },
+            { month: '2024-02', type: 'receivable', totalValue: 320 },
+            { month: '2024-03', type: 'invalid', totalValue: 999 }
         ]);
 
         const summary = await getMonthlySummary();

--- a/tests/unit/views/financePayments.view.test.js
+++ b/tests/unit/views/financePayments.view.test.js
@@ -81,6 +81,12 @@ const buildViewContext = () => ({
         totals: { new: 1, conflicting: 0, total: 1 },
         uploadedAt: new Date().toISOString()
     },
+    pagination: {
+        page: 1,
+        pageSize: 10,
+        totalPages: 2,
+        totalRecords: 12
+    },
     success_msg: null,
     error_msg: null,
     error: null,
@@ -137,9 +143,11 @@ describe('views/finance/payments', () => {
 
         expect(html).toContain('enctype="multipart/form-data"');
         expect(html).toContain('name="attachments"');
-        expect(html).toContain('href="/finance/attachments/701/download"');
+        expect(html).toContain('data-entry-edit');
+        expect(html).toContain('data-entry-attachments=');
+        expect(html).toContain('financeEntryModal');
+        expect(html).toContain('data-modal-attachments');
         expect(html).toContain('comprovante.pdf');
-        expect(html).toContain('bi bi-paperclip');
     });
 
     it('renders import preview with selection controls', async () => {
@@ -149,5 +157,15 @@ describe('views/finance/payments', () => {
         expect(html).toContain('data-import-select-all');
         expect(html).toContain('name="entries[0][enabled]"');
         expect(html).toContain('Importar lançamentos selecionados');
+    });
+
+    it('exibe navegação paginada com resumo de registros', async () => {
+        const html = await ejs.renderFile(viewPath, buildViewContext(), { async: true });
+
+        expect(html).toContain('aria-label="Paginação de lançamentos"');
+        expect(html).toContain('pageSize=10');
+        expect(html).toContain('page=2');
+        expect(html).toContain('Exibindo <strong>');
+        expect(html).toContain('de <strong>12</strong>');
     });
 });


### PR DESCRIPTION
## Summary
- add pagination support to finance payments queries and expose pagination metadata in the UI
- refactor finance reporting service to use aggregate queries for summaries and adjust the payments view and scripts for a shared modal
- extend unit tests to cover pagination behaviour and aggregated reporting logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1bbb689ac832fbd50d7ee189d32e9