### PR TITLE
feat(pos): add reporting service and routes

### DIFF
--- a/src/routes/posRoutes.js
+++ b/src/routes/posRoutes.js
@@ -24,5 +24,9 @@ router.post('/sales/:saleId/items', addItemValidation, posController.addItem);
 router.post('/sales/:saleId/payments', addPaymentValidation, posController.addPayment);
 router.post('/sales/:saleId/finalize', finalizeSaleValidation, posController.finalizeSale);
 router.get('/sales/:saleId/receipt', finalizeSaleValidation, posController.downloadReceipt);
+router.get('/reports', posController.getPosReports);
+router.get('/reports/top-products', posController.getTopProductsReport);
+router.get('/reports/traffic', posController.getTrafficReport);
+router.get('/reports/inventory', posController.getInventoryReport);
 
 module.exports = router;

--- a/src/services/posReportingService.js
+++ b/src/services/posReportingService.js
@@ -1,0 +1,451 @@
+'use strict';
+
+const { Op, fn, col } = require('sequelize');
+const { Sale, SaleItem, Product } = require('../../database/models');
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+const DEFAULT_INVENTORY_LIMIT = 50;
+const MAX_INVENTORY_LIMIT = 200;
+
+const DEFAULT_RANGE_DAYS = 30;
+const MAX_RANGE_DAYS = 180;
+
+const getSequelizeInstance = () => {
+    if (Sale?.sequelize) {
+        return Sale.sequelize;
+    }
+    if (SaleItem?.sequelize) {
+        return SaleItem.sequelize;
+    }
+    if (Product?.sequelize) {
+        return Product.sequelize;
+    }
+    return null;
+};
+
+const getDialect = () => {
+    const sequelizeInstance = getSequelizeInstance();
+    if (sequelizeInstance && typeof sequelizeInstance.getDialect === 'function') {
+        return sequelizeInstance.getDialect();
+    }
+    return 'sqlite';
+};
+
+const toNumber = (value) => {
+    if (value === null || value === undefined) {
+        return 0;
+    }
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : 0;
+    }
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const toInteger = (value, fallback = 0) => {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isInteger(parsed)) {
+        return fallback;
+    }
+    return parsed;
+};
+
+const clamp = (value, minValue, maxValue) => {
+    return Math.min(Math.max(value, minValue), maxValue);
+};
+
+const buildLimit = (value, { defaultValue = DEFAULT_LIMIT, maxValue = MAX_LIMIT } = {}) => {
+    const parsed = toInteger(value, defaultValue);
+    const normalized = clamp(parsed, 1, maxValue);
+    return normalized;
+};
+
+const resolveRange = ({ start, end } = {}) => {
+    const now = new Date();
+    const endDate = end ? new Date(end) : now;
+    if (Number.isNaN(endDate.getTime())) {
+        throw new Error('Data final inválida.');
+    }
+
+    const startDate = start ? new Date(start) : new Date(endDate.getTime() - DEFAULT_RANGE_DAYS * 86400000);
+    if (Number.isNaN(startDate.getTime())) {
+        throw new Error('Data inicial inválida.');
+    }
+
+    if (startDate > endDate) {
+        throw new Error('Data inicial não pode ser posterior à final.');
+    }
+
+    const minimumStart = new Date(endDate.getTime() - MAX_RANGE_DAYS * 86400000);
+    const normalizedStart = startDate < minimumStart ? minimumStart : startDate;
+
+    return {
+        start: normalizedStart,
+        end: endDate
+    };
+};
+
+const buildSaleDateWhere = ({ start, end }) => {
+    const conditions = [];
+
+    if (start) {
+        conditions.push({
+            [Op.or]: [
+                { closedAt: { [Op.gte]: start } },
+                {
+                    [Op.and]: [
+                        { closedAt: null },
+                        { openedAt: { [Op.gte]: start } }
+                    ]
+                }
+            ]
+        });
+    }
+
+    if (end) {
+        conditions.push({
+            [Op.or]: [
+                { closedAt: { [Op.lte]: end } },
+                {
+                    [Op.and]: [
+                        { closedAt: null },
+                        { openedAt: { [Op.lte]: end } }
+                    ]
+                }
+            ]
+        });
+    }
+
+    if (!conditions.length) {
+        return {};
+    }
+
+    if (conditions.length === 1) {
+        return conditions[0];
+    }
+
+    return {
+        [Op.and]: conditions
+    };
+};
+
+const getTopProducts = async ({
+    limit,
+    start,
+    end
+} = {}) => {
+    const { start: rangeStart, end: rangeEnd } = resolveRange({ start, end });
+    const normalizedLimit = buildLimit(limit);
+
+    const saleDateWhere = buildSaleDateWhere({ start: rangeStart, end: rangeEnd });
+
+    const rows = await SaleItem.findAll({
+        attributes: [
+            'productId',
+            [col('SaleItem.productName'), 'itemProductName'],
+            [col('SaleItem.sku'), 'itemSku'],
+            [fn('SUM', col('SaleItem.quantity')), 'totalQuantity'],
+            [fn('SUM', col('SaleItem.netTotal')), 'totalNet'],
+            [fn('SUM', col('SaleItem.grossTotal')), 'totalGross'],
+            [fn('SUM', col('SaleItem.discountValue')), 'totalDiscount']
+        ],
+        include: [
+            {
+                model: Sale,
+                as: 'sale',
+                attributes: [],
+                required: true,
+                where: {
+                    status: 'completed',
+                    ...saleDateWhere
+                }
+            },
+            {
+                model: Product,
+                as: 'product',
+                attributes: ['id', 'name', 'sku', 'price', 'stockQuantity', 'lowStockThreshold'],
+                required: false
+            }
+        ],
+        group: [
+            'SaleItem.productId',
+            'SaleItem.productName',
+            'SaleItem.sku',
+            'product.id'
+        ],
+        raw: true,
+        nest: true
+    });
+
+    const normalizedRows = rows
+        .map((row) => {
+            const quantity = toNumber(row.totalQuantity);
+            const revenue = toNumber(row.totalNet);
+            const gross = toNumber(row.totalGross);
+            const discount = toNumber(row.totalDiscount);
+
+            const productId = row.product?.id ?? row.productId ?? null;
+            const sku = row.product?.sku || row.itemSku || null;
+            const name = row.product?.name || row.itemProductName || 'Produto sem nome';
+
+            return {
+                productId,
+                name,
+                sku,
+                totalQuantity: quantity,
+                totalRevenue: revenue,
+                totalGross: gross,
+                totalDiscount: discount,
+                averageTicket: quantity > 0 ? Number((revenue / quantity).toFixed(2)) : 0
+            };
+        })
+        .sort((a, b) => b.totalQuantity - a.totalQuantity);
+
+    const topByQuantity = normalizedRows.slice(0, normalizedLimit);
+    const topByRevenue = [...normalizedRows]
+        .sort((a, b) => b.totalRevenue - a.totalRevenue)
+        .slice(0, normalizedLimit);
+
+    return {
+        period: {
+            start: rangeStart,
+            end: rangeEnd
+        },
+        limit: normalizedLimit,
+        byQuantity: topByQuantity,
+        byRevenue: topByRevenue
+    };
+};
+
+const buildTimestampExpression = () => {
+    const timestamp = fn('COALESCE', col('Sale.closedAt'), col('Sale.openedAt'));
+    return timestamp;
+};
+
+const buildHourExpression = (timestampExpression, dialect) => {
+    if (dialect === 'postgres') {
+        return fn('to_char', timestampExpression, 'HH24');
+    }
+    if (dialect === 'mysql' || dialect === 'mariadb') {
+        return fn('DATE_FORMAT', timestampExpression, '%H');
+    }
+    return fn('strftime', '%H', timestampExpression);
+};
+
+const buildWeekdayExpression = (timestampExpression, dialect) => {
+    if (dialect === 'postgres') {
+        return fn('to_char', timestampExpression, 'ID');
+    }
+    if (dialect === 'mysql' || dialect === 'mariadb') {
+        return fn('DATE_FORMAT', timestampExpression, '%w');
+    }
+    return fn('strftime', '%w', timestampExpression);
+};
+
+const buildDayExpression = (timestampExpression, dialect) => {
+    if (dialect === 'postgres') {
+        return fn('to_char', timestampExpression, 'YYYY-MM-DD');
+    }
+    if (dialect === 'mysql' || dialect === 'mariadb') {
+        return fn('DATE_FORMAT', timestampExpression, '%Y-%m-%d');
+    }
+    return fn('strftime', '%Y-%m-%d', timestampExpression);
+};
+
+const getTrafficReport = async ({
+    start,
+    end
+} = {}) => {
+    const { start: rangeStart, end: rangeEnd } = resolveRange({ start, end });
+    const saleDateWhere = buildSaleDateWhere({ start: rangeStart, end: rangeEnd });
+
+    const timestampExpression = buildTimestampExpression();
+    const dialect = getDialect();
+    const hourExpression = buildHourExpression(timestampExpression, dialect);
+    const weekdayExpression = buildWeekdayExpression(timestampExpression, dialect);
+    const dayExpression = buildDayExpression(timestampExpression, dialect);
+
+    const baseWhere = {
+        status: 'completed',
+        ...saleDateWhere
+    };
+
+    const [hourlyRows, weekdayRows, dailyRows] = await Promise.all([
+        Sale.findAll({
+            attributes: [
+                [hourExpression, 'hour'],
+                [fn('COUNT', col('Sale.id')), 'salesCount'],
+                [fn('SUM', col('Sale.totalNet')), 'totalRevenue']
+            ],
+            where: baseWhere,
+            group: [hourExpression],
+            raw: true
+        }),
+        Sale.findAll({
+            attributes: [
+                [weekdayExpression, 'weekday'],
+                [fn('COUNT', col('Sale.id')), 'salesCount'],
+                [fn('SUM', col('Sale.totalNet')), 'totalRevenue']
+            ],
+            where: baseWhere,
+            group: [weekdayExpression],
+            raw: true
+        }),
+        Sale.findAll({
+            attributes: [
+                [dayExpression, 'day'],
+                [fn('COUNT', col('Sale.id')), 'salesCount'],
+                [fn('SUM', col('Sale.totalNet')), 'totalRevenue']
+            ],
+            where: baseWhere,
+            group: [dayExpression],
+            raw: true
+        })
+    ]);
+
+    const totalSales = weekdayRows.reduce((acc, row) => acc + toNumber(row.salesCount), 0);
+    const totalRevenue = weekdayRows.reduce((acc, row) => acc + toNumber(row.totalRevenue), 0);
+
+    const normalizedHourly = hourlyRows
+        .map((row) => ({
+            hour: row.hour ? `${row.hour}:00` : null,
+            salesCount: toNumber(row.salesCount),
+            totalRevenue: Number(toNumber(row.totalRevenue).toFixed(2))
+        }))
+        .sort((a, b) => {
+            if (a.hour === null) return 1;
+            if (b.hour === null) return -1;
+            return a.hour.localeCompare(b.hour);
+        });
+
+    const normalizedWeekday = weekdayRows
+        .map((row) => ({
+            weekday: row.weekday ? Number.parseInt(row.weekday, 10) : 0,
+            salesCount: toNumber(row.salesCount),
+            totalRevenue: Number(toNumber(row.totalRevenue).toFixed(2))
+        }))
+        .sort((a, b) => a.weekday - b.weekday);
+
+    const normalizedDaily = dailyRows
+        .map((row) => ({
+            day: row.day || null,
+            salesCount: toNumber(row.salesCount),
+            totalRevenue: Number(toNumber(row.totalRevenue).toFixed(2))
+        }))
+        .sort((a, b) => {
+            if (!a.day) return 1;
+            if (!b.day) return -1;
+            return a.day.localeCompare(b.day);
+        });
+
+    return {
+        period: {
+            start: rangeStart,
+            end: rangeEnd
+        },
+        totals: {
+            salesCount: totalSales,
+            totalRevenue: Number(totalRevenue.toFixed(2))
+        },
+        byHour: normalizedHourly,
+        byWeekday: normalizedWeekday,
+        byDay: normalizedDaily
+    };
+};
+
+const getInventoryReport = async ({ limit } = {}) => {
+    const normalizedLimit = buildLimit(limit, {
+        defaultValue: DEFAULT_INVENTORY_LIMIT,
+        maxValue: MAX_INVENTORY_LIMIT
+    });
+
+    const products = await Product.findAll({
+        attributes: [
+            'id',
+            'name',
+            'sku',
+            'stockQuantity',
+            'lowStockThreshold',
+            'maxStockThreshold',
+            'stockStatus',
+            'price'
+        ],
+        where: {
+            status: 'active'
+        },
+        order: [
+            ['stockQuantity', 'ASC'],
+            ['name', 'ASC']
+        ],
+        limit: normalizedLimit
+    });
+
+    const items = products.map((product) => {
+        const stockQuantity = toInteger(product.stockQuantity, 0);
+        const lowStockThreshold = product.lowStockThreshold !== null && product.lowStockThreshold !== undefined
+            ? toInteger(product.lowStockThreshold, null)
+            : null;
+        const maxStockThreshold = product.maxStockThreshold !== null && product.maxStockThreshold !== undefined
+            ? toInteger(product.maxStockThreshold, null)
+            : null;
+
+        const isLowStock = lowStockThreshold !== null && stockQuantity <= lowStockThreshold;
+        const isOutOfStock = product.stockStatus === 'out-of-stock';
+
+        return {
+            productId: product.id,
+            name: product.name,
+            sku: product.sku,
+            stockQuantity,
+            lowStockThreshold,
+            maxStockThreshold,
+            stockStatus: product.stockStatus,
+            unitPrice: Number(toNumber(product.price).toFixed(2)),
+            lowStock: Boolean(isLowStock || isOutOfStock)
+        };
+    });
+
+    const lowStockAlerts = items
+        .filter((item) => item.lowStock)
+        .map((item) => ({
+            productId: item.productId,
+            name: item.name,
+            stockQuantity: item.stockQuantity,
+            lowStockThreshold: item.lowStockThreshold
+        }));
+
+    return {
+        limit: normalizedLimit,
+        items,
+        lowStockAlerts
+    };
+};
+
+const getReports = async (params = {}) => {
+    const [topProducts, traffic, inventory] = await Promise.all([
+        getTopProducts(params),
+        getTrafficReport(params),
+        getInventoryReport({ limit: params.inventoryLimit ?? params.limit })
+    ]);
+
+    return {
+        topProducts,
+        traffic,
+        inventory
+    };
+};
+
+module.exports = {
+    MAX_LIMIT,
+    MAX_RANGE_DAYS,
+    DEFAULT_RANGE_DAYS,
+    DEFAULT_INVENTORY_LIMIT,
+    MAX_INVENTORY_LIMIT,
+    getReports,
+    getTopProducts,
+    getTrafficReport,
+    getInventoryReport,
+    resolveRange,
+    buildLimit
+};

