### PR TITLE
Add persistent finance access policy management

### DIFF
--- a/database/migrations/20241001-create-finance-access-policies.js
+++ b/database/migrations/20241001-create-finance-access-policies.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const TABLE_NAME = 'FinanceAccessPolicies';
+const POLICY_KEY = 'finance_access';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        const tableDefinition = await queryInterface.describeTable(TABLE_NAME).catch(() => null);
+
+        if (!tableDefinition) {
+            await queryInterface.createTable(TABLE_NAME, {
+                id: {
+                    allowNull: false,
+                    autoIncrement: true,
+                    primaryKey: true,
+                    type: Sequelize.INTEGER
+                },
+                policyKey: {
+                    type: Sequelize.STRING(100),
+                    allowNull: false,
+                    defaultValue: POLICY_KEY,
+                    unique: true
+                },
+                allowedRoles: {
+                    type: Sequelize.TEXT,
+                    allowNull: false,
+                    defaultValue: '[]'
+                },
+                updatedById: {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                    references: {
+                        model: 'Users',
+                        key: 'id'
+                    },
+                    onUpdate: 'SET NULL',
+                    onDelete: 'SET NULL'
+                },
+                updatedByName: {
+                    type: Sequelize.STRING(255),
+                    allowNull: true
+                },
+                createdAt: {
+                    allowNull: false,
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+                },
+                updatedAt: {
+                    allowNull: false,
+                    type: Sequelize.DATE,
+                    defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+                }
+            });
+        }
+
+        const existingIndexes = await queryInterface.showIndex(TABLE_NAME).catch(() => []);
+        const indexNames = new Set(existingIndexes.map((index) => index.name));
+        const policyIndexName = 'finance_access_policy_key_idx';
+
+        if (!indexNames.has(policyIndexName)) {
+            await queryInterface.addIndex(TABLE_NAME, {
+                name: policyIndexName,
+                unique: true,
+                fields: ['policyKey']
+            });
+        }
+    },
+
+    down: async (queryInterface) => {
+        const tableDefinition = await queryInterface.describeTable(TABLE_NAME).catch(() => null);
+        if (tableDefinition) {
+            await queryInterface.dropTable(TABLE_NAME);
+        }
+    }
+};

--- a/database/models/financeAccessPolicy.js
+++ b/database/models/financeAccessPolicy.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const DEFAULT_POLICY_KEY = 'finance_access';
+
+const toPlainArray = (value) => {
+    if (Array.isArray(value)) {
+        return value;
+    }
+
+    if (value === undefined || value === null) {
+        return [];
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return [];
+        }
+
+        try {
+            const parsed = JSON.parse(trimmed);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            return trimmed
+                .split(/[,;|\s]+/)
+                .map((item) => item.trim())
+                .filter(Boolean);
+        }
+    }
+
+    return [];
+};
+
+module.exports = (sequelize, DataTypes) => {
+    const FinanceAccessPolicy = sequelize.define('FinanceAccessPolicy', {
+        policyKey: {
+            type: DataTypes.STRING(100),
+            allowNull: false,
+            defaultValue: DEFAULT_POLICY_KEY,
+            unique: true
+        },
+        allowedRoles: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+            defaultValue: '[]',
+            get() {
+                const rawValue = this.getDataValue('allowedRoles');
+                return toPlainArray(rawValue);
+            },
+            set(value) {
+                const plain = toPlainArray(value);
+                this.setDataValue('allowedRoles', JSON.stringify(plain));
+            }
+        },
+        updatedById: {
+            type: DataTypes.INTEGER,
+            allowNull: true
+        },
+        updatedByName: {
+            type: DataTypes.STRING(255),
+            allowNull: true
+        }
+    }, {
+        tableName: 'FinanceAccessPolicies'
+    });
+
+    FinanceAccessPolicy.associate = (models) => {
+        if (models.User) {
+            FinanceAccessPolicy.belongsTo(models.User, {
+                as: 'updatedBy',
+                foreignKey: 'updatedById'
+            });
+        }
+    };
+
+    FinanceAccessPolicy.DEFAULT_POLICY_KEY = DEFAULT_POLICY_KEY;
+
+    return FinanceAccessPolicy;
+};

