### PR TITLE
Add multi-store storefront and company-aware product management

### DIFF
--- a/database/models/product.js
+++ b/database/models/product.js
@@ -7,6 +7,23 @@ const PRODUCT_STOCK_STATUS = ['in-stock', 'out-of-stock', 'preorder', 'backorder
 
 module.exports = (sequelize, DataTypes) => {
     const Product = sequelize.define('Product', {
+        companyId: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'Companies',
+                key: 'id'
+            },
+            validate: {
+                isInt: {
+                    msg: 'Empresa inválida para o produto.'
+                },
+                min: {
+                    args: [1],
+                    msg: 'Empresa inválida para o produto.'
+                }
+            }
+        },
         name: {
             type: DataTypes.STRING(180),
             allowNull: false,
@@ -372,6 +389,13 @@ module.exports = (sequelize, DataTypes) => {
     });
 
     Product.associate = (models) => {
+        if (models.Company) {
+            Product.belongsTo(models.Company, {
+                as: 'company',
+                foreignKey: 'companyId'
+            });
+        }
+
         Product.hasMany(models.ProductVariation, {
             as: 'variations',
             foreignKey: 'productId',

--- a/public/css/storefront.css
+++ b/public/css/storefront.css
@@ -1,0 +1,514 @@
+:root {
+    --sf-bg: #0f172a;
+    --sf-bg-alt: #111c3a;
+    --sf-surface: #ffffff;
+    --sf-surface-alt: rgba(255, 255, 255, 0.05);
+    --sf-accent: #6366f1;
+    --sf-accent-strong: #4338ca;
+    --sf-accent-soft: rgba(99, 102, 241, 0.12);
+    --sf-text: #0f172a;
+    --sf-muted: #4c5370;
+    --sf-success: #22c55e;
+    --sf-warning: #f97316;
+    --sf-danger: #ef4444;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body.storefront-body {
+    margin: 0;
+    font-family: 'Poppins', 'Segoe UI', sans-serif;
+    background: radial-gradient(circle at top right, rgba(99, 102, 241, 0.15), transparent 50%),
+        linear-gradient(160deg, var(--sf-bg) 0%, #080d1f 40%, #0b1229 100%);
+    color: #e2e8f0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+.btn-gradient {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: none;
+    border-radius: 999px;
+    padding: 0.65rem 1.5rem;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(120deg, var(--sf-accent) 0%, var(--sf-accent-strong) 100%);
+    box-shadow: 0 16px 32px rgba(79, 70, 229, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.btn-gradient:hover,
+.btn-gradient:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 38px rgba(79, 70, 229, 0.45);
+    background: linear-gradient(120deg, var(--sf-accent-strong) 0%, #312e81 100%);
+}
+
+.btn-outline-primary {
+    border-radius: 999px;
+    font-weight: 600;
+    padding-inline: 1.5rem;
+}
+
+.badge-soft {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(148, 163, 184, 0.2);
+    color: #e2e8f0;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    font-size: 0.85rem;
+}
+
+.storefront-hero {
+    padding: 4rem 0 3rem;
+}
+
+.hero-chip,
+.section-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: var(--sf-accent);
+    background: var(--sf-accent-soft);
+    border-radius: 999px;
+    padding: 0.35rem 0.95rem;
+    font-size: 0.9rem;
+}
+
+.hero-title {
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    font-weight: 700;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    color: #f8fafc;
+}
+
+.hero-subtitle {
+    max-width: 540px;
+    color: rgba(226, 232, 240, 0.8);
+    font-weight: 400;
+}
+
+.hero-preview {
+    position: relative;
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(12px);
+    padding: 2rem;
+    border-radius: 24px;
+}
+
+.hero-preview__badge {
+    position: absolute;
+    top: -18px;
+    right: 24px;
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    background: linear-gradient(140deg, #f59e0b 0%, #ef4444 100%);
+    display: grid;
+    place-items: center;
+    color: #fff;
+    font-size: 1.35rem;
+}
+
+.hero-preview__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.hero-preview__list li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.hero-preview__list i {
+    color: var(--sf-accent);
+}
+
+.storefront-main {
+    padding: 3rem 0 4rem;
+}
+
+.section-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+}
+
+.section-title {
+    font-weight: 600;
+    color: #f8fafc;
+    margin: 0.75rem 0 0;
+}
+
+.section-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: rgba(226, 232, 240, 0.7);
+    font-weight: 500;
+}
+
+.store-card,
+.product-card {
+    background: rgba(15, 23, 42, 0.72);
+    border-radius: 24px;
+    padding: 2rem;
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    height: 100%;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.store-card:hover,
+.product-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 48px rgba(15, 23, 42, 0.45);
+    border-color: rgba(99, 102, 241, 0.35);
+}
+
+.store-card__badge {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    background: rgba(99, 102, 241, 0.15);
+    color: var(--sf-accent);
+    display: grid;
+    place-items: center;
+    font-size: 1.25rem;
+}
+
+.store-card__title {
+    margin: 0;
+    color: #f8fafc;
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.store-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    color: rgba(226, 232, 240, 0.7);
+    margin: 0;
+}
+
+.store-card__description {
+    color: rgba(226, 232, 240, 0.75);
+    margin-bottom: 0;
+    min-height: 72px;
+}
+
+.store-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.store-card__products {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: rgba(226, 232, 240, 0.75);
+    font-weight: 500;
+}
+
+.store-hero {
+    position: relative;
+}
+
+.store-hero__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: rgba(226, 232, 240, 0.7);
+    font-weight: 500;
+}
+
+.store-hero__title {
+    font-size: clamp(2.5rem, 5vw, 3.2rem);
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+    color: #f8fafc;
+}
+
+.store-hero__subtitle {
+    color: rgba(226, 232, 240, 0.75);
+    font-size: 1.05rem;
+    max-width: 620px;
+}
+
+.store-hero__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    color: rgba(226, 232, 240, 0.7);
+    font-weight: 500;
+}
+
+.store-hero__card {
+    background: rgba(15, 23, 42, 0.65);
+    border-radius: 24px;
+    padding: 1.75rem;
+    color: #f8fafc;
+}
+
+.featured-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, #fb7185 0%, #f472b6 100%);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-size: 1.4rem;
+}
+
+.featured-product {
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+}
+
+.featured-product img {
+    width: 88px;
+    height: 88px;
+    object-fit: cover;
+    border-radius: 18px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.image-placeholder {
+    width: 88px;
+    height: 88px;
+    border-radius: 18px;
+    border: 1px dashed rgba(148, 163, 184, 0.35);
+    display: grid;
+    place-items: center;
+    color: rgba(148, 163, 184, 0.5);
+    font-size: 1.75rem;
+}
+
+.featured-product__info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.featured-product__info .price {
+    font-size: 1.35rem;
+    font-weight: 700;
+}
+
+.featured-product__info .availability {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 500;
+}
+
+.featured-product__info .availability i {
+    font-size: 0.55rem;
+}
+
+.product-card__media {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: 20px;
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.5);
+    display: grid;
+    place-items: center;
+}
+
+.product-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.product-card__badge {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #fff;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.badge-danger {
+    background: rgba(239, 68, 68, 0.9);
+}
+
+.badge-warning {
+    background: rgba(249, 115, 22, 0.9);
+}
+
+.badge-success {
+    background: rgba(34, 197, 94, 0.9);
+}
+
+.product-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.product-card__title {
+    margin: 0;
+    color: #f8fafc;
+    font-size: 1.25rem;
+}
+
+.product-card__summary {
+    color: rgba(226, 232, 240, 0.75);
+    font-size: 0.95rem;
+    min-height: 72px;
+}
+
+.product-card__pricing {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+}
+
+.product-card__pricing .price {
+    font-weight: 700;
+    font-size: 1.2rem;
+    color: #f8fafc;
+}
+
+.compare-price {
+    color: rgba(226, 232, 240, 0.55);
+    text-decoration: line-through;
+    font-size: 0.95rem;
+}
+
+.product-card__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.product-card__footer .stock {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.empty-state {
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 28px;
+    padding: 4rem 2rem;
+    border: 1px dashed rgba(148, 163, 184, 0.25);
+}
+
+.empty-state i {
+    font-size: 2.5rem;
+    color: var(--sf-accent);
+}
+
+.storefront-footer {
+    margin-top: auto;
+    padding: 2.5rem 0;
+    background: rgba(8, 13, 31, 0.85);
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.storefront-footer a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+.not-found {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4rem 1.5rem;
+}
+
+.not-found__content {
+    max-width: 420px;
+    background: rgba(15, 23, 42, 0.75);
+    padding: 3rem 2.5rem;
+    border-radius: 28px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: 0 22px 46px rgba(15, 23, 42, 0.45);
+}
+
+.not-found__icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 24px;
+    display: grid;
+    place-items: center;
+    font-size: 2rem;
+    margin: 0 auto 1.5rem;
+    background: rgba(99, 102, 241, 0.2);
+    color: var(--sf-accent);
+}
+
+@media (max-width: 767px) {
+    .store-card,
+    .product-card {
+        padding: 1.75rem;
+    }
+
+    .store-hero__meta,
+    .product-card__footer,
+    .store-card__footer {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .hero-preview__badge {
+        right: 16px;
+        top: -16px;
+    }
+}

--- a/server.js
+++ b/server.js
@@ -61,6 +61,7 @@ const adminRoutes = require('./src/routes/adminRoutes');
 const supportRoutes = require('./src/routes/supportRoutes');
 const productRoutes = require('./src/routes/productRoutes');
 const posRoutes = require('./src/routes/posRoutes');
+const storeRoutes = require('./src/routes/storeRoutes');
 
 const app = express();
 const server = http.createServer(app);
@@ -227,7 +228,8 @@ app.use(async (req, res, next) => {
                 name: dbUser.name,
                 role: dbUser.role,
                 active: dbUser.active,
-                profileImage: dbUser.profileImage
+                profileImage: dbUser.profileImage,
+                companyId: dbUser.companyId
             };
 
             req.user = sanitizedUser;
@@ -237,7 +239,8 @@ app.use(async (req, res, next) => {
                 name: dbUser.name,
                 email: dbUser.email,
                 role: dbUser.role,
-                active: dbUser.active
+                active: dbUser.active,
+                companyId: dbUser.companyId
             };
         } else {
             req.session.user = null;
@@ -285,6 +288,7 @@ app.use('/admin', adminRoutes);
 app.use('/products', productRoutes);
 app.use('/support', supportRoutes);
 app.use('/pos', posRoutes);
+app.use('/store', storeRoutes);
 
 
 // Conexão DB

--- a/src/controllers/storefrontController.js
+++ b/src/controllers/storefrontController.js
@@ -1,0 +1,224 @@
+'use strict';
+
+const { Company, Product, ProductMedia } = require('../../database/models');
+
+const wantsJson = (req) => {
+    const acceptHeader = String(req.headers.accept || '').toLowerCase();
+    const contentType = String(req.headers['content-type'] || '').toLowerCase();
+    return req.xhr || acceptHeader.includes('application/json') || contentType.includes('application/json');
+};
+
+const toPlain = (instance) => {
+    if (!instance) {
+        return null;
+    }
+
+    if (typeof instance.toJSON === 'function') {
+        return instance.toJSON();
+    }
+
+    if (typeof instance.get === 'function') {
+        return instance.get({ plain: true });
+    }
+
+    return instance;
+};
+
+const formatCurrency = (value, currency = 'BRL') => {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isFinite(parsed)) {
+        return null;
+    }
+
+    return parsed.toLocaleString('pt-BR', {
+        style: 'currency',
+        currency
+    });
+};
+
+const buildProductCard = (product) => {
+    const plain = toPlain(product) || {};
+    const mediaItems = Array.isArray(plain.media) ? plain.media : [];
+    const primaryMedia = mediaItems.find((item) => item.isPrimary) || mediaItems[0] || null;
+
+    const normalizedPrice = formatCurrency(plain.price, plain.currency || 'BRL');
+    const compareAtPrice = formatCurrency(plain.compareAtPrice, plain.currency || 'BRL');
+
+    const stockQuantity = Number.parseInt(plain.stockQuantity, 10);
+    const lowStockThreshold = plain.lowStockThreshold !== null && plain.lowStockThreshold !== undefined
+        ? Number.parseInt(plain.lowStockThreshold, 10)
+        : null;
+
+    const isOutOfStock = !Number.isFinite(stockQuantity) || stockQuantity <= 0;
+    const isLowStock = !isOutOfStock && Number.isFinite(lowStockThreshold) && stockQuantity <= lowStockThreshold;
+
+    const summaryRaw = plain.shortDescription || plain.description || '';
+    const summary = summaryRaw.length > 180 ? `${summaryRaw.slice(0, 177)}...` : summaryRaw;
+
+    return {
+        id: plain.id,
+        name: plain.name || 'Produto sem nome',
+        slug: plain.slug,
+        summary,
+        priceLabel: normalizedPrice,
+        compareAtLabel: compareAtPrice,
+        currency: plain.currency || 'BRL',
+        stockQuantity: Number.isFinite(stockQuantity) ? stockQuantity : 0,
+        availability: isOutOfStock ? 'Indisponível' : isLowStock ? 'Poucas unidades' : 'Disponível',
+        isOutOfStock,
+        isLowStock,
+        imageUrl: primaryMedia?.url || plain.metaImageUrl || null
+    };
+};
+
+const buildStorefrontView = (company) => {
+    const plain = toPlain(company) || {};
+    const products = Array.isArray(plain.products) ? plain.products : [];
+    const productCards = products.map(buildProductCard);
+
+    const activeProducts = productCards.filter((product) => !product.isOutOfStock);
+    const featuredProduct = activeProducts[0] || productCards[0] || null;
+
+    return {
+        id: plain.id,
+        slug: plain.slug,
+        displayName: plain.tradeName || plain.corporateName || 'Loja',
+        heroSubtitle: plain.notes || 'Produtos selecionados para o seu dia a dia.',
+        city: plain.city || null,
+        state: plain.state || null,
+        contactEmail: plain.email || null,
+        contactPhone: plain.mobilePhone || plain.phone || null,
+        website: plain.website || null,
+        productCount: productCards.length,
+        featuredProduct,
+        products: productCards
+    };
+};
+
+const listStores = async (req, res) => {
+    try {
+        const companies = await Company.findAll({
+            where: { status: 'active' },
+            attributes: ['id', 'slug', 'tradeName', 'corporateName', 'city', 'state', 'email', 'mobilePhone', 'phone', 'website', 'notes'],
+            include: [
+                {
+                    model: Product,
+                    as: 'products',
+                    attributes: ['id'],
+                    where: {
+                        status: 'active',
+                        visibility: 'public'
+                    },
+                    required: false
+                }
+            ],
+            order: [
+                ['tradeName', 'ASC'],
+                ['corporateName', 'ASC']
+            ]
+        });
+
+        const stores = companies
+            .map((company) => buildStorefrontView(company))
+            .filter((store) => store.productCount > 0)
+            .map((store) => ({
+                id: store.id,
+                slug: store.slug,
+                displayName: store.displayName,
+                city: store.city,
+                state: store.state,
+                productCount: store.productCount,
+                heroSubtitle: store.heroSubtitle
+            }));
+
+        if (wantsJson(req)) {
+            return res.json({ data: stores });
+        }
+
+        res.locals.pageTitle = 'Lojas disponíveis';
+        return res.render('storefront/index', {
+            stores
+        });
+    } catch (error) {
+        console.error('[storefrontController] Falha ao listar lojas:', error);
+        if (wantsJson(req)) {
+            return res.status(500).json({ message: 'Não foi possível carregar as lojas.' });
+        }
+        res.locals.pageTitle = 'Lojas';
+        return res.status(500).render('storefront/not-found', {
+            slug: null,
+            message: 'Não foi possível carregar as lojas neste momento.'
+        });
+    }
+};
+
+const showStore = async (req, res) => {
+    const slug = String(req.params.slug || '').trim().toLowerCase();
+
+    if (!slug) {
+        if (wantsJson(req)) {
+            return res.status(400).json({ message: 'Loja inválida.' });
+        }
+        return res.status(404).render('storefront/not-found', { slug: null, message: 'Loja não encontrada.' });
+    }
+
+    try {
+        const company = await Company.findOne({
+            where: {
+                slug,
+                status: 'active'
+            },
+            include: [
+                {
+                    model: Product,
+                    as: 'products',
+                    where: {
+                        status: 'active',
+                        visibility: 'public'
+                    },
+                    required: false,
+                    include: [
+                        { model: ProductMedia, as: 'media', required: false }
+                    ]
+                }
+            ],
+            order: [
+                [{ model: Product, as: 'products' }, 'isFeatured', 'DESC'],
+                [{ model: Product, as: 'products' }, 'name', 'ASC'],
+                [{ model: Product, as: 'products' }, { model: ProductMedia, as: 'media' }, 'position', 'ASC']
+            ]
+        });
+
+        if (!company) {
+            if (wantsJson(req)) {
+                return res.status(404).json({ message: 'Loja não encontrada.' });
+            }
+            return res.status(404).render('storefront/not-found', { slug, message: 'Loja não encontrada.' });
+        }
+
+        const viewModel = buildStorefrontView(company);
+
+        if (wantsJson(req)) {
+            return res.json({ data: viewModel });
+        }
+
+        res.locals.pageTitle = `${viewModel.displayName} • E-commerce`;
+        return res.render('storefront/show', {
+            store: viewModel
+        });
+    } catch (error) {
+        console.error('[storefrontController] Falha ao carregar loja:', error);
+        if (wantsJson(req)) {
+            return res.status(500).json({ message: 'Não foi possível carregar a loja.' });
+        }
+        return res.status(500).render('storefront/not-found', {
+            slug,
+            message: 'Não foi possível carregar esta loja no momento.'
+        });
+    }
+};
+
+module.exports = {
+    listStores,
+    showStore
+};

--- a/src/routes/storeRoutes.js
+++ b/src/routes/storeRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+
+const storefrontController = require('../controllers/storefrontController');
+
+const router = express.Router();
+
+router.get('/', storefrontController.listStores);
+router.get('/:slug', storefrontController.showStore);
+
+module.exports = router;

--- a/src/views/storefront/index.ejs
+++ b/src/views/storefront/index.ejs
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title><%= pageTitle ? `${pageTitle} • ` : '' %><%= appName || 'Plataforma' %></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet"
+    />
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous"
+    />
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+        rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/css/storefront.css" />
+</head>
+<body class="storefront-body">
+    <header class="storefront-hero">
+        <div class="container">
+            <div class="row align-items-center g-4">
+                <div class="col-lg-7">
+                    <span class="hero-chip"><i class="bi bi-bag-check me-2"></i>E-commerce inteligente</span>
+                    <h1 class="hero-title">Descubra lojas conectadas ao <%= appName || 'Sistema' %></h1>
+                    <p class="hero-subtitle">
+                        Cada empresa possui uma vitrine exclusiva com produtos atualizados em tempo real.
+                        Escolha a loja desejada e finalize suas compras com segurança.
+                    </p>
+                </div>
+                <div class="col-lg-5">
+                    <div class="hero-preview card border-0 shadow-sm">
+                        <div class="hero-preview__badge">
+                            <i class="bi bi-stars"></i>
+                        </div>
+                        <div class="hero-preview__content">
+                            <p class="text-muted mb-2">Multi-loja</p>
+                            <h2 class="h4 mb-3">Experiência consistente para seus clientes</h2>
+                            <ul class="hero-preview__list">
+                                <li><i class="bi bi-check-circle-fill"></i> Página dedicada por empresa</li>
+                                <li><i class="bi bi-check-circle-fill"></i> Estoque e valores sincronizados</li>
+                                <li><i class="bi bi-check-circle-fill"></i> Layout responsivo e seguro</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="storefront-main">
+        <div class="container">
+            <div class="section-header">
+                <div>
+                    <span class="section-chip"><i class="bi bi-shop-window me-2"></i>Lojas disponíveis</span>
+                    <h2 class="section-title">Escolha a operação onde deseja comprar</h2>
+                </div>
+                <div class="section-meta">
+                    <i class="bi bi-boxes"></i>
+                    <span><%= stores.length %> loja<%= stores.length === 1 ? '' : 's' %> prontas para atendimento</span>
+                </div>
+            </div>
+
+            <% if (!stores.length) { %>
+                <div class="empty-state text-center">
+                    <i class="bi bi-search"></i>
+                    <h3 class="mt-3">Nenhuma loja disponível por enquanto</h3>
+                    <p class="text-muted mb-0">Assim que as empresas publicarem seus produtos, elas aparecerão aqui.</p>
+                </div>
+            <% } else { %>
+                <div class="row g-4">
+                    <% stores.forEach((store) => { %>
+                        <div class="col-md-6 col-xl-4">
+                            <article class="store-card">
+                                <div class="store-card__badge"><i class="bi bi-geo-alt"></i></div>
+                                <h3 class="store-card__title"><%= store.displayName %></h3>
+                                <p class="store-card__meta">
+                                    <% if (store.city) { %>
+                                        <span><i class="bi bi-geo-fill"></i><%= store.city %></span>
+                                    <% } %>
+                                    <% if (store.state) { %>
+                                        <span><i class="bi bi-map"></i><%= store.state %></span>
+                                    <% } %>
+                                </p>
+                                <p class="store-card__description"><%= store.heroSubtitle %></p>
+                                <div class="store-card__footer">
+                                    <span class="store-card__products">
+                                        <i class="bi bi-box-seam"></i>
+                                        <%= store.productCount %> produto<%= store.productCount === 1 ? '' : 's' %>
+                                    </span>
+                                    <a class="btn btn-gradient" href="/store/<%= store.slug %>">
+                                        Acessar loja
+                                        <i class="bi bi-arrow-right ms-2"></i>
+                                    </a>
+                                </div>
+                            </article>
+                        </div>
+                    <% }) %>
+                </div>
+            <% } %>
+        </div>
+    </main>
+
+    <footer class="storefront-footer">
+        <div class="container text-center">
+            <p class="mb-1">© <%= new Date().getFullYear() %> <%= appName || 'Plataforma' %>. Todos os direitos reservados.</p>
+            <p class="text-muted small mb-0">Ambiente seguro com monitoramento contínuo e dados criptografados.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/src/views/storefront/not-found.ejs
+++ b/src/views/storefront/not-found.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title><%= pageTitle ? `${pageTitle} • ` : '' %><%= appName || 'Plataforma' %></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet"
+    />
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous"
+    />
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+        rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/css/storefront.css" />
+</head>
+<body class="storefront-body">
+    <div class="not-found">
+        <div class="not-found__content text-center">
+            <span class="not-found__icon"><i class="bi bi-shop"></i></span>
+            <h1>Loja não encontrada</h1>
+            <p class="text-muted">
+                <%= typeof message === 'string' && message.length ? message : 'A loja que você está procurando pode ter sido removida ou ainda não foi publicada.' %>
+            </p>
+            <a href="/store" class="btn btn-gradient">
+                <i class="bi bi-arrow-left me-2"></i>Voltar para listagem
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/views/storefront/show.ejs
+++ b/src/views/storefront/show.ejs
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title><%= pageTitle ? `${pageTitle}` : `${store.displayName} • ${appName || 'Plataforma'}` %></title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet"
+    />
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+        rel="stylesheet"
+        integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+        crossorigin="anonymous"
+    />
+    <link
+        href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css"
+        rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/css/storefront.css" />
+</head>
+<body class="storefront-body">
+    <header class="storefront-hero store-hero">
+        <div class="container">
+            <div class="store-hero__top">
+                <a href="/store" class="back-link"><i class="bi bi-arrow-left"></i> Voltar para lojas</a>
+                <span class="badge-soft">Multi-loja</span>
+            </div>
+            <div class="row align-items-center g-4">
+                <div class="col-lg-7">
+                    <h1 class="store-hero__title"><%= store.displayName %></h1>
+                    <p class="store-hero__subtitle"><%= store.heroSubtitle %></p>
+                    <div class="store-hero__meta">
+                        <% if (store.city || store.state) { %>
+                            <span><i class="bi bi-geo-alt"></i><%= [store.city, store.state].filter(Boolean).join(' • ') %></span>
+                        <% } %>
+                        <% if (store.contactPhone) { %>
+                            <span><i class="bi bi-telephone"></i><%= store.contactPhone %></span>
+                        <% } %>
+                        <% if (store.contactEmail) { %>
+                            <span><i class="bi bi-envelope"></i><%= store.contactEmail %></span>
+                        <% } %>
+                    </div>
+                </div>
+                <div class="col-lg-5">
+                    <div class="store-hero__card card border-0 shadow-sm">
+                        <div class="d-flex align-items-center gap-3 mb-3">
+                            <div class="featured-icon"><i class="bi bi-fire"></i></div>
+                            <div>
+                                <span class="text-muted d-block small">Produto destaque</span>
+                                <strong class="d-block"><%= store.featuredProduct ? store.featuredProduct.name : 'Selecione um item' %></strong>
+                            </div>
+                        </div>
+                        <% if (store.featuredProduct) { %>
+                            <div class="featured-product">
+                                <% if (store.featuredProduct.imageUrl) { %>
+                                    <img src="<%= store.featuredProduct.imageUrl %>" alt="<%= store.featuredProduct.name %>" />
+                                <% } else { %>
+                                    <div class="image-placeholder"><i class="bi bi-image"></i></div>
+                                <% } %>
+                                <div class="featured-product__info">
+                                    <span class="price"><%= store.featuredProduct.priceLabel || 'Sob consulta' %></span>
+                                    <span class="availability <%= store.featuredProduct.isOutOfStock ? 'text-danger' : store.featuredProduct.isLowStock ? 'text-warning' : 'text-success' %>">
+                                        <i class="bi bi-circle-fill"></i>
+                                        <%= store.featuredProduct.availability %>
+                                    </span>
+                                </div>
+                            </div>
+                        <% } else { %>
+                            <p class="text-muted mb-0">Cadastre produtos ativos para destacá-los automaticamente aqui.</p>
+                        <% } %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="storefront-main store-grid">
+        <div class="container">
+            <div class="section-header">
+                <div>
+                    <span class="section-chip"><i class="bi bi-bag"></i>Produtos</span>
+                    <h2 class="section-title">Catálogo completo</h2>
+                </div>
+                <div class="section-meta">
+                    <i class="bi bi-box-seam"></i>
+                    <span><%= store.productCount %> item<%= store.productCount === 1 ? '' : 's' %> disponível<%= store.productCount === 1 ? '' : 's' %></span>
+                </div>
+            </div>
+
+            <% if (!store.products.length) { %>
+                <div class="empty-state text-center">
+                    <i class="bi bi-clipboard-x"></i>
+                    <h3 class="mt-3">Nenhum produto publicado</h3>
+                    <p class="text-muted mb-0">Solicite à equipe responsável para disponibilizar os itens desta loja.</p>
+                </div>
+            <% } else { %>
+                <div class="row g-4">
+                    <% store.products.forEach((product) => { %>
+                        <div class="col-md-6 col-xl-4">
+                            <article class="product-card">
+                                <div class="product-card__media">
+                                    <% if (product.imageUrl) { %>
+                                        <img src="<%= product.imageUrl %>" alt="<%= product.name %>" loading="lazy" />
+                                    <% } else { %>
+                                        <div class="image-placeholder"><i class="bi bi-image"></i></div>
+                                    <% } %>
+                                    <% if (product.isOutOfStock) { %>
+                                        <span class="product-card__badge badge-danger">Indisponível</span>
+                                    <% } else if (product.isLowStock) { %>
+                                        <span class="product-card__badge badge-warning">Poucas unidades</span>
+                                    <% } else { %>
+                                        <span class="product-card__badge badge-success">Disponível</span>
+                                    <% } %>
+                                </div>
+                                <div class="product-card__body">
+                                    <h3 class="product-card__title"><%= product.name %></h3>
+                                    <p class="product-card__summary"><%= product.summary %></p>
+                                    <div class="product-card__pricing">
+                                        <span class="price"><%= product.priceLabel || 'Sob consulta' %></span>
+                                        <% if (product.compareAtLabel) { %>
+                                            <span class="compare-price"><%= product.compareAtLabel %></span>
+                                        <% } %>
+                                    </div>
+                                </div>
+                                <div class="product-card__footer">
+                                    <span class="stock">
+                                        <i class="bi bi-stack"></i>
+                                        <%= product.stockQuantity %> em estoque
+                                    </span>
+                                    <button class="btn btn-outline-primary" type="button" disabled>
+                                        Comprar em breve
+                                        <i class="bi bi-lock ms-2"></i>
+                                    </button>
+                                </div>
+                            </article>
+                        </div>
+                    <% }) %>
+                </div>
+            <% } %>
+        </div>
+    </main>
+
+    <footer class="storefront-footer">
+        <div class="container text-center">
+            <p class="mb-1">© <%= new Date().getFullYear() %> <%= appName || 'Plataforma' %>. Ambiente seguro e monitorado.</p>
+            <% if (store.website) { %>
+                <p class="text-muted small mb-0">
+                    <i class="bi bi-globe me-1"></i>
+                    <a href="<%= store.website %>" target="_blank" rel="noopener" class="link-light">Visitar site institucional</a>
+                </p>
+            <% } else { %>
+                <p class="text-muted small mb-0">Proteção de dados e alta disponibilidade garantidas.</p>
+            <% } %>
+        </div>
+    </footer>
+</body>
+</html>

--- a/tests/integration/pos/posFlow.test.js
+++ b/tests/integration/pos/posFlow.test.js
@@ -8,7 +8,8 @@ const {
     Product,
     Sale,
     SaleItem,
-    SalePayment
+    SalePayment,
+    Company
 } = require('../../../database/models');
 const posRoutes = require('../../../src/routes/posRoutes');
 const { USER_ROLES } = require('../../../src/constants/roles');
@@ -26,6 +27,7 @@ describe('Integração PDV - fluxo completo', () => {
     let agent;
     let operator;
     let product;
+    let company;
 
     beforeAll(async () => {
         await sequelize.sync({ force: true });
@@ -34,12 +36,19 @@ describe('Integração PDV - fluxo completo', () => {
     beforeEach(async () => {
         await sequelize.sync({ force: true });
         app = createRouterTestApp({ routes: [['/pos', posRoutes]] });
+        company = await Company.create({
+            cnpj: '11222333000199',
+            corporateName: 'Beleza Inteligente LTDA',
+            tradeName: 'Studio Beleza',
+            email: 'contato@studiobeleza.com'
+        });
         operator = await User.create({
             name: 'Operador PDV',
             email: 'operador@example.com',
             password: 'SenhaSegura123',
             role: USER_ROLES.MANAGER,
-            active: true
+            active: true,
+            companyId: company.id
         });
         product = await Product.create({
             name: 'Sérum facial luminoso',
@@ -48,13 +57,15 @@ describe('Integração PDV - fluxo completo', () => {
             unit: 'un',
             price: '120.00',
             taxRate: '5.00',
-            taxCode: '1234.56.78'
+            taxCode: '1234.56.78',
+            companyId: company.id
         });
         ({ agent } = await authenticateTestUser(app, {
             id: operator.id,
             role: operator.role,
             name: operator.name,
-            email: operator.email
+            email: operator.email,
+            companyId: company.id
         }));
     });
 

--- a/tests/integration/pos/posReports.test.js
+++ b/tests/integration/pos/posReports.test.js
@@ -8,7 +8,8 @@ const {
     Product,
     Sale,
     SaleItem,
-    SalePayment
+    SalePayment,
+    Company
 } = require('../../../database/models');
 const posRoutes = require('../../../src/routes/posRoutes');
 const { USER_ROLES } = require('../../../src/constants/roles');
@@ -21,6 +22,7 @@ describe('Relatórios do PDV - integração', () => {
     let app;
     let agent;
     let operator;
+    let company;
 
     const seedSales = async () => {
         const now = new Date();
@@ -35,7 +37,8 @@ describe('Relatórios do PDV - integração', () => {
             stockQuantity: 5,
             lowStockThreshold: 4,
             stockStatus: 'in-stock',
-            allowBackorder: false
+            allowBackorder: false,
+            companyId: company.id
         });
 
         const productB = await Product.create({
@@ -46,7 +49,8 @@ describe('Relatórios do PDV - integração', () => {
             stockQuantity: 0,
             lowStockThreshold: 3,
             stockStatus: 'out-of-stock',
-            allowBackorder: true
+            allowBackorder: true,
+            companyId: company.id
         });
 
         const saleOne = await Sale.create({
@@ -125,19 +129,27 @@ describe('Relatórios do PDV - integração', () => {
     beforeEach(async () => {
         await sequelize.sync({ force: true });
         app = createRouterTestApp({ routes: [['/pos', posRoutes]] });
+        company = await Company.create({
+            cnpj: '44555666000155',
+            corporateName: 'Estética Moderna LTDA',
+            tradeName: 'Estética Moderna',
+            email: 'contato@esteticamoderna.com'
+        });
         operator = await User.create({
             name: 'Operador PDV',
             email: 'operador@empresa.com',
             password: 'SenhaForte123',
             role: USER_ROLES.MANAGER,
-            active: true
+            active: true,
+            companyId: company.id
         });
 
         ({ agent } = await authenticateTestUser(app, {
             id: operator.id,
             role: operator.role,
             name: operator.name,
-            email: operator.email
+            email: operator.email,
+            companyId: company.id
         }));
 
         await seedSales();

--- a/tests/integration/storefront/storefrontRoutes.test.js
+++ b/tests/integration/storefront/storefrontRoutes.test.js
@@ -1,0 +1,80 @@
+process.env.NODE_ENV = 'test';
+process.env.DB_DIALECT = 'sqlite';
+process.env.DB_STORAGE = ':memory:';
+
+const request = require('supertest');
+const {
+    sequelize,
+    Company,
+    Product
+} = require('../../../database/models');
+const storeRoutes = require('../../../src/routes/storeRoutes');
+const { createRouterTestApp } = require('../../utils/createRouterTestApp');
+
+const buildApp = () => createRouterTestApp({ routes: [['/store', storeRoutes]] });
+
+describe('Storefront público', () => {
+    let app;
+    let company;
+
+    beforeAll(async () => {
+        await sequelize.sync({ force: true });
+    });
+
+    beforeEach(async () => {
+        await sequelize.sync({ force: true });
+        app = buildApp();
+        company = await Company.create({
+            cnpj: '99888777000155',
+            corporateName: 'Aurora Cosméticos LTDA',
+            tradeName: 'Aurora Beleza',
+            email: 'contato@aurorabeleza.com',
+            notes: 'Produtos veganos e cruelty free.'
+        });
+
+        await Product.create({
+            companyId: company.id,
+            name: 'Hidratante Facial Aurora',
+            slug: 'hidratante-facial-aurora',
+            status: 'active',
+            visibility: 'public',
+            price: '129.90',
+            stockQuantity: 12,
+            shortDescription: 'Textura leve com ácido hialurônico.',
+            isFeatured: true
+        });
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    it('lista lojas com produtos ativos', async () => {
+        const response = await request(app).get('/store');
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Aurora Beleza');
+        expect(response.text).toContain('produtos atualizados');
+    });
+
+    it('exibe a vitrine da loja com produtos', async () => {
+        const response = await request(app).get(`/store/${company.slug}`);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain('Aurora Beleza');
+        expect(response.text).toContain('Hidratante Facial Aurora');
+    });
+
+    it('retorna representação JSON da loja', async () => {
+        const response = await request(app)
+            .get(`/store/${company.slug}`)
+            .set('Accept', 'application/json');
+
+        expect(response.status).toBe(200);
+        expect(response.body.data).toMatchObject({
+            slug: company.slug,
+            displayName: 'Aurora Beleza',
+            products: expect.any(Array)
+        });
+    });
+});

--- a/tests/unit/services/posReportingService.test.js
+++ b/tests/unit/services/posReportingService.test.js
@@ -7,7 +7,8 @@ const {
     User,
     Product,
     Sale,
-    SaleItem
+    SaleItem,
+    Company
 } = require('../../../database/models');
 const {
     getTopProducts,
@@ -19,25 +20,28 @@ const {
     MAX_INVENTORY_LIMIT
 } = require('../../../src/services/posReportingService');
 
-const createOperator = () => User.create({
+const createOperator = (companyId) => User.create({
     name: 'Operador Teste',
     email: 'operador+teste@example.com',
     password: 'SenhaSegura123',
     role: 'manager',
-    active: true
+    active: true,
+    companyId
 });
 
-const createProduct = (overrides = {}) => Product.create({
+const createProduct = (companyId, overrides = {}) => Product.create({
     name: 'Produto Base',
     sku: `SKU-${Math.random().toString(16).slice(2, 8)}`,
     status: 'active',
     price: '50.00',
     stockQuantity: 20,
     lowStockThreshold: 5,
+    companyId,
     ...overrides
 });
 
 describe('posReportingService', () => {
+    let company;
     let operator;
     let productA;
     let productB;
@@ -48,9 +52,14 @@ describe('posReportingService', () => {
 
     beforeEach(async () => {
         await sequelize.sync({ force: true });
-        operator = await createOperator();
-        productA = await createProduct({ name: 'Produto A', price: '80.00', stockQuantity: 3 });
-        productB = await createProduct({ name: 'Produto B', price: '40.00', stockQuantity: 12, lowStockThreshold: 10 });
+        company = await Company.create({
+            cnpj: '77888999000166',
+            corporateName: 'Relatorios Inteligentes LTDA',
+            tradeName: 'Relatórios Inteligentes'
+        });
+        operator = await createOperator(company.id);
+        productA = await createProduct(company.id, { name: 'Produto A', price: '80.00', stockQuantity: 3 });
+        productB = await createProduct(company.id, { name: 'Produto B', price: '40.00', stockQuantity: 12, lowStockThreshold: 10 });
 
         const sale1 = await Sale.create({
             userId: operator.id,

--- a/tests/utils/authTestUtils.js
+++ b/tests/utils/authTestUtils.js
@@ -7,7 +7,8 @@ const buildTestUser = (overrides = {}) => ({
     email: overrides.email || 'admin.teste@example.com',
     role: overrides.role || USER_ROLES.ADMIN,
     active: overrides.active !== false,
-    profileImage: overrides.profileImage ?? null
+    profileImage: overrides.profileImage ?? null,
+    companyId: overrides.companyId ?? null
 });
 
 const authenticateTestUser = async (app, overrides = {}) => {

--- a/tests/utils/createRouterTestApp.js
+++ b/tests/utils/createRouterTestApp.js
@@ -24,7 +24,8 @@ const sanitizeUser = (user = {}) => ({
     email: user.email || 'usuario@example.com',
     role: user.role || USER_ROLES.ADMIN,
     active: user.active !== false,
-    profileImage: user.profileImage || null
+    profileImage: user.profileImage || null,
+    companyId: Number.isInteger(user.companyId) ? user.companyId : null
 });
 
 const normalizeFlashMessages = (messages) => {


### PR DESCRIPTION
## Summary
- add slug generation and company/product associations to support multi-store data segregation
- implement public storefront routes, views and styling for a modern multi-loja e-commerce experience
- scope product management by empresa and expand automated tests, including storefront integration coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46f0245f0832fa9640a4ea063a69a