--- a/tests/integration/pos/posFlow.test.js
+++ b/tests/integration/pos/posFlow.test.js
@@ -15,6 +15,10 @@ const { USER_ROLES } = require('../../../src/constants/roles');
 const { createRouterTestApp } = require('../../utils/createRouterTestApp');
 const { authenticateTestUser } = require('../../utils/authTestUtils');
 
+jest.mock('qrcode', () => ({
+    toDataURL: jest.fn().mockResolvedValue('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=')
+}), { virtual: true });
+
 jest.setTimeout(15000);
 
 describe('Integração PDV - fluxo completo', () => {
@@ -40,8 +44,9 @@ describe('Integração PDV - fluxo completo', () => {
         product = await Product.create({
             name: 'Sérum facial luminoso',
             sku: 'SKU-PDV-001',
+            status: 'active',
+            price: '120.00',
             unit: 'un',
-            unitPrice: '120.00',
             taxRate: '5.00',
             taxCode: '1234.56.78',
             active: true

--- a/tests/integration/pos/posReports.test.js
+++ b/tests/integration/pos/posReports.test.js
@@ -1,0 +1,210 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const {
+    sequelize,
+    User,
+    Product,
+    Sale,
+    SaleItem
+} = require('../../../database/models');
+const posRoutes = require('../../../src/routes/posRoutes');
+const { USER_ROLES } = require('../../../src/constants/roles');
+const { createRouterTestApp } = require('../../utils/createRouterTestApp');
+const { authenticateTestUser } = require('../../utils/authTestUtils');
+
+jest.mock('qrcode', () => ({
+    toDataURL: jest.fn().mockResolvedValue('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=')
+}), { virtual: true });
+
+jest.setTimeout(20000);
+
+describe('Integração PDV - relatórios', () => {
+    let app;
+    let agent;
+    let operator;
+    let productA;
+    let productB;
+
+    beforeAll(async () => {
+        await sequelize.sync({ force: true });
+    });
+
+    beforeEach(async () => {
+        await sequelize.sync({ force: true });
+        app = createRouterTestApp({ routes: [['/pos', posRoutes]] });
+        operator = await User.create({
+            name: 'Operador PDV',
+            email: 'operador.relatorios@example.com',
+            password: 'SenhaSegura123',
+            role: USER_ROLES.MANAGER,
+            active: true
+        });
+
+        productA = await Product.create({
+            name: 'Vitamina C Serum',
+            sku: 'SKU-REL-001',
+            status: 'active',
+            price: '120.00',
+            stockQuantity: 2,
+            lowStockThreshold: 3
+        });
+
+        productB = await Product.create({
+            name: 'Hidratante Facial',
+            sku: 'SKU-REL-002',
+            status: 'active',
+            price: '80.00',
+            stockQuantity: 15,
+            lowStockThreshold: 5
+        });
+
+        const sale1 = await Sale.create({
+            userId: operator.id,
+            status: 'completed',
+            totalGross: '200.00',
+            totalNet: '180.00',
+            totalPaid: '180.00',
+            openedAt: new Date('2024-05-05T14:15:00Z'),
+            closedAt: new Date('2024-05-05T14:30:00Z')
+        });
+
+        const sale2 = await Sale.create({
+            userId: operator.id,
+            status: 'completed',
+            totalGross: '160.00',
+            totalNet: '160.00',
+            totalPaid: '160.00',
+            openedAt: new Date('2024-05-06T10:00:00Z'),
+            closedAt: new Date('2024-05-06T10:10:00Z')
+        });
+
+        await SaleItem.bulkCreate([
+            {
+                saleId: sale1.id,
+                productId: productA.id,
+                productName: productA.name,
+                sku: productA.sku,
+                quantity: '1.000',
+                unitPrice: '120.00',
+                grossTotal: '120.00',
+                discountValue: '0.00',
+                netTotal: '120.00'
+            },
+            {
+                saleId: sale1.id,
+                productId: productB.id,
+                productName: productB.name,
+                sku: productB.sku,
+                quantity: '2.000',
+                unitPrice: '40.00',
+                grossTotal: '80.00',
+                discountValue: '20.00',
+                netTotal: '60.00'
+            },
+            {
+                saleId: sale2.id,
+                productId: productB.id,
+                productName: productB.name,
+                sku: productB.sku,
+                quantity: '3.000',
+                unitPrice: '40.00',
+                grossTotal: '120.00',
+                discountValue: '0.00',
+                netTotal: '120.00'
+            }
+        ]);
+
+        await Sale.create({
+            userId: operator.id,
+            status: 'completed',
+            totalGross: '50.00',
+            totalNet: '50.00',
+            totalPaid: '50.00',
+            openedAt: new Date('2023-10-01T09:00:00Z'),
+            closedAt: new Date('2023-10-01T09:20:00Z')
+        });
+
+        ({ agent } = await authenticateTestUser(app, {
+            id: operator.id,
+            role: operator.role,
+            name: operator.name,
+            email: operator.email
+        }));
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    const defaultQuery = {
+        startDate: '2024-05-01',
+        endDate: '2024-05-10'
+    };
+
+    it('retorna visão consolidada de relatórios do PDV', async () => {
+        const response = await agent.get('/pos/reports').query(defaultQuery);
+
+        expect(response.status).toBe(200);
+        expect(response.body.topProducts).toBeDefined();
+        expect(response.body.traffic).toBeDefined();
+        expect(response.body.inventory).toBeDefined();
+        expect(response.body.topProducts.byQuantity[0].productId).toBe(productB.id);
+        expect(response.body.inventory.lowStockAlerts[0].productId).toBe(productA.id);
+        expect(response.body.metadata.maxLimit).toBeGreaterThan(0);
+    });
+
+    it('filtra ranking de produtos com limite personalizado', async () => {
+        const response = await agent
+            .get('/pos/reports/top-products')
+            .query({ ...defaultQuery, limit: 1 });
+
+        expect(response.status).toBe(200);
+        expect(response.body.report.limit).toBe(1);
+        expect(response.body.report.byQuantity).toHaveLength(1);
+        expect(response.body.report.byRevenue[0].productId).toBe(productB.id);
+    });
+
+    it('retorna horários e dias de maior movimento', async () => {
+        const response = await agent
+            .get('/pos/reports/traffic')
+            .query(defaultQuery);
+
+        expect(response.status).toBe(200);
+        expect(response.body.report.byHour.length).toBeGreaterThan(0);
+        expect(response.body.report.byDay.some((entry) => entry.day === '2024-05-05')).toBe(true);
+    });
+
+    it('controla limite de itens no relatório de estoque', async () => {
+        const response = await agent
+            .get('/pos/reports/inventory')
+            .query({ inventoryLimit: 1 });
+
+        expect(response.status).toBe(200);
+        expect(response.body.report.items).toHaveLength(1);
+        expect(response.body.report.items[0].productId).toBe(productA.id);
+        expect(response.body.metadata.maxLimit).toBeGreaterThan(0);
+    });
+
+    it('rejeita datas inválidas e protege contra injeção', async () => {
+        const maliciousDate = "2024-05-01'; DROP TABLE SaleItems; --";
+        const response = await agent
+            .get('/pos/reports')
+            .query({ startDate: maliciousDate, endDate: defaultQuery.endDate });
+
+        expect(response.status).toBe(400);
+        expect(response.body.message).toMatch(/Data inicial inválida/i);
+        const itemCount = await SaleItem.count();
+        expect(itemCount).toBeGreaterThan(0);
+    });
+
+    it('impõe máximo de limite configurado', async () => {
+        const response = await agent
+            .get('/pos/reports/top-products')
+            .query({ ...defaultQuery, limit: 999 });
+
+        expect(response.status).toBe(200);
+        expect(response.body.report.limit).toBeLessThanOrEqual(50);
+    });
+});

--- a/tests/unit/services/posReportingService.test.js
+++ b/tests/unit/services/posReportingService.test.js
@@ -1,0 +1,176 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const {
+    sequelize,
+    User,
+    Product,
+    Sale,
+    SaleItem
+} = require('../../../database/models');
+const {
+    getTopProducts,
+    getTrafficReport,
+    getInventoryReport,
+    resolveRange,
+    buildLimit,
+    DEFAULT_INVENTORY_LIMIT,
+    MAX_INVENTORY_LIMIT
+} = require('../../../src/services/posReportingService');
+
+const createOperator = () => User.create({
+    name: 'Operador Teste',
+    email: 'operador+teste@example.com',
+    password: 'SenhaSegura123',
+    role: 'manager',
+    active: true
+});
+
+const createProduct = (overrides = {}) => Product.create({
+    name: 'Produto Base',
+    sku: `SKU-${Math.random().toString(16).slice(2, 8)}`,
+    status: 'active',
+    price: '50.00',
+    stockQuantity: 20,
+    lowStockThreshold: 5,
+    ...overrides
+});
+
+describe('posReportingService', () => {
+    let operator;
+    let productA;
+    let productB;
+
+    beforeAll(async () => {
+        await sequelize.sync({ force: true });
+    });
+
+    beforeEach(async () => {
+        await sequelize.sync({ force: true });
+        operator = await createOperator();
+        productA = await createProduct({ name: 'Produto A', price: '80.00', stockQuantity: 3 });
+        productB = await createProduct({ name: 'Produto B', price: '40.00', stockQuantity: 12, lowStockThreshold: 10 });
+
+        const sale1 = await Sale.create({
+            userId: operator.id,
+            status: 'completed',
+            totalGross: '200.00',
+            totalNet: '180.00',
+            totalPaid: '180.00',
+            openedAt: new Date('2024-05-01T12:15:00Z'),
+            closedAt: new Date('2024-05-01T12:45:00Z')
+        });
+
+        const sale2 = await Sale.create({
+            userId: operator.id,
+            status: 'completed',
+            totalGross: '90.00',
+            totalNet: '90.00',
+            totalPaid: '90.00',
+            openedAt: new Date('2024-05-02T18:00:00Z'),
+            closedAt: new Date('2024-05-02T18:20:00Z')
+        });
+
+        await SaleItem.bulkCreate([
+            {
+                saleId: sale1.id,
+                productId: productA.id,
+                productName: productA.name,
+                sku: productA.sku,
+                quantity: '2.000',
+                unitPrice: '80.00',
+                grossTotal: '160.00',
+                discountValue: '10.00',
+                netTotal: '150.00'
+            },
+            {
+                saleId: sale1.id,
+                productId: productB.id,
+                productName: productB.name,
+                sku: productB.sku,
+                quantity: '1.000',
+                unitPrice: '40.00',
+                grossTotal: '40.00',
+                discountValue: '0.00',
+                netTotal: '30.00'
+            },
+            {
+                saleId: sale2.id,
+                productId: productB.id,
+                productName: productB.name,
+                sku: productB.sku,
+                quantity: '3.000',
+                unitPrice: '30.00',
+                grossTotal: '90.00',
+                discountValue: '0.00',
+                netTotal: '90.00'
+            }
+        ]);
+
+        await Sale.create({
+            userId: operator.id,
+            status: 'completed',
+            totalGross: '120.00',
+            totalNet: '120.00',
+            totalPaid: '120.00',
+            openedAt: new Date('2023-12-01T09:00:00Z'),
+            closedAt: new Date('2023-12-01T09:30:00Z')
+        });
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    it('gera ranking de produtos por quantidade e receita dentro do período', async () => {
+        const report = await getTopProducts({
+            start: new Date('2024-05-01T00:00:00Z'),
+            end: new Date('2024-05-03T23:59:59Z'),
+            limit: 5
+        });
+
+        expect(report.limit).toBe(5);
+        expect(report.byQuantity).toHaveLength(2);
+        expect(report.byQuantity[0].name).toBe('Produto B');
+        expect(report.byQuantity[0].totalQuantity).toBeCloseTo(4, 3);
+        expect(report.byRevenue[0].name).toBe('Produto A');
+        expect(report.byRevenue[0].totalRevenue).toBeCloseTo(150, 2);
+    });
+
+    it('calcula horários e dias de maior movimento', async () => {
+        const report = await getTrafficReport({
+            start: new Date('2024-05-01T00:00:00Z'),
+            end: new Date('2024-05-03T23:59:59Z')
+        });
+
+        expect(report.totals.salesCount).toBeGreaterThanOrEqual(2);
+        expect(report.byHour.some((entry) => entry.hour === '12:00')).toBe(true);
+        expect(report.byDay.find((entry) => entry.day === '2024-05-01')).toBeDefined();
+    });
+
+    it('identifica produtos com estoque baixo', async () => {
+        const report = await getInventoryReport({ limit: 10 });
+        expect(report.limit).toBe(10);
+        const alert = report.lowStockAlerts.find((item) => item.productId === productA.id);
+        expect(alert).toBeDefined();
+        const productBItem = report.items.find((item) => item.productId === productB.id);
+        expect(productBItem.lowStock).toBe(false);
+    });
+
+    it('limita intervalo máximo no resolveRange', () => {
+        const now = new Date('2024-07-01T00:00:00Z');
+        const start = new Date(now.getTime() - (400 * 86400000));
+
+        const range = resolveRange({ start, end: now });
+        const diffDays = Math.round((range.end - range.start) / 86400000);
+        expect(diffDays).toBeLessThanOrEqual(180);
+    });
+
+    it('clampa limites personalizados', () => {
+        expect(buildLimit('abc')).toBe(10);
+        expect(buildLimit(999)).toBe(50);
+        expect(buildLimit(2)).toBe(2);
+        expect(buildLimit(500, { defaultValue: DEFAULT_INVENTORY_LIMIT, maxValue: MAX_INVENTORY_LIMIT })).toBe(MAX_INVENTORY_LIMIT);
+    });
+});


### PR DESCRIPTION
## Summary
- add a dedicated POS reporting service to aggregate product rankings, traffic windows and inventory data
- expose reporting handlers in the POS controller and wire authenticated routes for consolidated, top-products, traffic and inventory insights
- cover reporting logic with unit tests and ensure integration endpoints validate ranges, limits and SQL injection resilience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33305b330832f98bebe31fcd90fec