--- a/src/middlewares/permissionMiddleware.js
+++ b/src/middlewares/permissionMiddleware.js
@@ -2,4 +2,30 @@
 // Mantido por compatibilidade: utiliza o novo middleware authorize internamente
 const authorize = require('./authorize');
 
-module.exports = (requiredRole) => authorize(requiredRole);
+module.exports = (requiredRole) => {
+    if (typeof requiredRole === 'function') {
+        return async (req, res, next) => {
+            try {
+                const resolvedRoles = await requiredRole(req, res, next);
+                const middleware = authorize(resolvedRoles);
+                return middleware(req, res, next);
+            } catch (error) {
+                console.error('Erro ao resolver permissões dinamicamente:', error);
+
+                const acceptsJson = req.xhr || (req.headers && typeof req.headers.accept === 'string' && req.headers.accept.includes('application/json'));
+
+                if (acceptsJson) {
+                    return res.status(500).json({ message: 'Não foi possível validar permissões.' });
+                }
+
+                if (typeof req.flash === 'function') {
+                    req.flash('error_msg', 'Não foi possível validar permissões. Tente novamente mais tarde.');
+                }
+
+                return res.redirect('/');
+            }
+        };
+    }
+
+    return authorize(requiredRole);
+};

--- a/src/routes/adminFinanceRoutes.js
+++ b/src/routes/adminFinanceRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const adminFinanceController = require('../controllers/adminFinanceController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const permissionMiddleware = require('../middlewares/permissionMiddleware');
+const audit = require('../middlewares/audit');
 const { USER_ROLES } = require('../constants/roles');
 
 const router = express.Router();
@@ -19,6 +20,13 @@ router.use((req, res, next) => {
 
 router.use(authMiddleware);
 router.use(permissionMiddleware(USER_ROLES.ADMIN));
+
+router.get('/access-policy', adminFinanceController.renderFinanceAccessPolicy);
+router.post(
+    '/access-policy',
+    audit('finance.accessPolicy.update', () => 'FinanceAccessPolicy'),
+    adminFinanceController.updateFinanceAccessPolicy
+);
 
 router.get('/budgets', adminFinanceController.listBudgets);
 router.post('/budgets', adminFinanceController.createBudget);

--- a/src/services/__tests__/financeAccessPolicyService.test.js
+++ b/src/services/__tests__/financeAccessPolicyService.test.js
@@ -1,0 +1,162 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { USER_ROLES } = require('../../constants/roles');
+
+const resolveService = () => require.resolve('../financeAccessPolicyService');
+const resolveModels = () => require.resolve('../../../database/models');
+
+const mockModels = (mockExports) => {
+    const resolved = resolveModels();
+    const original = require.cache[resolved];
+    require.cache[resolved] = {
+        id: resolved,
+        filename: resolved,
+        loaded: true,
+        exports: mockExports
+    };
+
+    return () => {
+        if (original) {
+            require.cache[resolved] = original;
+        } else {
+            delete require.cache[resolved];
+        }
+    };
+};
+
+const loadService = () => {
+    delete require.cache[resolveService()];
+    return require('../financeAccessPolicyService');
+};
+
+const ORIGINAL_ENV_VALUE = process.env.FINANCE_ALLOWED_ROLES;
+
+const resetEnv = () => {
+    if (ORIGINAL_ENV_VALUE === undefined) {
+        delete process.env.FINANCE_ALLOWED_ROLES;
+    } else {
+        process.env.FINANCE_ALLOWED_ROLES = ORIGINAL_ENV_VALUE;
+    }
+};
+
+test('getAllowedRoles usa fallback do ambiente quando não há política persistida', async (t) => {
+    process.env.FINANCE_ALLOWED_ROLES = `${USER_ROLES.MANAGER}, ${USER_ROLES.ADMIN}`;
+    const restoreModels = mockModels({
+        FinanceAccessPolicy: {
+            findOne: async () => null
+        }
+    });
+
+    t.teardown(() => {
+        restoreModels();
+        resetEnv();
+    });
+
+    const service = loadService();
+    const roles = await service.getAllowedRoles();
+
+    assert.deepStrictEqual(roles, [USER_ROLES.MANAGER, USER_ROLES.ADMIN]);
+});
+
+test('getFinanceAccessPolicy retorna perfis persistidos e metadados', async (t) => {
+    const updatedAt = new Date('2024-10-01T10:15:00Z');
+    const restoreModels = mockModels({
+        FinanceAccessPolicy: {
+            findOne: async () => ({
+                get: () => ({
+                    allowedRoles: JSON.stringify([USER_ROLES.ADMIN, USER_ROLES.MANAGER, USER_ROLES.CLIENT]),
+                    updatedAt,
+                    updatedByName: 'Maria CFO',
+                    updatedById: 42
+                })
+            })
+        }
+    });
+
+    delete process.env.FINANCE_ALLOWED_ROLES;
+
+    t.teardown(() => {
+        restoreModels();
+        resetEnv();
+    });
+
+    const service = loadService();
+    const policy = await service.getFinanceAccessPolicy();
+
+    assert.deepStrictEqual(policy.allowedRoles, [USER_ROLES.CLIENT, USER_ROLES.MANAGER, USER_ROLES.ADMIN]);
+    assert.equal(policy.source, 'database');
+    assert.equal(policy.fallbackApplied, false);
+    assert.equal(policy.updatedByName, 'Maria CFO');
+    assert(policy.updatedAt instanceof Date);
+});
+
+test('saveFinanceAccessPolicy persiste, invalida cache e ordena perfis', async (t) => {
+    let storedRecord = null;
+    let findOneCalls = 0;
+
+    const restoreModels = mockModels({
+        FinanceAccessPolicy: {
+            DEFAULT_POLICY_KEY: 'finance_access',
+            findOne: async () => {
+                findOneCalls += 1;
+                if (!storedRecord) {
+                    return null;
+                }
+                return {
+                    get: () => ({
+                        allowedRoles: storedRecord.allowedRoles,
+                        updatedAt: storedRecord.updatedAt,
+                        updatedByName: storedRecord.updatedByName,
+                        updatedById: storedRecord.updatedById
+                    })
+                };
+            },
+            upsert: async (payload) => {
+                storedRecord = {
+                    allowedRoles: payload.allowedRoles,
+                    updatedById: payload.updatedById,
+                    updatedByName: payload.updatedByName,
+                    updatedAt: new Date('2024-10-02T09:00:00Z')
+                };
+            }
+        }
+    });
+
+    process.env.FINANCE_ALLOWED_ROLES = USER_ROLES.CLIENT;
+    const service = loadService();
+
+    t.teardown(() => {
+        restoreModels();
+        resetEnv();
+    });
+
+    const initialRoles = await service.getAllowedRoles();
+    assert.deepStrictEqual(initialRoles, [USER_ROLES.CLIENT]);
+    assert.equal(findOneCalls, 1);
+
+    const cachedRoles = await service.getAllowedRoles();
+    assert.deepStrictEqual(cachedRoles, [USER_ROLES.CLIENT]);
+    assert.equal(findOneCalls, 1);
+
+    const policy = await service.saveFinanceAccessPolicy({
+        allowedRoles: [USER_ROLES.ADMIN, USER_ROLES.MANAGER],
+        updatedBy: { id: 7, name: 'Ana Admin' }
+    });
+
+    assert.deepStrictEqual(storedRecord.allowedRoles, [USER_ROLES.MANAGER, USER_ROLES.ADMIN]);
+    assert.equal(storedRecord.updatedById, 7);
+    assert.equal(storedRecord.updatedByName, 'Ana Admin');
+
+    assert.deepStrictEqual(policy.allowedRoles, [USER_ROLES.MANAGER, USER_ROLES.ADMIN]);
+    assert.equal(policy.source, 'database');
+    assert.equal(policy.fallbackApplied, false);
+
+    const refreshedRoles = await service.getAllowedRoles();
+    assert.deepStrictEqual(refreshedRoles, [USER_ROLES.MANAGER, USER_ROLES.ADMIN]);
+    assert.equal(findOneCalls, 2);
+});

--- a/src/services/financeAccessPolicyService.js
+++ b/src/services/financeAccessPolicyService.js
@@ -1,0 +1,208 @@
+const { FinanceAccessPolicy } = require('../../database/models');
+const { USER_ROLES, parseRole, sortRolesByHierarchy } = require('../constants/roles');
+
+const DEFAULT_ALLOWED_ROLES = [USER_ROLES.CLIENT];
+const POLICY_KEY = FinanceAccessPolicy?.DEFAULT_POLICY_KEY || 'finance_access';
+
+let cachedPolicy = null;
+let loadingPromise = null;
+
+const toArray = (value) => {
+    if (Array.isArray(value)) {
+        return value;
+    }
+
+    if (value === undefined || value === null) {
+        return [];
+    }
+
+    if (typeof value === 'string') {
+        const normalized = value.trim();
+        if (!normalized) {
+            return [];
+        }
+
+        try {
+            const parsed = JSON.parse(normalized);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (error) {
+            return normalized
+                .split(/[,;|\s]+/)
+                .map((token) => token.trim())
+                .filter(Boolean);
+        }
+    }
+
+    return [];
+};
+
+const sanitizeRoles = (roles) => sortRolesByHierarchy(
+    toArray(roles).map((role) => parseRole(role)).filter(Boolean)
+);
+
+const resolveEnvFallbackRoles = () => {
+    const envValue = process.env.FINANCE_ALLOWED_ROLES;
+    const resolved = sanitizeRoles(envValue);
+    if (resolved.length) {
+        return resolved;
+    }
+    return [...DEFAULT_ALLOWED_ROLES];
+};
+
+const buildPolicy = ({
+    allowedRoles,
+    source,
+    fallbackApplied,
+    updatedAt = null,
+    updatedById = null,
+    updatedByName = null
+}) => ({
+    allowedRoles,
+    source,
+    fallbackApplied,
+    updatedAt,
+    updatedById,
+    updatedByName
+});
+
+const isMissingTableError = (error) => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const parent = error.parent || error.original || {};
+    const code = parent.code || error.code;
+    const message = String(parent.message || error.message || '').toLowerCase();
+
+    if (message.includes('no such table') || message.includes('does not exist')) {
+        return true;
+    }
+
+    if (code === '42P01') {
+        return true;
+    }
+
+    return false;
+};
+
+const buildEnvFallbackPolicy = () => {
+    const fallback = resolveEnvFallbackRoles();
+    return buildPolicy({
+        allowedRoles: fallback,
+        source: 'env',
+        fallbackApplied: true
+    });
+};
+
+const fetchPolicyFromDatabase = async () => {
+    if (!FinanceAccessPolicy || typeof FinanceAccessPolicy.findOne !== 'function') {
+        return buildEnvFallbackPolicy();
+    }
+
+    let record;
+    try {
+        record = await FinanceAccessPolicy.findOne({
+            where: { policyKey: POLICY_KEY },
+            order: [['updatedAt', 'DESC']]
+        });
+    } catch (error) {
+        if (isMissingTableError(error)) {
+            return buildEnvFallbackPolicy();
+        }
+        throw error;
+    }
+
+    if (!record) {
+        return buildEnvFallbackPolicy();
+    }
+
+    const plain = typeof record.get === 'function' ? record.get({ plain: true }) : record;
+    const normalized = sanitizeRoles(plain.allowedRoles);
+    const fallback = resolveEnvFallbackRoles();
+    const usesFallback = normalized.length === 0;
+
+    return buildPolicy({
+        allowedRoles: usesFallback ? fallback : normalized,
+        source: usesFallback ? 'env' : 'database',
+        fallbackApplied: usesFallback,
+        updatedAt: plain.updatedAt ? new Date(plain.updatedAt) : null,
+        updatedById: plain.updatedById ?? null,
+        updatedByName: plain.updatedByName ?? null
+    });
+};
+
+const loadPolicy = async ({ force } = {}) => {
+    if (!force && cachedPolicy) {
+        return cachedPolicy;
+    }
+
+    if (!loadingPromise) {
+        loadingPromise = fetchPolicyFromDatabase()
+            .then((policy) => {
+                cachedPolicy = policy;
+                return policy;
+            })
+            .catch((error) => {
+                if (isMissingTableError(error)) {
+                    const fallbackPolicy = buildEnvFallbackPolicy();
+                    cachedPolicy = fallbackPolicy;
+                    return fallbackPolicy;
+                }
+                throw error;
+            })
+            .finally(() => {
+                loadingPromise = null;
+            });
+    }
+
+    return loadingPromise;
+};
+
+const getFinanceAccessPolicy = async () => {
+    const policy = await loadPolicy({ force: false });
+    return buildPolicy({
+        ...policy,
+        allowedRoles: [...policy.allowedRoles]
+    });
+};
+
+const getAllowedRoles = async () => {
+    const policy = await loadPolicy({ force: false });
+    return [...policy.allowedRoles];
+};
+
+const invalidateCache = () => {
+    cachedPolicy = null;
+};
+
+const saveFinanceAccessPolicy = async ({ allowedRoles, updatedBy } = {}) => {
+    if (!FinanceAccessPolicy || typeof FinanceAccessPolicy.upsert !== 'function') {
+        throw new Error('FinanceAccessPolicy model is not available.');
+    }
+
+    const sanitized = sanitizeRoles(allowedRoles);
+    const fallback = resolveEnvFallbackRoles();
+    const resolvedRoles = sanitized.length ? sanitized : fallback;
+    const payload = {
+        policyKey: POLICY_KEY,
+        allowedRoles: resolvedRoles,
+        updatedById: updatedBy?.id ?? null,
+        updatedByName: updatedBy?.name ?? null
+    };
+
+    await FinanceAccessPolicy.upsert(payload);
+    invalidateCache();
+    const policy = await loadPolicy({ force: true });
+    return buildPolicy({
+        ...policy,
+        allowedRoles: [...policy.allowedRoles]
+    });
+};
+
+module.exports = {
+    getFinanceAccessPolicy,
+    getAllowedRoles,
+    saveFinanceAccessPolicy,
+    invalidateCache,
+    resolveEnvFallbackRoles
+};

--- a/src/views/admin/financeAccessPolicy.ejs
+++ b/src/views/admin/financeAccessPolicy.ejs
@@ -1,0 +1,168 @@
+<%- include('../partials/header') %>
+
+<%
+    const selectedRoles = Array.isArray(policy?.allowedRoles) ? policy.allowedRoles : [];
+    const fallbackRolesList = Array.isArray(fallbackRoles) ? fallbackRoles : [];
+    const fallbackSet = new Set(fallbackRolesList);
+    const intlFormatter = new Intl.DateTimeFormat('pt-BR', {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+    });
+    const formatDateTime = (value) => {
+        if (!value) {
+            return 'Nunca configurado';
+        }
+        const dateInstance = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(dateInstance.getTime())) {
+            return 'Nunca configurado';
+        }
+        return intlFormatter.format(dateInstance);
+    };
+    const fallbackRolesText = fallbackRolesList
+        .map((role) => roleLabels?.[role] || role)
+        .join(', ');
+    const allowedRolesText = selectedRoles
+        .map((role) => roleLabels?.[role] || role)
+        .join(', ');
+    const isUsingFallback = Boolean(fallbackApplied) || policySource !== 'database';
+    const hasCustomSelection = selectedRoles.some((role) => !fallbackSet.has(role)) || fallbackRolesList.some((role) => !selectedRoles.includes(role));
+%>
+
+<section class="container py-5 fade-in">
+    <div class="row g-4 align-items-start">
+        <div class="col-12">
+            <div class="d-flex flex-column flex-lg-row align-items-start align-items-lg-center justify-content-between gap-4">
+                <div>
+                    <span class="app-chip"><i class="bi bi-shield-lock me-2"></i>Política de acesso financeiro</span>
+                    <h1 class="section-title mb-2">Defina com precisão quem pode operar o módulo financeiro.</h1>
+                    <p class="text-muted mb-0">
+                        Escolha os perfis autorizados, valide constantemente a governança de dados sensíveis e mantenha rastreabilidade completa.
+                    </p>
+                </div>
+                <a href="/finance/overview" class="btn btn-outline-primary d-flex align-items-center gap-2">
+                    <i class="bi bi-kanban"></i>
+                    Abrir painel financeiro
+                </a>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <% if (success_msg) { %>
+                <div class="alert alert-success alert-auto shadow-sm" data-auto-dismiss="5000">
+                    <i class="bi bi-check-circle me-2"></i>
+                    <%= success_msg %>
+                </div>
+            <% } else if (error_msg) { %>
+                <div class="alert alert-danger alert-auto shadow-sm" data-auto-dismiss="7000">
+                    <i class="bi bi-exclamation-triangle me-2"></i>
+                    <%= error_msg %>
+                </div>
+            <% } %>
+        </div>
+
+        <div class="col-12 col-lg-8">
+            <div class="card card-soft p-4 shadow-sm h-100">
+                <div class="d-flex flex-column flex-lg-row justify-content-between align-items-start align-items-lg-center gap-3 mb-3">
+                    <div>
+                        <h2 class="h4 mb-1">Perfis com acesso autorizado</h2>
+                        <p class="text-muted mb-0">Selecione quem pode visualizar e operar lançamentos financeiros críticos.</p>
+                    </div>
+                    <span class="badge bg-secondary-subtle text-secondary d-flex align-items-center gap-2">
+                        <i class="bi bi-fingerprint"></i>
+                        Auditoria ativa
+                    </span>
+                </div>
+
+                <form action="/admin/finance/access-policy" method="POST" class="row g-4" novalidate>
+                    <% roleOptions.forEach((option) => { %>
+                        <div class="col-12 col-md-6">
+                            <div class="border rounded-4 p-4 h-100 shadow-sm bg-white position-relative">
+                                <div class="form-check">
+                                    <input
+                                        class="form-check-input"
+                                        type="checkbox"
+                                        id="finance-role-<%= option.value %>"
+                                        name="allowedRoles"
+                                        value="<%= option.value %>"
+                                        <%= option.selected ? 'checked' : '' %>
+                                    />
+                                    <label class="form-check-label fw-semibold" for="finance-role-<%= option.value %>">
+                                        <%= option.label %>
+                                    </label>
+                                </div>
+                                <p class="text-muted small mb-0 mt-3"><%= option.description %></p>
+                            </div>
+                        </div>
+                    <% }) %>
+
+                    <div class="col-12">
+                        <div class="d-flex flex-column flex-md-row justify-content-between align-items-stretch align-items-md-center gap-3">
+                            <div class="text-muted small">
+                                Alterações são registradas com auditoria automática e refletem em até alguns segundos para todos os usuários.
+                            </div>
+                            <button type="submit" class="btn btn-gradient px-4">
+                                <i class="bi bi-save me-2"></i>
+                                Salvar política de acesso
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="col-12 col-lg-4">
+            <div class="card card-soft p-4 shadow-sm mb-4">
+                <h3 class="h5 mb-3">Status da política</h3>
+                <ul class="list-unstyled mb-0 small text-muted">
+                    <li class="mb-2 d-flex gap-2 align-items-start">
+                        <i class="bi bi-clock-history text-primary"></i>
+                        <div>
+                            <strong>Última atualização:</strong>
+                            <div><%= formatDateTime(policy?.updatedAt) %></div>
+                        </div>
+                    </li>
+                    <li class="mb-2 d-flex gap-2 align-items-start">
+                        <i class="bi bi-person-badge text-primary"></i>
+                        <div>
+                            <strong>Responsável:</strong>
+                            <div><%= policy?.updatedByName || 'Ainda não identificado' %></div>
+                        </div>
+                    </li>
+                    <li class="d-flex gap-2 align-items-start">
+                        <i class="bi bi-shield-check text-primary"></i>
+                        <div>
+                            <strong>Perfis autorizados:</strong>
+                            <div><%= allowedRolesText || 'Clientes (padrão)' %></div>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="card card-soft p-4 shadow-sm bg-light-subtle">
+                <h3 class="h6 text-uppercase text-muted mb-3">Política padrão</h3>
+                <p class="small text-muted mb-3">
+                    Caso não exista configuração persistida, aplicamos automaticamente os perfis definidos via <code>FINANCE_ALLOWED_ROLES</code>.
+                </p>
+                <div class="alert <%= isUsingFallback ? 'alert-warning' : 'alert-success' %> small" role="status">
+                    <i class="bi <%= isUsingFallback ? 'bi-exclamation-circle' : 'bi-check-circle' %> me-2"></i>
+                    <% if (isUsingFallback) { %>
+                        Política ativa carregada do ambiente. Perfis atuais: <strong><%= fallbackRolesText || 'Clientes' %></strong>.
+                    <% } else { %>
+                        Política persistida ativa. Padrão do ambiente: <strong><%= fallbackRolesText || 'Clientes' %></strong>.
+                    <% } %>
+                </div>
+                <% if (hasCustomSelection) { %>
+                    <p class="small text-muted mb-0">
+                        A seleção atual difere do padrão de ambiente, garantindo controle dedicado para o módulo financeiro.
+                    </p>
+                <% } else { %>
+                    <p class="small text-muted mb-0">
+                        A seleção atual corresponde ao padrão de ambiente, mantendo alinhamento com a configuração global.
+                    </p>
+                <% } %>
+            </div>
+        </div>
+    </div>
+</section>
+
+<%- include('../partials/footer') %>

--- a/tests/integration/adminFinanceAccessPolicy.test.js
+++ b/tests/integration/adminFinanceAccessPolicy.test.js
@@ -1,0 +1,140 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const request = require('supertest');
+const { USER_ROLES, ROLE_LABELS } = require('../../src/constants/roles');
+const { createRouterTestApp } = require('../utils/createRouterTestApp');
+const { authenticateTestUser } = require('../utils/authTestUtils');
+
+const mockGetFinanceAccessPolicy = jest.fn();
+const mockSaveFinanceAccessPolicy = jest.fn();
+const mockResolveEnvFallbackRoles = jest.fn(() => ['client']);
+
+jest.mock('../../src/services/financeAccessPolicyService', () => ({
+    getFinanceAccessPolicy: (...args) => mockGetFinanceAccessPolicy(...args),
+    saveFinanceAccessPolicy: (...args) => mockSaveFinanceAccessPolicy(...args),
+    resolveEnvFallbackRoles: (...args) => mockResolveEnvFallbackRoles(...args),
+    getAllowedRoles: jest.fn(() => Promise.resolve(['client']))
+}));
+
+const adminFinanceRoutes = require('../../src/routes/adminFinanceRoutes');
+
+const buildApp = () => createRouterTestApp({
+    routes: [['/admin/finance', adminFinanceRoutes]]
+});
+
+describe('Admin finance access policy routes', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+        mockResolveEnvFallbackRoles.mockImplementation(() => ['client']);
+    });
+
+    it('exige autenticação para acessar a tela de política de acesso', async () => {
+        mockGetFinanceAccessPolicy.mockResolvedValue({
+            allowedRoles: [USER_ROLES.MANAGER],
+            source: 'database',
+            fallbackApplied: false
+        });
+
+        const app = buildApp();
+        const response = await request(app)
+            .get('/admin/finance/access-policy');
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/login');
+        expect(mockGetFinanceAccessPolicy).not.toHaveBeenCalled();
+    });
+
+    it('renderiza a política atual para administradores autenticados', async () => {
+        const policyResponse = {
+            allowedRoles: [USER_ROLES.MANAGER, USER_ROLES.ADMIN],
+            source: 'database',
+            fallbackApplied: false,
+            updatedByName: 'Ana Gestora',
+            updatedAt: new Date('2024-10-01T12:00:00Z')
+        };
+        mockGetFinanceAccessPolicy.mockResolvedValue(policyResponse);
+        mockResolveEnvFallbackRoles.mockReturnValue([USER_ROLES.CLIENT]);
+
+        const app = buildApp();
+        const { agent } = await authenticateTestUser(app, { role: USER_ROLES.ADMIN });
+        const response = await agent.get('/admin/finance/access-policy');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Perfis com acesso autorizado');
+        expect(response.text).toContain(ROLE_LABELS[USER_ROLES.MANAGER]);
+        expect(response.text).toContain(ROLE_LABELS[USER_ROLES.ADMIN]);
+        expect(mockGetFinanceAccessPolicy).toHaveBeenCalledTimes(1);
+    });
+
+    it('não persiste quando nenhum perfil válido é enviado', async () => {
+        mockGetFinanceAccessPolicy.mockResolvedValue({
+            allowedRoles: [USER_ROLES.CLIENT],
+            source: 'env',
+            fallbackApplied: true
+        });
+
+        const app = buildApp();
+        const { agent } = await authenticateTestUser(app, { role: USER_ROLES.ADMIN });
+
+        const response = await agent
+            .post('/admin/finance/access-policy')
+            .send({ allowedRoles: [] });
+
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toBe('/admin/finance/access-policy');
+        expect(mockSaveFinanceAccessPolicy).not.toHaveBeenCalled();
+    });
+
+    it('persiste nova política e retorna JSON quando solicitado', async () => {
+        mockGetFinanceAccessPolicy.mockResolvedValue({
+            allowedRoles: [USER_ROLES.CLIENT],
+            source: 'env',
+            fallbackApplied: true
+        });
+        mockSaveFinanceAccessPolicy.mockResolvedValue({
+            allowedRoles: [USER_ROLES.MANAGER, USER_ROLES.ADMIN],
+            source: 'database',
+            fallbackApplied: false
+        });
+
+        const app = buildApp();
+        const { agent, user } = await authenticateTestUser(app, { role: USER_ROLES.ADMIN, name: 'Administrador' });
+
+        const response = await agent
+            .post('/admin/finance/access-policy')
+            .set('Accept', 'application/json')
+            .send({ allowedRoles: [USER_ROLES.ADMIN, USER_ROLES.MANAGER] });
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({
+            message: 'Perfis autorizados atualizados com sucesso.',
+            data: { allowedRoles: [USER_ROLES.MANAGER, USER_ROLES.ADMIN] }
+        });
+        expect(mockSaveFinanceAccessPolicy).toHaveBeenCalledWith({
+            allowedRoles: [USER_ROLES.MANAGER, USER_ROLES.ADMIN],
+            updatedBy: { id: user.id, name: 'Administrador' }
+        });
+    });
+
+    it('retorna erro 500 em caso de falha ao salvar', async () => {
+        mockGetFinanceAccessPolicy.mockResolvedValue({
+            allowedRoles: [USER_ROLES.CLIENT],
+            source: 'env',
+            fallbackApplied: true
+        });
+        mockSaveFinanceAccessPolicy.mockRejectedValue(new Error('DB indisponível'));
+
+        const app = buildApp();
+        const { agent } = await authenticateTestUser(app, { role: USER_ROLES.ADMIN });
+
+        const response = await agent
+            .post('/admin/finance/access-policy')
+            .set('Accept', 'application/json')
+            .send({ allowedRoles: [USER_ROLES.ADMIN] });
+
+        expect(response.status).toBe(500);
+        expect(response.body).toEqual({ message: 'Não foi possível atualizar a política financeira.' });
+    });
+});


### PR DESCRIPTION
## Summary
- add a FinanceAccessPolicies table and Sequelize model to persist allowed roles for the finance module, exposing a caching service that falls back to environment defaults when needed
- update finance routing to consult the new policy service, support asynchronous permission resolution, and provide an administrative UI to manage the allowed profiles with audit logging
- cover the new persistence layer and admin workflow with dedicated unit and integration tests while adapting existing permission tests to the service-driven flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1bbb8bbcc832f82ba5bfa64d20455